### PR TITLE
Unit testing client

### DIFF
--- a/Codigo/FileIO.bas
+++ b/Codigo/FileIO.bas
@@ -1798,8 +1798,8 @@ Sub LoadMapData()
         Dim npcfile   As String
 
 #If UNIT_TEST = 1 Then
-        'We only need 10 maps for unit testing
-        NumMaps = 10
+        'We only need 50 maps for unit testing
+        NumMaps = 50
         Debug.Print "UNIT_TEST Enabled Loading just " & NumMaps & " maps"
 #Else
 

--- a/Codigo/General.bas
+++ b/Codigo/General.bas
@@ -757,6 +757,7 @@ Sub Main()
                     Debug.Assert (suite_passed_ok)
                     
                     Debug.Print "Running proto suite, trying to connect to 127.0.0.1:7667"
+                    Call UnitClient.Init
                     Call UnitClient.Connect("127.0.0.1", "7667")
         #End If
         

--- a/Codigo/Unit_Protocol_Writes.bas
+++ b/Codigo/Unit_Protocol_Writes.bas
@@ -81,7 +81,11 @@ Public Sub WriteLong(ByVal value_to_send As Long)
     Call Writer.WriteInt16(value_to_send)
     Call UnitClient.Send(Writer)
 End Sub
-
+Public Sub HandleErrorMessageBox(ByRef Reader As Network.Reader)
+    Dim mensaje As String
+    mensaje = Reader.ReadString8()
+    Debug.Print "HandleErrorMessageBox " & mensaje
+End Sub
 Public Sub HandleShowMessageBox(ByRef Reader As Network.Reader)
     Dim mensaje As String
     mensaje = Reader.ReadString8()


### PR DESCRIPTION
Now it can reconnect and run a sequence of tests simulating client requests

Added handler for unit test

Added handled for ServerPacketID.ErrorMsg in the unit test

The server closed the socket because we were loading only 10 maps and the PC was in map 34 (invalid map)