### PR TITLE
Contar las muertes de los faccionarios

### DIFF
--- a/Codigo/Hogar.bas
+++ b/Codigo/Hogar.bas
@@ -415,7 +415,7 @@ Public Sub HandleHome(ByVal UserIndex As Integer)
             End If
                 
             'Si el mapa tiene alguna restriccion (newbie, dungeon, etc...), no lo dejamos viajar.
-108         If MapInfo(.Pos.Map).zone = "NEWBIE" Then
+108         If MapInfo(.Pos.Map).zone = "NEWBIE" Or MapData(.Pos.Map, .Pos.X, .Pos.Y).trigger = CARCEL Then
 110             Call WriteConsoleMsg(UserIndex, "No pueder viajar a tu hogar desde este mapa.", FontTypeNames.FONTTYPE_FIGHT)
                 Exit Sub
             
@@ -424,12 +424,6 @@ Public Sub HandleHome(ByVal UserIndex As Integer)
             'Si es un mapa comun y no esta en cana
 112         If .Counters.Pena <> 0 Then
 114             Call WriteConsoleMsg(UserIndex, "No puedes usar este comando en prisión.", FontTypeNames.FONTTYPE_FIGHT)
-                Exit Sub
-
-            End If
-        
-116         If .flags.Muerto = 0 Then
-118             Call WriteConsoleMsg(UserIndex, "Debes estar muerto para utilizar este comando.", FontTypeNames.FONTTYPE_FIGHT)
                 Exit Sub
 
             End If

--- a/Codigo/Modulo_UsUaRiOs.bas
+++ b/Codigo/Modulo_UsUaRiOs.bas
@@ -1518,45 +1518,40 @@ ErrorHandler:
 End Sub
 
 Sub ContarMuerte(ByVal Muerto As Integer, ByVal Atacante As Integer)
-        
         On Error GoTo ContarMuerte_Err
-        
 
-100     If EsNewbie(Muerto) Then Exit Sub
-102     If TriggerZonaPelea(Muerto, Atacante) = TRIGGER6_PERMITE Then Exit Sub
-104     If Abs(CInt(UserList(Muerto).Stats.ELV) - CInt(UserList(Atacante).Stats.ELV)) > 14 Then Exit Sub
-106     If Status(Muerto) = 0 Then
-108         If UserList(Atacante).flags.LastCrimMatado <> UserList(Muerto).name Then
-110             UserList(Atacante).flags.LastCrimMatado = UserList(Muerto).name
 
-112             If UserList(Atacante).Faccion.CriminalesMatados < MAXUSERMATADOS Then UserList(Atacante).Faccion.CriminalesMatados = UserList(Atacante).Faccion.CriminalesMatados + 1
+        If EsNewbie(Muerto) Then Exit Sub
+        If TriggerZonaPelea(Muerto, Atacante) = TRIGGER6_PERMITE Then Exit Sub
+        If Abs(CInt(UserList(Muerto).Stats.ELV) - CInt(UserList(Atacante).Stats.ELV)) > 14 Then Exit Sub
+        If Status(Muerto) = 0 Or Status(Muerto) = 2 Then
+            If UserList(Atacante).flags.LastCrimMatado <> UserList(Muerto).name Then
+                UserList(Atacante).flags.LastCrimMatado = UserList(Muerto).name
 
-            End If
-        
-114         If UserList(Atacante).Faccion.RecompensasCaos > 0 And UserList(Muerto).Faccion.FuerzasCaos = 1 Then
-116             UserList(Atacante).Faccion.Reenlistadas = 200  'jaja que trucho
-            
-                'con esto evitamos que se vuelva a reenlistar
+                If UserList(Atacante).Faccion.CriminalesMatados < MAXUSERMATADOS Then
+                    UserList(Atacante).Faccion.CriminalesMatados = UserList(Atacante).Faccion.CriminalesMatados + 1
+                End If
             End If
 
-118     ElseIf Status(Muerto) = 1 Then
+        ElseIf Status(Muerto) = 1 Or Status(Muerto) = 3 Then
 
-120         If UserList(Atacante).flags.LastCiudMatado <> UserList(Muerto).name Then
-122             UserList(Atacante).flags.LastCiudMatado = UserList(Muerto).name
+            If UserList(Atacante).flags.LastCiudMatado <> UserList(Muerto).name Then
+                UserList(Atacante).flags.LastCiudMatado = UserList(Muerto).name
 
-124             If UserList(Atacante).Faccion.ciudadanosMatados < MAXUSERMATADOS Then UserList(Atacante).Faccion.ciudadanosMatados = UserList(Atacante).Faccion.ciudadanosMatados + 1
+                If UserList(Atacante).Faccion.ciudadanosMatados < MAXUSERMATADOS Then
+                    UserList(Atacante).Faccion.ciudadanosMatados = UserList(Atacante).Faccion.ciudadanosMatados + 1
+                End If
 
             End If
 
         End If
 
-        
         Exit Sub
 
 ContarMuerte_Err:
-126     Call RegistrarError(Err.Number, Err.Description, "UsUaRiOs.ContarMuerte", Erl)
-128     Resume Next
-        
+        Call RegistrarError(Err.Number, Err.Description, "UsUaRiOs.ContarMuerte", Erl)
+        Resume Next
+
 End Sub
 
 Sub Tilelibre(ByRef Pos As WorldPos, ByRef nPos As WorldPos, ByRef obj As obj, ByRef Agua As Boolean, ByRef Tierra As Boolean)

--- a/Codigo/SistemaCombate.bas
+++ b/Codigo/SistemaCombate.bas
@@ -1542,7 +1542,7 @@ Private Sub UserDañoUser(ByVal AtacanteIndex As Integer, ByVal VictimaIndex As 
 218             Call Statistics.StoreFrag(AtacanteIndex, VictimaIndex)
 220             Call ContarMuerte(VictimaIndex, AtacanteIndex)
 222             Call ActStats(VictimaIndex, AtacanteIndex)
-
+                Call UserDie(VictimaIndex)
             ' Si sigue vivo
             Else
                 ' Enviamos la vida

--- a/Codigo/modHechizos.bas
+++ b/Codigo/modHechizos.bas
@@ -2805,6 +2805,7 @@ Sub HechizoPropUsuario(ByVal UserIndex As Integer, ByRef b As Boolean)
 442             Call Statistics.StoreFrag(UserIndex, tempChr)
 444             Call ContarMuerte(tempChr, UserIndex)
 446             Call ActStats(tempChr, UserIndex)
+                Call UserDie(tempChr)
             Else
 448             Call WriteUpdateHP(tempChr)
             End If


### PR DESCRIPTION
Hasta ahora, solo contabamos las muertes de los ciudadanos o criminales, pero ignorabamos
si los usuarios eran de la Armada o del Caos!

Ademas, a veces no se llamaba al rutina de `UserDie` que se encarga de mandar sonidos, etc.