### PR TITLE
FacudeArghal - Declares datatype

### DIFF
--- a/Codigo/Declares.bas
+++ b/Codigo/Declares.bas
@@ -1395,7 +1395,7 @@ Public Type t_Quest
     RequiredLevel As Byte
     RequiredClass As Byte
     
-    RequiredQuest As Integer 'Changed from Byte in order to develop more than 255 quests
+    RequiredQuest As Integer 'Changed in order to develop more than 255 quests
     Trabajador As Boolean
     TalkTo As Integer
     

--- a/Codigo/Declares.bas
+++ b/Codigo/Declares.bas
@@ -1395,7 +1395,7 @@ Public Type t_Quest
     RequiredLevel As Byte
     RequiredClass As Byte
     
-    RequiredQuest As Byte
+    RequiredQuest As Integer 'Changed from Byte in order to develop more than 255 quests
     Trabajador As Boolean
     TalkTo As Integer
     


### PR DESCRIPTION
RequiredQuest variable was originally byte and that limits our posibility to develop quests to 255.

