### PR TITLE
Eliminar duplicados en el historial de solicitudes de guild usando DISTINCT

### DIFF
--- a/Codigo/modDatabase.bas
+++ b/Codigo/modDatabase.bas
@@ -751,7 +751,7 @@ Public Function GetUserGuildMemberDatabase(username As String) As String
         user_id = GetCharacterIdWithName(username)
         Dim RS As ADODB.Recordset
         Dim History As String
-100     Set RS = Query("SELECT guild_name FROM guild_member_history where user_id = ? order by request_time DESC", user_id)
+100     Set RS = Query("SELECT DISTINCT guild_name FROM guild_member_history where user_id = ? order by request_time DESC", user_id)
 102     If RS Is Nothing Then Exit Function
 104     If Not RS.RecordCount = 0 Then
             Dim i As Integer
@@ -794,7 +794,7 @@ Public Function GetUserGuildPedidosDatabase(username As String) As String
         user_id = GetCharacterIdWithName(username)
         Dim RS As ADODB.Recordset
         Dim History As String
-100     Set RS = Query("SELECT guild_name FROM guild_request_history where user_id = ? order by request_time DESC", user_id)
+100     Set RS = Query("SELECT DISTINCT guild_name FROM guild_request_history where user_id = ? order by request_time DESC", user_id)
 102     If RS Is Nothing Then Exit Function
 104     If Not RS.RecordCount = 0 Then
             Dim i As Integer


### PR DESCRIPTION
Se actualizaron las consultas en GetUserGuildPedidosDatabase y GetUserGuildMemberDatabase para utilizar SELECT DISTINCT guild_name, evitando así que el historial (GuildRequestHistory y GuilldHistory) contengan nombres de clanes repetidos cuando un mismo usuario envía varias solicitudes o participa de un mismo guild. Esto simplifica el procesamiento en el cliente y mejora la legibilidad de los datos enviados desde el servidor.

<img width="810" height="215" alt="historyguild" src="https://github.com/user-attachments/assets/130490a3-9d34-4abb-b68d-b31bbced2015" />
