### PR TITLE
Guard reachable NPCs from temporary immunity

### DIFF
--- a/Codigo/AI_NPC.bas
+++ b/Codigo/AI_NPC.bas
@@ -435,11 +435,15 @@ End Sub
 Private Sub AI_CaminarConRumbo(ByVal NpcIndex As Integer, ByRef rumbo As t_WorldPos)
         On Error GoTo AI_CaminarConRumbo_Err
     
+098     If NpcList(NpcIndex).TargetUser.ArrayIndex = 0 Then
+099         Call NpcClearTargetUnreachable(NpcIndex)
+        End If
 100     If Not NPCs.CanMove(NpcList(npcIndex).Contadores, NpcList(npcIndex).flags) Then
 102         Call AnimacionIdle(NpcIndex, True)
             Exit Sub
         End If
         If NpcList(NpcIndex).pos.x = rumbo.x And NpcList(NpcIndex).pos.y = rumbo.y Then
+            Call NpcClearTargetUnreachable(NpcIndex)
             NpcList(NpcIndex).pathFindingInfo.PathLength = 0
             Call AnimacionIdle(NpcIndex, True)
             Exit Sub
@@ -453,17 +457,22 @@ Private Sub AI_CaminarConRumbo(ByVal NpcIndex As Integer, ByRef rumbo As t_World
                 ' Recalculamos el camino
 112             If SeekPath(NpcIndex, True) Then
                     ' Si consiguo un camino
-114                 Call FollowPath(NpcIndex)
+114                 Call NpcClearTargetUnreachable(NpcIndex)
+115                 Call FollowPath(NpcIndex)
                 Else
                     ' Cannot find path
                     If NpcList(NpcIndex).Hostile = 1 And NpcList(NpcIndex).TargetUser.ArrayIndex <> 0 Then
                         NpcList(NpcIndex).pathFindingInfo.RangoVision = Min(SvrConfig.GetValue("NPC_MAX_VISION_RANGE"), NpcList(NpcIndex).pathFindingInfo.RangoVision + PATH_VISION_DELTA)
                     End If
+                    If NpcList(NpcIndex).TargetUser.ArrayIndex <> 0 Then
+                        Call NpcMarkTargetUnreachable(NpcIndex)
+                    End If
                         ' Si no hay camino, pasar a estado idle
                     Call AnimacionIdle(NpcIndex, True)
                 End If
             Else ' Avanzamos en el camino
-116             Call FollowPath(NpcIndex)
+116             Call NpcClearTargetUnreachable(NpcIndex)
+118             Call FollowPath(NpcIndex)
             End If
 
         End With
@@ -476,6 +485,43 @@ AI_CaminarConRumbo_Err:
 120     Call TraceError(Err.Number, errorDescription, "AI.AI_CaminarConRumbo", Erl)
 
 End Sub
+
+Private Sub NpcMarkTargetUnreachable(ByVal NpcIndex As Integer)
+    Dim targetRef As t_AnyReference
+    Dim targetPos As t_WorldPos
+
+    With NpcList(NpcIndex)
+        If Not .pathFindingInfo.TargetUnreachable Then
+            If CastUserToAnyRef(.TargetUser, targetRef) Then
+                targetPos = GetPosition(targetRef)
+
+                If .Pos.Map = targetPos.Map Then
+                    If NPCs.CanAttack(.Contadores, .flags) Then
+                        If Distance(.Pos.X, .Pos.Y, targetPos.X, targetPos.Y) <= .AttackRange Then
+                            If NpcCanAttack(NpcIndex, targetRef) = eCanAttack Then
+                                Exit Sub
+                            End If
+                        End If
+                    End If
+                End If
+            End If
+
+            .pathFindingInfo.TargetUnreachable = True
+            .pathFindingInfo.PreviousAttackable = .Attackable
+            .Attackable = 0
+        End If
+    End With
+End Sub
+
+Private Sub NpcClearTargetUnreachable(ByVal NpcIndex As Integer)
+    With NpcList(NpcIndex)
+        If .pathFindingInfo.TargetUnreachable Then
+            .Attackable = .pathFindingInfo.PreviousAttackable
+            .pathFindingInfo.TargetUnreachable = False
+        End If
+    End With
+End Sub
+
 Private Function NpcLanzaSpellInmovilizado(ByVal NpcIndex As Integer, ByVal tIndex As Integer) As Boolean
         
     NpcLanzaSpellInmovilizado = False

--- a/Codigo/Declares.bas
+++ b/Codigo/Declares.bas
@@ -2781,6 +2781,8 @@ Public Type t_NpcPathFindingInfo
     destination As t_Position ' The location where the NPC has to go
     RangoVision As Single
     OriginalVision As Single
+    TargetUnreachable As Boolean
+    PreviousAttackable As Byte
     
     
     '* By setting PathLenght to 0 we force the recalculation

--- a/Codigo/MODULO_NPCs.bas
+++ b/Codigo/MODULO_NPCs.bas
@@ -478,6 +478,9 @@ Sub ResetNpcMainInfo(ByVal NpcIndex As Integer)
         
     With (NpcList(NpcIndex))
 100     .Attackable = 0
+        .pathFindingInfo.TargetUnreachable = False
+        .pathFindingInfo.PreviousAttackable = 0
+        .pathFindingInfo.PathLength = 0
 102     .Comercia = 0
 104     .GiveEXP = 0
 106     .GiveEXPClan = 0
@@ -1557,6 +1560,8 @@ Function OpenNPC(ByVal NpcNumber As Integer, _
             '<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< PATHFINDING >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
             .pathFindingInfo.RangoVision = val(Leer.GetValue("NPC" & NpcNumber, "Distancia", RANGO_VISION_X))
             .pathFindingInfo.OriginalVision = .pathFindingInfo.RangoVision
+            .pathFindingInfo.TargetUnreachable = False
+            .pathFindingInfo.PreviousAttackable = .Attackable
             ReDim .pathFindingInfo.Path(1 To MAX_PATH_LENGTH)
     
             '<<<<<<<<<<<<<< Sistema de Viajes NUEVO >>>>>>>>>>>>>>>>
@@ -2044,7 +2049,7 @@ UserCanAttackNpc.TurnPK = False
      End If
      
      'Es una criatura atacable?
-128  If NpcList(NpcIndex).Attackable = 0 Then
+128  If NpcList(NpcIndex).Attackable = 0 Or NpcList(NpcIndex).pathFindingInfo.TargetUnreachable Then
 132     UserCanAttackNpc.Result = eInmuneNpc
         Exit Function
      End If

--- a/Codigo/UnitTesting.bas
+++ b/Codigo/UnitTesting.bas
@@ -182,10 +182,160 @@ Function test_make_user_char() As Boolean
     test_make_user_char = True
 End Function
 
+Function test_npc_pathfinding_attackable_state() As Boolean
+    Dim npcIndex As Integer
+    Dim attackCheck As t_AttackInteractionResult
+    npcIndex = 1
+
+    Call ResetNpcMainInfo(npcIndex)
+    Call ResetNpcFlags(npcIndex)
+    Call ResetNpcCounters(npcIndex)
+    ReDim NpcList(npcIndex).pathFindingInfo.Path(1 To MAX_PATH_LENGTH)
+
+    With NpcList(npcIndex)
+        .Attackable = 1
+        .Hostile = 1
+        .Pos.Map = 1
+        .Pos.X = 10
+        .Pos.Y = 10
+        .Orig = .Pos
+        .pathFindingInfo.RangoVision = 1
+        .pathFindingInfo.OriginalVision = 1
+        .pathFindingInfo.PathLength = 0
+        .flags.Faccion = e_Facciones.Ciudadano
+        .Humanoide = False
+    End With
+
+    NumMaps = 1
+    MinXBorder = XMinMapSize
+    MaxXBorder = XMaxMapSize
+    MinYBorder = YMinMapSize
+    MaxYBorder = YMaxMapSize
+    ReDim MapData(1 To 1, XMinMapSize To XMaxMapSize, YMinMapSize To YMaxMapSize)
+    ReDim MapInfo(1 To 1)
+    MapInfo(1).Seguro = False
+    MapInfo(1).SafeFightMap = False
+
+    MapData(1, 10, 10).NpcIndex = npcIndex
+    MapData(1, 9, 10).Blocked = e_Block.ALL_SIDES
+    MapData(1, 11, 10).Blocked = e_Block.ALL_SIDES
+    MapData(1, 10, 9).Blocked = e_Block.ALL_SIDES
+    MapData(1, 10, 11).Blocked = e_Block.ALL_SIDES
+
+    With UserList(1)
+        .VersionId = 1
+        .flags.Privilegios = e_PlayerType.user
+        .flags.Muerto = 0
+        .flags.Montado = 0
+        .flags.Inmunidad = 0
+        .flags.EnConsulta = False
+        .flags.Seguro = False
+        .flags.CurrentTeam = 0
+        .flags.AdminInvisible = 0
+        .Grupo.EnGrupo = False
+        .Grupo.Id = 0
+        .GuildIndex = 0
+        .Faccion.Status = e_Facciones.Criminal
+        .Pos.Map = 1
+        .Pos.X = 12
+        .Pos.Y = 10
+    End With
+    LastUser = 1
+    MapData(1, 12, 10).UserIndex = 1
+
+    Debug.Assert SetUserRef(NpcList(npcIndex).TargetUser, 1)
+
+    Call AI_CaminarConRumbo(npcIndex, UserList(1).Pos)
+
+    Debug.Assert NpcList(npcIndex).pathFindingInfo.TargetUnreachable
+    Debug.Assert NpcList(npcIndex).Attackable = 0
+    attackCheck = UserCanAttackNpc(1, npcIndex)
+    Debug.Assert attackCheck.Result = eInmuneNpc
+
+    MapData(1, 12, 10).UserIndex = 0
+    UserList(1).Pos.X = 10
+    UserList(1).Pos.Y = 10
+    MapData(1, 10, 10).UserIndex = 1
+    MapData(1, 9, 10).Blocked = 0
+
+    Call AI_CaminarConRumbo(npcIndex, UserList(1).Pos)
+
+    Debug.Assert Not NpcList(npcIndex).pathFindingInfo.TargetUnreachable
+    Debug.Assert NpcList(npcIndex).Attackable = 1
+    attackCheck = UserCanAttackNpc(1, npcIndex)
+    Debug.Assert attackCheck.Result = eCanAttack
+
+    Call ResetNpcMainInfo(npcIndex)
+    Call ResetNpcFlags(npcIndex)
+    Call ResetNpcCounters(npcIndex)
+    ReDim NpcList(npcIndex).pathFindingInfo.Path(1 To MAX_PATH_LENGTH)
+
+    With NpcList(npcIndex)
+        .Attackable = 1
+        .Hostile = 1
+        .Pos.Map = 1
+        .Pos.X = 10
+        .Pos.Y = 10
+        .Orig = .Pos
+        .AttackRange = 2
+        .pathFindingInfo.RangoVision = 1
+        .pathFindingInfo.OriginalVision = 1
+        .pathFindingInfo.PathLength = 0
+        .flags.Faccion = e_Facciones.Ciudadano
+        .Humanoide = False
+    End With
+
+    NumMaps = 1
+    MinXBorder = XMinMapSize
+    MaxXBorder = XMaxMapSize
+    MinYBorder = YMinMapSize
+    MaxYBorder = YMaxMapSize
+
+    ReDim MapData(1 To 1, XMinMapSize To XMaxMapSize, YMinMapSize To YMaxMapSize)
+    ReDim MapInfo(1 To 1)
+    MapInfo(1).Seguro = False
+    MapInfo(1).SafeFightMap = False
+
+    MapData(1, 10, 10).NpcIndex = npcIndex
+    MapData(1, 11, 10).Blocked = e_Block.ALL_SIDES
+    MapData(1, 12, 10).Blocked = e_Block.ALL_SIDES
+
+    With UserList(1)
+        .VersionId = 1
+        .flags.Privilegios = e_PlayerType.user
+        .flags.Muerto = 0
+        .flags.Montado = 0
+        .flags.Inmunidad = 0
+        .flags.EnConsulta = False
+        .flags.Seguro = False
+        .flags.CurrentTeam = 0
+        .flags.AdminInvisible = 0
+        .Grupo.EnGrupo = False
+        .Grupo.Id = 0
+        .GuildIndex = 0
+        .Faccion.Status = e_Facciones.Criminal
+        .Pos.Map = 1
+        .Pos.X = 12
+        .Pos.Y = 10
+    End With
+    MapData(1, 12, 10).UserIndex = 1
+    LastUser = 1
+
+    Debug.Assert SetUserRef(NpcList(npcIndex).TargetUser, 1)
+
+    Call AI_CaminarConRumbo(npcIndex, UserList(1).Pos)
+
+    Debug.Assert Not NpcList(npcIndex).pathFindingInfo.TargetUnreachable
+    Debug.Assert NpcList(npcIndex).Attackable = 1
+
+    test_npc_pathfinding_attackable_state = True
+End Function
+
 Function test_suite() As Boolean
     Dim result As Boolean
     result = test_make_user_char()
     result = result And test_maths()
+    result = result And test_npc_pathfinding_attackable_state()
     test_suite = result
 End Function
 


### PR DESCRIPTION
## Summary
- prevent `NpcMarkTargetUnreachable` from toggling NPCs into immunity when they already have attack access to their targets
- extend the pathfinding test to confirm attackable NPCs remain vulnerable when a target is within range despite path failures

## Testing
- not run (VB6 unit tests are not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d14d281cd083339c1c599cae2012c8