### PR TITLE
Arreglo envío de mensaje en quest requerida

### DIFF
--- a/Codigo/ModQuest.bas
+++ b/Codigo/ModQuest.bas
@@ -777,7 +777,7 @@ Public Function CanUserAcceptQuest(ByVal UserIndex As Integer, ByVal NpcIndex As
     
     If tmpQuest.RequiredQuest > 0 Then
         If Not UserDoneQuest(UserIndex, tmpQuest.RequiredQuest) Then
-            Call WriteLocaleMsg(UserIndex, 1424, e_FontTypeNames.FONTTYPE_INFO)
+            Call WriteLocaleMsg(UserIndex, 1424, e_FontTypeNames.FONTTYPE_INFO, QuestList(tmpQuest.RequiredQuest).nombre)
             Exit Function
         End If
     End If


### PR DESCRIPTION
Agrego el nombre de la quest requerida en el envío del mensaje 1424 para que se muestre correctamente en consola.