### PR TITLE
Handle caster reachability in NPC pathfinding

### DIFF
--- a/Codigo/Declares.bas
+++ b/Codigo/Declares.bas
@@ -2781,6 +2781,8 @@ Public Type t_NpcPathFindingInfo
     destination As t_Position ' The location where the NPC has to go
     RangoVision As Single
     OriginalVision As Single
+    TargetUnreachable As Boolean
+    PreviousAttackable As Byte
     
     
     '* By setting PathLenght to 0 we force the recalculation


### PR DESCRIPTION
## Summary
- avoid marking NPC targets as unreachable when casters can attack within spell range
- add helpers and flags to track target reachability state and restore attackable state when appropriate
- add a unit test covering caster pathfinding failures remaining attackable

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d1b9b2ade48333ae44009cb7753b54