### PR TITLE
Clear connection reference

### DIFF
--- a/Codigo/TCP.bas
+++ b/Codigo/TCP.bas
@@ -1509,7 +1509,6 @@ Sub ResetUserSlot(ByVal UserIndex As Integer)
 156     Call ResetUserBanco(UserIndex)
 158     Call ResetUserSkills(UserIndex)
 160     Call ResetUserKeys(UserIndex)
-161     Call IncreaseVersionId(UserIndex)
 162     With UserList(UserIndex).ComUsu
 164         .Acepto = False
 166         .cant = 0

--- a/Codigo/modHechizos.bas
+++ b/Codigo/modHechizos.bas
@@ -851,7 +851,7 @@ Sub HechizoInvocacion(ByVal UserIndex As Integer, ByRef b As Boolean)
         Exit Sub
     
 HechizoInvocacion_Err:
-208     Call TraceError(Err.Number, Err.Description, "modHechizos.HechizoTerrenoEstado")
+208     Call TraceError(Err.Number, Err.Description, "modHechizos.HechizoInvocacion")
 
 
 End Sub

--- a/Codigo/modNetwork.bas
+++ b/Codigo/modNetwork.bas
@@ -82,10 +82,10 @@ On Error GoTo Kick_ErrHandler:
         
     Call Server.Flush(Connection)
     Call Server.Kick(Connection, True)
-    
     Exit Sub
     
 Kick_ErrHandler:
+    Call TraceError(Err.Number, Err.Description, "modNetwork.Kick", Erl)
 End Sub
 
 Public Function GetTimeOfNextFlush() As Single
@@ -162,19 +162,19 @@ On Error GoTo OnServerClose_Err:
 114    End If
     
 116    Debug.Assert IsValidUserRef(UserRef)
-118    If Not IsValidUserRef(UserRef) Then Exit Sub
+118    If IsValidUserRef(UserRef) Then
+120        If UserList(UserRef.ArrayIndex).flags.UserLogged Then
+122            Call CloseSocketSL(UserRef.ArrayIndex)
+124            Call Cerrar_Usuario(UserRef.ArrayIndex)
+126        Else
+128            Call CloseSocket(UserRef.ArrayIndex)
+130        End If
     
-120    If UserList(UserRef.ArrayIndex).flags.UserLogged Then
-122        Call CloseSocketSL(UserRef.ArrayIndex)
-124        Call Cerrar_Usuario(UserRef.ArrayIndex)
-126    Else
-128        Call CloseSocket(UserRef.ArrayIndex)
-130    End If
-    
-132    UserList(UserRef.ArrayIndex).ConnIDValida = False
-134    UserList(UserRef.ArrayIndex).ConnID = 0
-136    Call ClearUserRef(Mapping(Connection))
-138    Call IncreaseVersionId(UserRef.ArrayIndex)
+132        UserList(UserRef.ArrayIndex).ConnIDValida = False
+134        UserList(UserRef.ArrayIndex).ConnID = 0
+136        Call IncreaseVersionId(UserRef.ArrayIndex)
+       End If
+138    Call ClearUserRef(Mapping(Connection))
 
 140    Exit Sub
     

--- a/Codigo/modNetwork.bas
+++ b/Codigo/modNetwork.bas
@@ -92,6 +92,7 @@ Public Function GetTimeOfNextFlush() As Single
     GetTimeOfNextFlush = max(0, TIME_SEND_FREQUENCY - Time(1))
 End Function
 
+
 Public Sub close_not_logged_sockets_if_timeout()
     Dim i As Integer
     For i = 1 To LastUser
@@ -101,7 +102,13 @@ Public Sub close_not_logged_sockets_if_timeout()
                     Ticks = GetTickCount
                     Delta = Ticks - .Counters.OnConnectTimestamp
                     If Delta > 3000 Then
-                        Call Kick(.ConnID, "Connection timeout")
+                        If Mapping(.ConnID).ArrayIndex = i Then
+                            Call Kick(.ConnID, "Connection timeout")
+                        Else
+                            .ConnID = 0
+                            .ConnIDValida = False
+                            Call TraceError(Err.Number, Err.Description, "trying to kick an invalid mapping", Erl)
+                        End If
                     End If
                 End If
             End With
@@ -173,6 +180,8 @@ On Error GoTo OnServerClose_Err:
 132        UserList(UserRef.ArrayIndex).ConnIDValida = False
 134        UserList(UserRef.ArrayIndex).ConnID = 0
 136        Call IncreaseVersionId(UserRef.ArrayIndex)
+       Else
+           Call TraceError(Err.Number, Err.Description, "Trying to disconnect an invalid user", Erl)
        End If
 138    Call ClearUserRef(Mapping(Connection))
 


### PR DESCRIPTION
when if the code call player clear before the disconnection takes place the disconnection may fail to clear the connection id for the player slot

when that happens the timeout code might step on a unused slot with a random .ConnId and try to kick it

let say player on userSlot5 has connectionId = 4
if he disconnect and we dont clear the slot containts conId=4
after that if someone reuse the connectionId 4 to UserSlot=6

on next timeout tick the code will find the UserSlot 5 with valid ConId and and very long timestamp and kick connection 4

this prevent anyone connecting with that connection until server restart or someone login to the same slot fixing the timestamp and connection values