### PR TITLE
Added IsPotionFreeZone for potions type 1, 2, 3, 4 - Removed duels map from exclusion zone

### DIFF
--- a/Codigo/InvUsuario.bas
+++ b/Codigo/InvUsuario.bas
@@ -1971,8 +1971,11 @@ Sub UseInvItem(ByVal UserIndex As Integer, ByVal Slot As Byte, ByVal ByClick As 
 260                 .flags.TipoPocion = obj.TipoPocion
                     
                     Dim CabezaFinal  As Integer
-    
                     Dim CabezaActual As Integer
+
+                    ' Esta en Zona de Pelea?
+                    Dim triggerStatus As e_Trigger6
+                    triggerStatus = TriggerZonaPelea(UserIndex, UserIndex)
     
 262                 Select Case .flags.TipoPocion
             
@@ -2022,16 +2025,12 @@ Sub UseInvItem(ByVal UserIndex As Integer, ByVal Slot As Byte, ByVal ByClick As 
                                 ' Usa el ítem
                                 Dim HealingAmount As Long
                                 Dim Source As Integer
-                                Dim T As e_Trigger6
                             
                                 ' Calcula la cantidad de curación
                                 HealingAmount = RandomNumber(obj.MinModificador, obj.MaxModificador) * UserMod.GetSelfHealingBonus(UserList(UserIndex))
                             
                                 ' Modifica la salud del jugador
                                 Call UserMod.ModifyHealth(UserIndex, HealingAmount)
-                            
-                                ' Verifica si el jugador está en la ARENA
-                                T = TriggerZonaPelea(UserIndex, UserIndex)
                             
                                 ' Consumir pocion solo si el usuario no esta en zona de uso libre
                                 If Not IsPotionFreeZone(UserIndex, triggerStatus) Then
@@ -2054,10 +2053,6 @@ Sub UseInvItem(ByVal UserIndex As Integer, ByVal Slot As Byte, ByVal ByClick As 
                                 ' Usa el ítem: restaura el MANA
                                 .Stats.MinMAN = IIf(.Stats.MinMAN > 20000, 20000, .Stats.MinMAN + Porcentaje(.Stats.MaxMAN, porcentajeRec))
                                 If .Stats.MinMAN > .Stats.MaxMAN Then .Stats.MinMAN = .Stats.MaxMAN
-                            
-                                ' Verifica si el jugador está en la ARENA
-                                Dim triggerStatus As e_Trigger6
-                                triggerStatus = TriggerZonaPelea(UserIndex, UserIndex)
 
                                 ' Consumir pocion solo si el usuario no esta en zona de uso libre
                                 If Not IsPotionFreeZone(UserIndex, triggerStatus) Then


### PR DESCRIPTION
This pull request refines the potion consumption logic in the `Sub UseInvItem` function of the `Codigo/InvUsuario.bas` file to ensure that potions are not consumed in designated "free zones" or special areas. It introduces a new utility function `IsPotionFreeZone` and removes redundant code for better maintainability.

### Enhancements to potion consumption logic:

* Added a check using the new `IsPotionFreeZone` function to ensure potions are only removed from inventory when the user is not in a potion-free zone. This change was applied in multiple sections of the `Sub UseInvItem` function. [[1]](diffhunk://#diff-03be7c9b977a51a8935e8a8503f9ba726e2fe4b70b80996ad1cf4d6dbe2e50b8L1985-R1994) [[2]](diffhunk://#diff-03be7c9b977a51a8935e8a8503f9ba726e2fe4b70b80996ad1cf4d6dbe2e50b8L2001-R2013) [[3]](diffhunk://#diff-03be7c9b977a51a8935e8a8503f9ba726e2fe4b70b80996ad1cf4d6dbe2e50b8L2017-L2035) [[4]](diffhunk://#diff-03be7c9b977a51a8935e8a8503f9ba726e2fe4b70b80996ad1cf4d6dbe2e50b8L2052-L2055)

* Removed redundant logic for checking specific maps and triggers directly within `Sub UseInvItem` by consolidating this functionality into the `IsPotionFreeZone` function. [[1]](diffhunk://#diff-03be7c9b977a51a8935e8a8503f9ba726e2fe4b70b80996ad1cf4d6dbe2e50b8L2017-L2035) [[2]](diffhunk://#diff-03be7c9b977a51a8935e8a8503f9ba726e2fe4b70b80996ad1cf4d6dbe2e50b8L2052-L2055)

### Updates to `IsPotionFreeZone`:

* Simplified the list of special zones where potions are not consumed by removing outdated or unnecessary map references (e.g., arenas like 324, 372, 389, 390).

* Updated comments in `IsPotionFreeZone` for clarity, including renaming descriptions of zones (e.g., "Meson Hostigado - Beneficio Patreon").

These changes improve code readability, reduce duplication, and ensure consistent behavior for potion usage across different zones.