### PR TITLE
fix_CannotEquipFactionArmorOutsideSafeZone

### DIFF
--- a/Codigo/InvUsuario.bas
+++ b/Codigo/InvUsuario.bas
@@ -1473,6 +1473,14 @@ Sub EquiparInvItem(ByVal UserIndex As Integer, ByVal Slot As Byte)
 
                     End If
   
+                    'Si esta equipando armadura faccionaria fuera de zona segura o fuera de trigger seguro
+                    If obj.Real > 0 Or obj.Caos > 0 Then
+                        If Not MapData(.Pos.Map, .Pos.x, .Pos.y).trigger = e_Trigger.ZonaSegura And Not MapInfo(.Pos.Map).Seguro = 1 Then
+                            Call WriteLocaleMsg(UserIndex, "2091", e_FontTypeNames.FONTTYPE_INFO)
+                            Exit Sub
+                        End If
+                    End If
+                    
                     'Lo equipa
 396                 If Len(obj.CreaGRH) <> 0 Then
 398                     .Char.Body_Aura = obj.CreaGRH


### PR DESCRIPTION
-Faction players can no longer equip faction items outside cities or safe zones