### PR TITLE
Fix var type

### DIFF
--- a/Codigo/MODULO_NPCs.bas
+++ b/Codigo/MODULO_NPCs.bas
@@ -58,7 +58,7 @@ Sub MuereNpc(ByVal NpcIndex As Integer, ByVal UserIndex As Integer)
 
         Dim EraCriminal As Byte
 
-        Dim TiempoRespw As Integer
+        Dim TiempoRespw As Long
 
 102     TiempoRespw = NpcList(NpcIndex).Contadores.InvervaloRespawn
 


### PR DESCRIPTION
Cuando el respown timeout es muy grande (como el caso de "Devorador de ...") la funcion falla y no termina de ejecutar