### PR TITLE
fix_NpcNotThrowingSpells

### DIFF
--- a/Codigo/AI_NPC.bas
+++ b/Codigo/AI_NPC.bas
@@ -522,7 +522,7 @@ Private Sub AI_AtacarUsuarioObjetivo(ByVal AtackerNpcIndex As Integer)
     With NpcList(AtackerNpcIndex)
         If Not IsValidUserRef(.TargetUser) Then Exit Sub
         EstaPegadoAlUsuario = (Distancia(.pos, UserList(.TargetUser.ArrayIndex).pos) <= 1)
-        AtacaConMagia = .flags.LanzaSpells And IntervaloPermiteLanzarHechizo(AtackerNpcIndex) And (RandomNumber(1, 100) <= 50)
+        AtacaConMagia = .flags.LanzaSpells And IntervaloPermiteLanzarHechizo(AtackerNpcIndex)
         AtacaMelee = EstaPegadoAlUsuario And UsuarioAtacableConMelee(AtackerNpcIndex, .TargetUser.ArrayIndex)
         AtacaMelee = AtacaMelee And (.flags.LanzaSpells > 0 And ((UserList(.TargetUser.ArrayIndex).flags.invisible > 0 Or UserList(.TargetUser.ArrayIndex).flags.Oculto > 0)) Or ( _
                 IsFeatureEnabled("Magic_and_Punch") And Not IsSet(.flags.BehaviorFlags, e_BehaviorFlags.eDontHitVisiblePlayers)))
@@ -1035,7 +1035,6 @@ Private Sub NpcLanzaUnSpell(ByVal NpcIndex As Integer)
     Dim SpellIndex          As Integer
     Dim Target              As Integer
     Dim PuedeDanarAlUsuario As Boolean
-    If Not IntervaloPermiteLanzarHechizo(NpcIndex) Then Exit Sub
     If Not IsValidUserRef(NpcList(NpcIndex).TargetUser) Then Exit Sub
     Target = NpcList(NpcIndex).TargetUser.ArrayIndex
     ' Compute how far the user is from the npcs

--- a/Codigo/modHechizos.bas
+++ b/Codigo/modHechizos.bas
@@ -41,7 +41,7 @@ Sub NpcLanzaSpellSobreUser(ByVal NpcIndex As Integer, ByVal UserIndex As Integer
         If Not IgnoreVisibilityCheck Then
             If .flags.invisible = 1 Or .flags.Oculto = 1 Or .flags.Inmunidad = 1 Then Exit Sub
         End If
-        NpcList(NpcIndex).Contadores.IntervaloLanzarHechizo = GetTickCount()
+        NpcList(NpcIndex).Contadores.IntervaloLanzarHechizo = GetTickCountRaw()
         If Hechizos(Spell).Tipo = uPhysicalSkill Then
             If Not HandlePhysicalSkill(NpcIndex, eNpc, UserIndex, eUser, Spell, IsAlive) Then
                 Exit Sub
@@ -244,7 +244,7 @@ Sub NpcLanzaSpellSobreNpc(ByVal NpcIndex As Integer, ByVal TargetNPC As Integer,
         End If
     End If
     With NpcList(TargetNPC)
-        .Contadores.IntervaloLanzarHechizo = GetTickCount()
+        .Contadores.IntervaloLanzarHechizo = GetTickCountRaw()
         If IsSet(Hechizos(Spell).Effects, e_SpellEffects.eDoHeal) Then ' Cura
             Damage = RandomNumber(Hechizos(Spell).MinHp, Hechizos(Spell).MaxHp)
             Damage = Damage * NPCs.GetMagicHealingBonus(NpcList(NpcIndex))
@@ -343,7 +343,7 @@ Public Sub NpcLanzaSpellSobreArea(ByVal NpcIndex As Integer, ByVal SpellIndex As
     Dim x              As Long
     Dim y              As Long
     Dim mitadAreaRadio As Integer
-    NpcList(NpcIndex).Contadores.IntervaloLanzarHechizo = GetTickCount()
+    NpcList(NpcIndex).Contadores.IntervaloLanzarHechizo = GetTickCountRaw()
     With Hechizos(SpellIndex)
         afectaUsers = (.AreaAfecta = 1 Or .AreaAfecta = 3)
         afectaNPCs = (.AreaAfecta = 2 Or .AreaAfecta = 3)


### PR DESCRIPTION
Removed redundant interval check before NPC spell casting and replaced GetTickCount with GetTickCountRaw for spell interval updates. This streamlines spell casting logic and ensures consistent interval tracking.