### PR TITLE
Ajustes en Perdonar/Donar

### DIFF
--- a/Codigo/Modulo_UsUaRiOs.bas
+++ b/Codigo/Modulo_UsUaRiOs.bas
@@ -1495,19 +1495,6 @@ Sub UserDie(ByVal UserIndex As Integer)
     
             End If
         
-240         .flags.VecesQueMoriste = .flags.VecesQueMoriste + 1
-        
-            ' << Restauramos los atributos >>
-242         If .flags.TomoPocion = True And .flags.BattleModo = 0 Then
-    
-244             For i = 1 To 4
-246                 .Stats.UserAtributos(i) = .Stats.UserAtributosBackUP(i)
-248             Next i
-    
-250             Call WriteFYA(UserIndex)
-    
-            End If
-        
             '<< Cambiamos la apariencia del char >>
 252         If .flags.Navegando = 0 Then
 254             .Char.Body = iCuerpoMuerto

--- a/Codigo/Protocol.bas
+++ b/Codigo/Protocol.bas
@@ -12981,51 +12981,50 @@ Private Sub HandleForgive(ByVal UserIndex As Integer)
                 Exit Sub
 
             End If
-        
-            'Validate NPC and make sure player is dead
+
+            'Validate NPC and make sure player is not dead
 108         If (NpcList(.flags.TargetNPC).NPCtype <> eNPCType.Revividor And (NpcList(.flags.TargetNPC).NPCtype <> eNPCType.ResucitadorNewbie Or Not EsNewbie(UserIndex))) Or .flags.Muerto = 1 Then Exit Sub
         
+            Dim priest As npc
+                priest = NpcList(.flags.TargetNPC)
+
             'Make sure it's close enough
-110         If Distancia(.Pos, NpcList(.flags.TargetNPC).Pos) > 3 Then
+110         If Distancia(.Pos, priest.Pos) > 3 Then
                 'Call WriteLocaleMsg(UserIndex, "8", FontTypeNames.FONTTYPE_INFO)
 112             Call WriteConsoleMsg(UserIndex, "El sacerdote no puede escuchar tus pecados debido a que estás demasiado lejos.", FontTypeNames.FONTTYPE_INFO)
                 Exit Sub
             End If
         
-114         If UserList(UserIndex).Faccion.Status = 1 Or UserList(UserIndex).Faccion.ArmadaReal = 1 Then
+114         If .Faccion.Status = 1 Or .Faccion.ArmadaReal = 1 Then
                 'Call WriteLocaleMsg(UserIndex, "8", FontTypeNames.FONTTYPE_INFO)
-116             Call WriteChatOverHead(UserIndex, "Tu alma ya esta libre de pecados hijo mio.", NpcList(UserList(UserIndex).flags.TargetNPC).Char.CharIndex, vbWhite)
+116             Call WriteChatOverHead(UserIndex, "Tu alma ya esta libre de pecados hijo mio.", priest.Char.CharIndex, vbWhite)
                 Exit Sub
             End If
         
-118         If UserList(UserIndex).Faccion.FuerzasCaos > 0 Then
-120             Call WriteChatOverHead(UserIndex, "¡¡Dios no te perdonará mientras seas fiel al Demonio!!", NpcList(UserList(UserIndex).flags.TargetNPC).Char.CharIndex, vbWhite)
+118         If .Faccion.FuerzasCaos > 0 Then
+120             Call WriteChatOverHead(UserIndex, "¡¡Dios no te perdonará mientras seas fiel al Demonio!!", priest.Char.CharIndex, vbWhite)
                 Exit Sub
             End If
-            
-122         If UserList(UserIndex).Faccion.ciudadanosMatados > 0 Then
-                Dim Donacion As Long
-124             Donacion = UserList(UserIndex).Faccion.ciudadanosMatados * OroMult * CostoPerdonPorCiudadano
-                
-126             Call WriteChatOverHead(UserIndex, "Has matado a ciudadanos inocentes, Dios no puede perdonarte lo que has hecho. " & _
-                        "Pero si haces una generosa donación de, digamos, " & PonerPuntos(Donacion) & " monedas de oro, tal vez cambie de opinión...", NpcList(UserList(UserIndex).flags.TargetNPC).Char.CharIndex, vbWhite)
-                Exit Sub
-            End If
-        
-            Dim Clanalineacion As Byte
-                        
-128         If .GuildIndex <> 0 Then
-130             Clanalineacion = modGuilds.Alineacion(.GuildIndex)
 
-132             If Clanalineacion = 1 Then
-134                 Call WriteChatOverHead(UserIndex, "Te encuentras en un clan criminal... debes retirarte para que pueda perdonarte.", NpcList(UserList(UserIndex).flags.TargetNPC).Char.CharIndex, vbWhite)
-                    Exit Sub
+            If .GuildIndex <> 0 Then
+                If modGuilds.Alineacion(.GuildIndex) = 1 Then
+                   Call WriteChatOverHead(UserIndex, "Te encuentras en un clan criminal... debes retirarte para que pueda perdonarte.", priest.Char.CharIndex, vbWhite)
+                   Exit Sub
 
                 End If
 
             End If
-        
-136         Call WriteChatOverHead(UserIndex, "Con estas palabras, te libero de todo tipo de pecados. ¡Que Dios te acompañe hijo mío!", NpcList(UserList(UserIndex).flags.TargetNPC).Char.CharIndex, vbYellow)
+
+            If .Faccion.ciudadanosMatados > 0 Then
+                Dim Donacion As Long
+                Donacion = .Faccion.ciudadanosMatados * OroMult * CostoPerdonPorCiudadano
+
+                Call WriteChatOverHead(UserIndex, "Has matado a ciudadanos inocentes, Dios no puede perdonarte lo que has hecho. " & _
+                        "Pero si haces una generosa donación de, digamos, " & PonerPuntos(Donacion) & " monedas de oro, tal vez cambie de opinión...", priest.Char.CharIndex, vbWhite)
+                Exit Sub
+            End If
+
+136         Call WriteChatOverHead(UserIndex, "Con estas palabras, te libero de todo tipo de pecados. ¡Que Dios te acompañe hijo mío!", priest.Char.CharIndex, vbYellow)
 
 138         Call SendData(SendTarget.ToPCArea, UserIndex, PrepareMessageParticleFX(UserList(UserIndex).Char.CharIndex, "80", 100, False))
 140         Call SendData(SendTarget.ToPCArea, UserIndex, PrepareMessagePlayWave("100", UserList(UserIndex).Pos.X, UserList(UserIndex).Pos.Y))
@@ -17101,7 +17100,7 @@ Public Sub HandleDonateGold(ByVal UserIndex As Integer)
              'Remove Packet ID
 102         Call .incomingData.ReadByte
 
-             Dim Oro As Long
+            Dim Oro As Long
 104         Oro = .incomingData.ReadLong
 
 106         If Oro <= 0 Then Exit Sub
@@ -17109,47 +17108,53 @@ Public Sub HandleDonateGold(ByVal UserIndex As Integer)
              'Se asegura que el target es un npc
 108         If .flags.TargetNPC = 0 Then
 110             Call WriteConsoleMsg(UserIndex, "Primero tenés que seleccionar al sacerdote.", FontTypeNames.FONTTYPE_INFO)
-                 Exit Sub
-             End If
+                Exit Sub
+            End If
         
-             'Validate NPC and make sure player is dead
-112         If (NpcList(.flags.TargetNPC).NPCtype <> eNPCType.Revividor And (NpcList(.flags.TargetNPC).NPCtype <> eNPCType.ResucitadorNewbie Or Not EsNewbie(UserIndex))) Or .flags.Muerto = 1 Then Exit Sub
-        
+            Dim priest As npc
+                priest = NpcList(.flags.TargetNPC)
+
+             'Validate NPC is an actual priest and the player is not dead
+112         If (priest.NPCtype <> eNPCType.Revividor And (priest.NPCtype <> eNPCType.ResucitadorNewbie Or Not EsNewbie(UserIndex))) Or .flags.Muerto = 1 Then Exit Sub
+
              'Make sure it's close enough
 114         If Distancia(.Pos, NpcList(.flags.TargetNPC).Pos) > 3 Then
-116              Call WriteLocaleMsg(UserIndex, "8", FontTypeNames.FONTTYPE_INFO)
-                 Exit Sub
-             End If
-        
+116             Call WriteLocaleMsg(UserIndex, "8", FontTypeNames.FONTTYPE_INFO)
+                Exit Sub
+            End If
+
 118         If .Faccion.Status = 1 Or .Faccion.ArmadaReal = 1 Or .Faccion.FuerzasCaos > 0 Or .Faccion.ciudadanosMatados = 0 Then
-120              Call WriteChatOverHead(UserIndex, "No puedo aceptar tu donación en este momento...", NpcList(.flags.TargetNPC).Char.CharIndex, vbWhite)
-                 Exit Sub
-             End If
-            
-             Dim Clanalineacion As Byte
-                        
-122         If .GuildIndex <> 0 Then
-124             If modGuilds.Alineacion(.GuildIndex) = 1 Then Exit Sub
-             End If
-            
-126          If .Stats.GLD < Oro Then
-128              Call WriteConsoleMsg(UserIndex, "No tienes suficiente dinero.", FontTypeNames.FONTTYPE_INFO)
-                 Exit Sub
-             End If
+120             Call WriteChatOverHead(UserIndex, "No puedo aceptar tu donación en este momento...", NpcList(.flags.TargetNPC).Char.CharIndex, vbWhite)
+                Exit Sub
+            End If
 
-             Dim Donacion As Long
-130          Donacion = .Faccion.ciudadanosMatados * OroMult * CostoPerdonPorCiudadano
-            
-132          If Oro < Donacion Then
-134              Call WriteChatOverHead(UserIndex, "Dios no puede perdonarte si eres una persona avara.", NpcList(.flags.TargetNPC).Char.CharIndex, vbWhite)
-                 Exit Sub
-             End If
-            
-136          .Stats.GLD = .Stats.GLD - Oro
+            If .GuildIndex <> 0 Then
+                If modGuilds.Alineacion(.GuildIndex) = 1 Then
+                   Call WriteChatOverHead(UserIndex, "Te encuentras en un clan criminal... no puedo aceptar tu donación.", priest.Char.CharIndex, vbWhite)
+                   Exit Sub
 
-138          Call WriteUpdateGold(UserIndex)
+                End If
 
-140          Call WriteConsoleMsg(UserIndex, "Has donado " & PonerPuntos(Oro) & " monedas de oro.", FontTypeNames.FONTTYPE_INFO)
+            End If
+
+126         If .Stats.GLD < Oro Then
+128             Call WriteConsoleMsg(UserIndex, "No tienes suficiente dinero.", FontTypeNames.FONTTYPE_INFO)
+                Exit Sub
+            End If
+
+            Dim Donacion As Long
+130         Donacion = .Faccion.ciudadanosMatados * OroMult * CostoPerdonPorCiudadano
+
+132         If Oro < Donacion Then
+134             Call WriteChatOverHead(UserIndex, "Dios no puede perdonarte si eres una persona avara.", NpcList(.flags.TargetNPC).Char.CharIndex, vbWhite)
+                Exit Sub
+            End If
+
+136         .Stats.GLD = .Stats.GLD - Oro
+
+138         Call WriteUpdateGold(UserIndex)
+
+140         Call WriteConsoleMsg(UserIndex, "Has donado " & PonerPuntos(Oro) & " monedas de oro.", FontTypeNames.FONTTYPE_INFO)
 
 142         Call WriteChatOverHead(UserIndex, "¡Gracias por tu generosa donación! Con estas palabras, te libero de todo tipo de pecados. ¡Que Dios te acompañe hijo mío!", NpcList(UserList(UserIndex).flags.TargetNPC).Char.CharIndex, vbYellow)
 

--- a/Configuracion.ini
+++ b/Configuracion.ini
@@ -8,7 +8,7 @@ OroAutoEquipable=1
 DuracionDia=180
 BattleActivado=0
 BattleMinNivel=20
-CostoPerdonPorCiudadano=10000
+CostoPerdonPorCiudadano=2000
 
 'Mientras mas alto sea DropMult menos probabilidad de tirar algun item.
 [DROPEO]


### PR DESCRIPTION
@VanCleff me pidio:

> Que cuando ponés `/perdon` en el sacerdote para volver a ser ciudadano te cobre 2000 monedas de oro por cada ciudadano asesinado que tengas.

Ademas, encontre que unos mensajes que faltaban cuando perteneces a un clan criminal.