### PR TITLE
Migrate timers to GetTickCountRaw

### DIFF
--- a/Codigo/AI_NPC.bas
+++ b/Codigo/AI_NPC.bas
@@ -945,7 +945,7 @@ Private Sub HacerCaminata(ByVal NpcIndex As Integer)
             ' Si no pudimos moverlo, hacemos como si hubiese llegado a destino... para evitar que se quede atascado
             If Not PudoMover Or Distancia(.pos, Destino) = 0 Then
                 ' Llegamos a destino, ahora esperamos el tiempo necesario para continuar
-                .Contadores.IntervaloMovimiento = GetTickCount + .Caminata(.CaminataActual).Espera - .IntervaloMovimiento
+                .Contadores.IntervaloMovimiento = AddMod32(GetTickCountRaw(), .Caminata(.CaminataActual).Espera)
                 ' Pasamos a la siguiente caminata
                 .CaminataActual = .CaminataActual + 1
                 ' Si pasamos el ultimo, volvemos al primero

--- a/Codigo/Acciones.bas
+++ b/Codigo/Acciones.bas
@@ -369,7 +369,7 @@ Sub Accion(ByVal UserIndex As Integer, ByVal Map As Integer, ByVal x As Integer,
                     Exit Sub
                 End If
                 If NpcList(TempCharIndex).Movement = e_TipoAI.Caminata Then
-                    NpcList(TempCharIndex).Contadores.IntervaloMovimiento = GetTickCount + 15000 - NpcList(TempCharIndex).IntervaloMovimiento
+                    NpcList(TempCharIndex).Contadores.IntervaloMovimiento = AddMod32(GetTickCountRaw(), 15000)
                 End If
                 'Iniciamos la rutina pa' comerciar.
                 Call IniciarComercioNPC(UserIndex)
@@ -421,7 +421,7 @@ Sub Accion(ByVal UserIndex As Integer, ByVal Map As Integer, ByVal x As Integer,
                 End If
                 '  Hacemos que se detenga a hablar un momento :P
                 If NpcList(TempCharIndex).Movement = Caminata Then
-                    NpcList(TempCharIndex).Contadores.IntervaloMovimiento = GetTickCount + 5000 - NpcList(TempCharIndex).IntervaloMovimiento ' 5 segundos
+                    NpcList(TempCharIndex).Contadores.IntervaloMovimiento = AddMod32(GetTickCountRaw(), 5000) ' 5 segundos
                 End If
                 UserList(UserIndex).flags.Envenenado = 0
                 UserList(UserIndex).flags.Incinerado = 0
@@ -458,7 +458,7 @@ Sub Accion(ByVal UserIndex As Integer, ByVal Map As Integer, ByVal x As Integer,
                     Exit Sub
                 End If
                 If NpcList(TempCharIndex).Movement = Caminata Then
-                    NpcList(TempCharIndex).Contadores.IntervaloMovimiento = GetTickCount + 20000 - NpcList(TempCharIndex).IntervaloMovimiento
+                    NpcList(TempCharIndex).Contadores.IntervaloMovimiento = AddMod32(GetTickCountRaw(), 20000)
                 End If
                 Call IniciarSubasta(UserIndex)
             ElseIf NpcList(TempCharIndex).npcType = e_NPCType.Quest Then

--- a/Codigo/Declares.bas
+++ b/Codigo/Declares.bas
@@ -3637,16 +3637,18 @@ Public Sub IncreaseLong(ByRef dest As Long, ByVal amount As Long)
 End Sub
 
 Public Sub PerformanceTestStart(ByRef timer As Long)
-    timer = GetTickCount()
+    timer = GetTickCountRaw()
 End Sub
 
 ' Test the time since last call and update the time
 ' log if there time betwen calls exced the limit
 Public Sub PerformTimeLimitCheck(ByRef timer As Long, ByRef TestText As String, Optional ByVal TimeLimit As Long = 1000)
-    Dim CurrTime As Long
-    CurrTime = GetTickCount() - timer
+    Dim nowRaw   As Long
+    Dim CurrTime As Double
+    nowRaw = GetTickCountRaw()
+    CurrTime = TicksElapsed(timer, nowRaw)
     If CurrTime > TimeLimit Then
-        Call LogPerformance("Performance warning at: " & TestText & " elapsed time: " & CurrTime)
+        Call LogPerformance("Performance warning at: " & TestText & " elapsed time: " & CLng(CurrTime))
     End If
-    timer = GetTickCount()
+    timer = nowRaw
 End Sub

--- a/Codigo/EffectsOverTime.bas
+++ b/Codigo/EffectsOverTime.bas
@@ -71,12 +71,8 @@ Public Sub UpdateEffectOverTime()
     On Error GoTo Update_Err
     Dim CurrTime    As Long
     Dim ElapsedTime As Long
-    CurrTime = GetTickCount()
-    If CurrTime < LastUpdateTime Then ' GetTickCount can overflow se we take care of that
-        ElapsedTime = 0
-    Else
-        ElapsedTime = CurrTime - LastUpdateTime
-    End If
+    CurrTime = GetTickCountRaw()
+    ElapsedTime = CLng(TicksElapsed(LastUpdateTime, CurrTime))
     LastUpdateTime = CurrTime
     Dim i As Integer
     Do While i < ActiveEffects.EffectCount

--- a/Codigo/FileIO.bas
+++ b/Codigo/FileIO.bas
@@ -2314,7 +2314,7 @@ Sub SaveUser(ByVal UserIndex As Integer, Optional ByVal Logout As Boolean = Fals
     If Logout Then
         Call RemoveTokenDatabase(UserIndex)
     End If
-    UserList(UserIndex).Counters.LastSave = GetTickCount
+    UserList(UserIndex).Counters.LastSave = GetTickCountRaw()
     Exit Sub
 SaveUser_Err:
     Call TraceError(Err.Number, Err.Description, "ES.SaveUser", Erl)

--- a/Codigo/GameLogic.bas
+++ b/Codigo/GameLogic.bas
@@ -1092,8 +1092,7 @@ Sub LookatTile(ByVal UserIndex As Integer, ByVal Map As Integer, ByVal x As Inte
             If Len(NpcList(TempCharIndex).Desc) > 1 Then
                 '  Hacemos que se detenga a hablar un momento :P
                 If NpcList(TempCharIndex).Movement = Caminata Then
-                    NpcList(TempCharIndex).Contadores.IntervaloMovimiento = GetTickCount + 5000 + Len(NpcList(TempCharIndex).Desc) * 50 - NpcList( _
-                            TempCharIndex).IntervaloMovimiento ' 5 segundos + 1 segundo cada 20 caracteres
+                    NpcList(TempCharIndex).Contadores.IntervaloMovimiento = AddMod32(GetTickCountRaw(), 5000 + Len(NpcList(TempCharIndex).Desc) * 50) ' 5 segundos + 1 segundo cada 20 caracteres
                 End If
                 If UserList(UserIndex).flags.Muerto = 0 Or (UserList(UserIndex).flags.Muerto = 1 And NpcList(TempCharIndex).npcType = e_NPCType.Revividor) Then
                     If NpcList(TempCharIndex).npcType = e_NPCType.Quest Or NpcList(TempCharIndex).npcType = e_NPCType.Banquero Or NpcList(TempCharIndex).npcType = _
@@ -1101,7 +1100,7 @@ Sub LookatTile(ByVal UserIndex As Integer, ByVal Map As Integer, ByVal x As Inte
                             TempCharIndex).npcType = e_NPCType.Gobernador Then
                         If Distance(UserList(UserIndex).pos.x, UserList(UserIndex).pos.y, NpcList(TempCharIndex).pos.x, NpcList(TempCharIndex).pos.y) < 3 Then
                             If NpcList(TempCharIndex).Movement = Caminata Then
-                                NpcList(TempCharIndex).Contadores.IntervaloMovimiento = GetTickCount + 15000 - NpcList(TempCharIndex).IntervaloMovimiento ' 15 segundos
+                                NpcList(TempCharIndex).Contadores.IntervaloMovimiento = AddMod32(GetTickCountRaw(), 15000) ' 15 segundos
                             End If
                             If NpcList(TempCharIndex).SoundOpen <> 0 Then
                                 Call WritePlayWave(UserIndex, NpcList(TempCharIndex).SoundOpen, NpcList(TempCharIndex).pos.x, NpcList(TempCharIndex).pos.y, 1, 1)

--- a/Codigo/General.bas
+++ b/Codigo/General.bas
@@ -583,7 +583,7 @@ Sub Main()
         Call UnitClient.Connect("127.0.0.1", "7667")
     #End If
     While (True)
-        GlobalFrameTime = GetTickCount()
+        GlobalFrameTime = GetTickCountRaw()
         Dim PerformanceTimer As Long
         Call PerformanceTestStart(PerformanceTimer)
         #If PYMMO = 1 Then

--- a/Codigo/Hogar.bas
+++ b/Codigo/Hogar.bas
@@ -110,15 +110,15 @@ End Sub
 Public Function IntervaloGoHome(ByVal UserIndex As Integer, Optional ByVal TimeInterval As Long, Optional ByVal Actualizar As Boolean = False) As Boolean
     On Error GoTo IntervaloGoHome_Err
     'Add the Timer which determines wether the user can be teleported to its home or not
-    Dim TActual As Long
-    TActual = GetTickCount()
+    Dim nowRaw As Long
+    nowRaw = GetTickCountRaw()
     With UserList(UserIndex)
         ' Inicializa el timer
         If Actualizar Then
             .flags.Traveling = 1
-            .Counters.goHome = TActual + TimeInterval
+            .Counters.goHome = AddMod32(nowRaw, TimeInterval)
         Else
-            If TActual >= .Counters.goHome Then
+            If DeadlinePassed(nowRaw, .Counters.goHome) Then
                 IntervaloGoHome = True
             End If
         End If

--- a/Codigo/InvUsuario.bas
+++ b/Codigo/InvUsuario.bas
@@ -1410,6 +1410,7 @@ Sub UseInvItem(ByVal UserIndex As Integer, ByVal Slot As Byte, ByVal ByClick As 
     Dim ObjIndex As Integer
     Dim TargObj  As t_ObjData
     Dim MiObj    As t_Obj
+    Dim nowRaw   As Long
     With UserList(UserIndex)
         If .invent.Object(Slot).amount = 0 Then Exit Sub
         If Not CanUseItem(.flags, .Counters) Then
@@ -1420,7 +1421,8 @@ Sub UseInvItem(ByVal UserIndex As Integer, ByVal Slot As Byte, ByVal ByClick As 
             Exit Sub
         End If
         obj = ObjData(.invent.Object(Slot).ObjIndex)
-        Dim TimeSinceLastUse As Long: TimeSinceLastUse = GetTickCount() - .CdTimes(obj.cdType)
+        nowRaw = GetTickCountRaw()
+        Dim TimeSinceLastUse As Double: TimeSinceLastUse = TicksElapsed(.CdTimes(obj.cdType), nowRaw)
         If TimeSinceLastUse < obj.Cooldown Then Exit Sub
         If IsSet(obj.ObjFlags, e_ObjFlags.e_UseOnSafeAreaOnly) Then
             If MapInfo(.pos.Map).Seguro = 0 Then
@@ -2059,9 +2061,10 @@ Sub UseInvItem(ByVal UserIndex As Integer, ByVal Slot As Byte, ByVal ByClick As 
                         Call UserMod.UserDie(UserIndex)
                         'Poción de reset (resetea el personaje)
                     Case 22
-                        If GetTickCount - .Counters.LastResetTick > 3000 Then
+                        nowRaw = GetTickCountRaw()
+                        If TicksElapsed(.Counters.LastResetTick, nowRaw) > 3000 Then
                             Call writeAnswerReset(UserIndex)
-                            .Counters.LastResetTick = GetTickCount
+                            .Counters.LastResetTick = nowRaw
                         Else
                             'Msg894= Debes esperar unos momentos para tomar esta poción.
                             Call WriteLocaleMsg(UserIndex, "894", e_FontTypeNames.FONTTYPE_INFO)
@@ -2732,8 +2735,8 @@ ItemNewbie_Err:
 End Function
 
 Public Function IsItemInCooldown(ByRef User As t_User, ByRef obj As t_UserOBJ) As Boolean
-    Dim ElapsedTime As Long
-    ElapsedTime = GetTickCount() - User.CdTimes(ObjData(obj.ObjIndex).cdType)
+    Dim ElapsedTime As Double
+    ElapsedTime = TicksElapsed(User.CdTimes(ObjData(obj.ObjIndex).cdType), GetTickCountRaw())
     IsItemInCooldown = ElapsedTime < ObjData(obj.ObjIndex).Cooldown
 End Function
 

--- a/Codigo/ModInvasion.bas
+++ b/Codigo/ModInvasion.bas
@@ -167,7 +167,7 @@ Sub IniciarInvasion(ByVal Index As Integer)
     With Invasiones(Index)
         .Activa = True
         .VidaMuralla = .MaxVidaMuralla
-        .TiempoDeInicio = GetTickCount
+        .TiempoDeInicio = GetTickCountRaw()
         ' Enviamos info sobre la invasión a los usuarios en estos mapas
         Call EnviarInfoInvasion(Index)
         Call MensajeGlobal(.Desc, e_FontTypeNames.FONTTYPE_New_Eventos)
@@ -297,7 +297,9 @@ Public Sub EnviarInfoInvasion(ByVal Index As Integer)
     With Invasiones(Index)
         Dim PorcentajeVida As Byte, PorcentajeTiempo As Byte
         PorcentajeVida = (.VidaMuralla / .MaxVidaMuralla) * 100
-        PorcentajeTiempo = (GetTickCount - .TiempoDeInicio) / (.Duracion * 600)
+        Dim elapsedMs As Double
+        elapsedMs = TicksElapsed(.TiempoDeInicio, GetTickCountRaw())
+        PorcentajeTiempo = CByte(elapsedMs / (.Duracion * 600))
         Dim i As Integer, Mapa As Integer, j As Integer
         For i = 1 To UBound(.SpawnBoxes)
             Mapa = .SpawnBoxes(i).TopLeft.Map

--- a/Codigo/Modulo_UsUaRiOs.bas
+++ b/Codigo/Modulo_UsUaRiOs.bas
@@ -615,7 +615,7 @@ Public Function ConnectUser_Complete(ByVal UserIndex As Integer, ByRef name As S
         NumUsers = NumUsers + 1
         .flags.UserLogged = True
         Call Execute("Update user set is_logged = true where id = ?", UserList(UserIndex).Id)
-        .Counters.LastSave = GetTickCount
+        .Counters.LastSave = GetTickCountRaw()
         MapInfo(.pos.Map).NumUsers = MapInfo(.pos.Map).NumUsers + 1
         If .Stats.SkillPts > 0 Then
             Call WriteSendSkills(UserIndex)
@@ -2645,7 +2645,7 @@ Public Function CanUseItem(ByRef flags As t_UserFlags, ByRef Counters As t_UserC
 End Function
 
 Public Sub UpdateCd(ByVal UserIndex As Integer, ByVal cdType As e_CdTypes)
-    UserList(UserIndex).CdTimes(cdType) = GetTickCount()
+    UserList(UserIndex).CdTimes(cdType) = GetTickCountRaw()
     Call WriteUpdateCdType(UserIndex, cdType)
 End Sub
 

--- a/Codigo/Protocol_GmCommands.bas
+++ b/Codigo/Protocol_GmCommands.bas
@@ -3404,21 +3404,21 @@ HandleGlobalOnOff_Err:
 End Sub
 
 Public Sub HandleGlobalMessage(ByVal UserIndex As Integer)
-    Dim TActual     As Long
-    Dim ElapsedTime As Long
-    TActual = GetTickCount()
-    ElapsedTime = TActual - UserList(UserIndex).Counters.MensajeGlobal
+    Dim nowRaw      As Long
+    Dim elapsedMs   As Double
+    nowRaw = GetTickCountRaw()
+    elapsedMs = TicksElapsed(UserList(UserIndex).Counters.MensajeGlobal, nowRaw)
     On Error GoTo ErrHandler
     With UserList(UserIndex)
         Dim chat As String
         chat = reader.ReadString8()
         If .flags.Silenciado = 1 Then
             Call WriteLocaleMsg(UserIndex, "110", e_FontTypeNames.FONTTYPE_VENENO, .flags.MinutosRestantes)
-        ElseIf ElapsedTime < IntervaloMensajeGlobal Then
+        ElseIf elapsedMs < IntervaloMensajeGlobal Then
             ' Msg548=No puedes escribir mensajes globales tan rápido.
             Call WriteLocaleMsg(UserIndex, "548", e_FontTypeNames.FONTTYPE_WARNING)
         Else
-            UserList(UserIndex).Counters.MensajeGlobal = TActual
+            UserList(UserIndex).Counters.MensajeGlobal = nowRaw
             If SvrConfig.GetValue("ChatGlobal") = 1 Then
                 If LenB(chat) <> 0 Then
                     Dim i As Integer
@@ -3440,7 +3440,7 @@ Public Sub HandleGlobalMessage(ByVal UserIndex As Integer)
     End With
     Exit Sub
 ErrHandler:
-    Call TraceError(Err.Number, Err.Description, "Protocol.?", Erl)
+    Call TraceError(Err.Number, Err.Description, "Protocol.HandleGlobalMessage", Erl)
 End Sub
 
 Public Sub HandleGlobalOnOff(ByVal UserIndex As Integer)
@@ -3509,10 +3509,10 @@ ErrHandler:
 End Sub
 
 Public Sub HandleQuestionGM(ByVal UserIndex As Integer)
-    Dim TActual     As Long
-    Dim ElapsedTime As Long
-    TActual = GetTickCount()
-    ElapsedTime = TActual - UserList(UserIndex).Counters.LastGmMessage
+    Dim nowRaw      As Long
+    Dim elapsedMs   As Double
+    nowRaw = GetTickCountRaw()
+    elapsedMs = TicksElapsed(UserList(UserIndex).Counters.LastGmMessage, nowRaw)
     On Error GoTo ErrHandler
     With UserList(UserIndex)
         Dim Consulta       As String
@@ -3540,12 +3540,12 @@ Public Sub HandleQuestionGM(ByVal UserIndex As Integer)
                 End If
             Next i
         End If
-        If ElapsedTime < IntervaloConsultaGM Then
+        If elapsedMs < IntervaloConsultaGM Then
             ' Msg552=Solo puedes enviar una consulta cada 5 minutos.
             Call WriteLocaleMsg(UserIndex, "552", e_FontTypeNames.FONTTYPE_WARNING)
             Exit Sub
         End If
-        UserList(UserIndex).Counters.LastGmMessage = TActual
+        UserList(UserIndex).Counters.LastGmMessage = nowRaw
         Call Ayuda.Push(.name, Consulta, TipoDeConsulta)
         Call SendData(SendTarget.ToAdmins, 0, PrepareMessageLocaleMsg(1836, UserList(UserIndex).name, e_FontTypeNames.FONTTYPE_SERVER)) ' Msg1836=Se ha recibido un nuevo mensaje de soporte de ¬1.
         .Counters.CounterGmMessages = 0

--- a/Codigo/Protocol_Writes.bas
+++ b/Codigo/Protocol_Writes.bas
@@ -4391,7 +4391,7 @@ Public Sub WriteDebugLogResponse(ByVal UserIndex As Integer, ByVal debugType, By
             Call Writer.WriteString8("remote DEBUG: " & " user name: " & Args(0))
             With UserList(tIndex)
                 Dim timeSinceLastReset As Long
-                timeSinceLastReset = GetTickCount() - Mapping(.ConnectionDetails.ConnID).TimeLastReset
+                timeSinceLastReset = CLng(TicksElapsed(Mapping(.ConnectionDetails.ConnID).TimeLastReset, GetTickCountRaw()))
                 Call Writer.WriteString8("validConnection: " & .ConnectionDetails.ConnIDValida & " connectionID: " & .ConnectionDetails.ConnID & " UserIndex: " & tIndex & _
                         " charNmae" & .name & " UserLogged state: " & .flags.UserLogged & ", time since last message: " & timeSinceLastReset & " timeout setting: " & _
                         DisconnectTimeout)

--- a/Codigo/ScenarioDeathMatch.cls
+++ b/Codigo/ScenarioDeathMatch.cls
@@ -412,9 +412,11 @@ Public Sub IBaseScenario_PlayerKillPlayer(ByVal killerIndex As Integer, ByVal de
 End Sub
 
 Public Sub IBaseScenario_Update()
+    Dim nowRaw As Long
     Dim frametime As Long
-    frametime = GetTickCount() - LastFrameTime
-    LastFrameTime = GetTickCount()
+    nowRaw = GetTickCountRaw()
+    frametime = CLng(TicksElapsed(LastFrameTime, nowRaw))
+    LastFrameTime = nowRaw
     If LobbyList(LobbyIndex).State = e_LobbyState.InProgress Then
         If CountdownTimer.Occurrences < 10 Then
             If UpdateTime(CountdownTimer, frametime) Then
@@ -470,7 +472,7 @@ End Sub
 Private Sub StartGame()
     Call SetTimer(BroadCastTimer, 60000)
     Call SetTimer(ScoreBroadcastTimer, 20000)
-    LastFrameTime = GetTickCount()
+    LastFrameTime = GetTickCountRaw()
     Call SendData(SendTarget.toMap, MapNumber, PrepareMessageLocaleMsg(1893, vbNullString, e_FontTypeNames.FONTTYPE_GUILD)) 'Msg1893=¡Que inicie la masacre!
     ElapsedTime = 0
     Call LimitFightArea
@@ -553,11 +555,11 @@ Private Sub RespawnPlayers()
     Dim currentTime As Long
     Dim RespawnInfo As clsRespawnInfo
     Dim i           As Integer
-    currentTime = GetTickCount()
+    currentTime = GetTickCountRaw()
     Keys = PlayerRespawn.Keys
     For Each key In Keys
         Set RespawnInfo = PlayerRespawn.Item(key)
-        If currentTime - RespawnInfo.RespawnTime > PlayerRespawnTime Then
+        If TicksElapsed(RespawnInfo.RespawnTime, currentTime) > PlayerRespawnTime Then
             Call Respawn(key)
             For i = 0 To RespawnInfo.EquipedElementCount - 1
                 Call EquiparInvItem(key, RespawnInfo.GetActiveSlot(i))
@@ -627,7 +629,7 @@ End Sub
 Public Sub IBaseScenario_UserDie(ByVal UserIndex)
     Dim RespawnInfo As clsRespawnInfo
     Set RespawnInfo = New clsRespawnInfo
-    RespawnInfo.RespawnTime = GetTickCount()
+    RespawnInfo.RespawnTime = GetTickCountRaw()
     With UserList(UserIndex)
         Dim i As Integer
         For i = LBound(.invent.Object) To UBound(.invent.Object)

--- a/Codigo/ScenarioHuntNpc.cls
+++ b/Codigo/ScenarioHuntNpc.cls
@@ -226,7 +226,7 @@ Private Sub StartGame()
             SpawnNpc (MatchNpc(key).NpcId)
         Next i
     Next key
-    LastFrameTime = GetTickCount()
+    LastFrameTime = GetTickCountRaw()
     BroadCastInterval = 60000
     Call SendData(SendTarget.toMap, MapNumber, PrepareMessageLocaleMsg(1730, "", e_FontTypeNames.FONTTYPE_GUILD)) 'Msg1730=Â¡Que inicie la cacerÃ­a!
 End Sub
@@ -262,9 +262,11 @@ Private Sub IBaseScenario_PlayerKillPlayer(ByVal killerIndex As Integer, ByVal d
 End Sub
 
 Private Sub IBaseScenario_Update()
+    Dim nowRaw As Long
     Dim frametime As Long
-    frametime = GetTickCount() - LastFrameTime
-    LastFrameTime = GetTickCount()
+    nowRaw = GetTickCountRaw()
+    frametime = CLng(TicksElapsed(LastFrameTime, nowRaw))
+    LastFrameTime = nowRaw
     If LobbyList(LobbyIndex).State = e_LobbyState.InProgress Then
         If StartTimer.Occurrences < 10 Then
             If UpdateTime(StartTimer, frametime) Then
@@ -386,7 +388,7 @@ End Sub
 Public Sub IBaseScenario_UserDie(ByVal UserIndex)
     Dim RespawnInfo As clsRespawnInfo
     Set RespawnInfo = New clsRespawnInfo
-    RespawnInfo.RespawnTime = GetTickCount()
+    RespawnInfo.RespawnTime = GetTickCountRaw()
     With UserList(UserIndex)
         Dim i As Integer
         For i = LBound(.invent.Object) To UBound(.invent.Object)
@@ -423,11 +425,11 @@ Private Sub RespawnPlayers()
     Dim currentTime As Long
     Dim RespawnInfo As clsRespawnInfo
     Dim i           As Integer
-    currentTime = GetTickCount()
+    currentTime = GetTickCountRaw()
     Keys = PlayerRespawn.Keys
     For Each key In Keys
         Set RespawnInfo = PlayerRespawn.Item(key)
-        If currentTime - RespawnInfo.RespawnTime > PlayerRespawnTime Then
+        If TicksElapsed(RespawnInfo.RespawnTime, currentTime) > PlayerRespawnTime Then
             Call Respawn(key)
             For i = 0 To RespawnInfo.EquipedElementCount - 1
                 Call EquiparInvItem(key, RespawnInfo.GetActiveSlot(i))

--- a/Codigo/Scenearios/ScenarioNavalBoarding.cls
+++ b/Codigo/Scenearios/ScenarioNavalBoarding.cls
@@ -486,9 +486,11 @@ Public Sub IBaseScenario_PlayerKillPlayer(ByVal killerIndex As Integer, ByVal de
 End Sub
 
 Public Sub IBaseScenario_Update()
+    Dim nowRaw As Long
     Dim frametime As Long
-    frametime = GetTickCount() - LastFrameTime
-    LastFrameTime = GetTickCount()
+    nowRaw = GetTickCountRaw()
+    frametime = CLng(TicksElapsed(LastFrameTime, nowRaw))
+    LastFrameTime = nowRaw
     If LobbyList(LobbyIndex).State = e_LobbyState.InProgress Then
         If CountdownTimer.Occurrences < 10 Then
             If UpdateTime(CountdownTimer, frametime) Then
@@ -558,7 +560,7 @@ End Sub
 Private Sub StartGame()
     Call SetTimer(BroadCastTimer, 60000)
     Call SetTimer(ScoreBroadcastTimer, 20000)
-    LastFrameTime = GetTickCount()
+    LastFrameTime = GetTickCountRaw()
     Call SendData(SendTarget.toMap, MapNumbers(1), PrepareMessageLocaleMsg(1883, vbNullString, e_FontTypeNames.FONTTYPE_GUILD)) 'Msg1883=¡Marineros al abordaje!
     ElapsedTime = 0
     Call ConfigMapEvent
@@ -643,7 +645,7 @@ Private Sub RespawnPlayers()
     Dim currentTime As Long
     Dim RespawnInfo As clsRespawnInfo
     Dim i           As Integer
-    currentTime = GetTickCount()
+    currentTime = GetTickCountRaw()
     Keys = PlayerRespawn.Keys
     For Each key In Keys
         Set RespawnInfo = PlayerRespawn.Item(key)
@@ -790,7 +792,7 @@ End Sub
 Public Sub IBaseScenario_UserDie(ByVal UserIndex)
     Dim RespawnInfo As clsRespawnInfo
     Set RespawnInfo = New clsRespawnInfo
-    RespawnInfo.RespawnTime = GetTickCount()
+    RespawnInfo.RespawnTime = GetTickCountRaw()
     With UserList(UserIndex)
         Dim i As Integer
         For i = LBound(.invent.Object) To UBound(.invent.Object)

--- a/Codigo/Trabajo.bas
+++ b/Codigo/Trabajo.bas
@@ -2117,7 +2117,7 @@ Public Sub DoTalar(ByVal UserIndex As Integer, ByVal x As Byte, ByVal y As Byte,
             Dim nPos  As t_WorldPos
             Dim MiObj As t_Obj
             Call ActualizarRecurso(.pos.Map, x, y)
-            MapData(.pos.Map, x, y).ObjInfo.data = GetTickCount() ' Ultimo uso
+            MapData(.pos.Map, x, y).ObjInfo.data = GetTickCountRaw() ' Ultimo uso
             If .clase = Trabajador Then
                 MiObj.amount = GetExtractResourceForLevel(.Stats.ELV)
             Else
@@ -2210,7 +2210,7 @@ Public Sub DoMineria(ByVal UserIndex As Integer, ByVal x As Byte, ByVal y As Byt
             Dim MiObj As t_Obj
             Dim nPos  As t_WorldPos
             Call ActualizarRecurso(.pos.Map, x, y)
-            MapData(.pos.Map, x, y).ObjInfo.data = GetTickCount() ' Ultimo uso
+            MapData(.pos.Map, x, y).ObjInfo.data = GetTickCountRaw() ' Ultimo uso
             Yacimiento = ObjData(MapData(.pos.Map, x, y).ObjInfo.ObjIndex)
             MiObj.ObjIndex = Yacimiento.MineralIndex
             If .clase = Trabajador Then
@@ -2390,11 +2390,17 @@ Public Sub ActualizarRecurso(ByVal Map As Integer, ByVal x As Integer, ByVal y A
     Dim ObjIndex As Integer
     ObjIndex = MapData(Map, x, y).ObjInfo.ObjIndex
     Dim TiempoActual As Long
-    TiempoActual = GetTickCount()
+    TiempoActual = GetTickCountRaw()
     ' Data = Ultimo uso
-    If (TiempoActual - MapData(Map, x, y).ObjInfo.data) * 0.001 > ObjData(ObjIndex).TiempoRegenerar Then
-        MapData(Map, x, y).ObjInfo.amount = ObjData(ObjIndex).VidaUtil
-        MapData(Map, x, y).ObjInfo.data = &H7FFFFFFF   ' Ultimo uso = Max Long
+    Dim lastUse As Long
+    lastUse = MapData(Map, x, y).ObjInfo.data
+    If lastUse <> &H7FFFFFFF Then
+        Dim elapsedMs As Double
+        elapsedMs = TicksElapsed(lastUse, TiempoActual)
+        If elapsedMs / 1000# > ObjData(ObjIndex).TiempoRegenerar Then
+            MapData(Map, x, y).ObjInfo.amount = ObjData(ObjIndex).VidaUtil
+            MapData(Map, x, y).ObjInfo.data = &H7FFFFFFF   ' Ultimo uso = Max Long
+        End If
     End If
     Exit Sub
 ActualizarRecurso_Err:

--- a/Codigo/frmMain.frm
+++ b/Codigo/frmMain.frm
@@ -1112,16 +1112,18 @@ Private Sub TimerGuardarUsuarios_Timer()
         ' Guardar usuarios (solo si pasó el tiempo mínimo para guardar)
         Dim UserIndex        As Integer, UserGuardados As Integer
         Dim PerformanceTimer As Long
+        Dim nowRaw          As Long
         Call PerformanceTestStart(PerformanceTimer)
         For UserIndex = 1 To LastUser
             With UserList(UserIndex)
                 If .flags.UserLogged Then
-                    If GetTickCount - .Counters.LastSave > IntervaloGuardarUsuarios Then
+                    nowRaw = GetTickCountRaw()
+                    If TicksElapsed(.Counters.LastSave, nowRaw) > IntervaloGuardarUsuarios Then
                         Call SaveUser(UserIndex)
                         UserGuardados = UserGuardados + 1
                         If UserGuardados > NumUsers Then Exit For
                         'limit the amount of time we block the only thread we have here, lets save some user on the next loop
-                        If (GetTickCount - PerformanceTimer) > 100 Then Exit For
+                        If TicksElapsed(PerformanceTimer, GetTickCountRaw()) > 100 Then Exit For
                     End If
                 End If
             End With
@@ -1378,6 +1380,7 @@ Private Sub Automatic_Event_Timer()
     Dim CurrentDay    As Byte
     Dim CurrentHour   As Byte
     Dim EventOfTheDay As Integer
+    Dim nowRaw        As Long
     CurrentDay = Weekday(Date) 'domingo=1 , lunes=2, martes=3, miercoles=4, jueves=5, viernes=6, sabado=7
     CurrentHour = Hour(Time) 'number between 0 and 23
     'si no es la hora de activar el evento salimos
@@ -1386,7 +1389,8 @@ Private Sub Automatic_Event_Timer()
     End If
     If AlreadyDidAutoEventToday Then
         '3600000 = 1 hora en milisegundos
-        If GetTickCount - LastAutoEventAttempt > 3600000 Then
+        nowRaw = GetTickCountRaw()
+        If TicksElapsed(LastAutoEventAttempt, nowRaw) > 3600000 Then
             AlreadyDidAutoEventToday = False
         End If
         Exit Sub
@@ -1466,7 +1470,7 @@ Private Sub Automatic_Event_Timer()
         Call CreatePublicEvent(LobbySettings)
     End If
     AlreadyDidAutoEventToday = True
-    LastAutoEventAttempt = GetTickCount
+    LastAutoEventAttempt = GetTickCountRaw()
     Exit Sub
 Evento_Timer_Err:
     Call TraceError(Err.Number, Err.Description, "frmMain.Evento_Timer", Erl)

--- a/Codigo/modHechizos.bas
+++ b/Codigo/modHechizos.bas
@@ -41,7 +41,7 @@ Sub NpcLanzaSpellSobreUser(ByVal NpcIndex As Integer, ByVal UserIndex As Integer
         If Not IgnoreVisibilityCheck Then
             If .flags.invisible = 1 Or .flags.Oculto = 1 Or .flags.Inmunidad = 1 Then Exit Sub
         End If
-        NpcList(NpcIndex).Contadores.IntervaloLanzarHechizo = GetTickCount()
+        NpcList(NpcIndex).Contadores.IntervaloLanzarHechizo = GetTickCountRaw()
         If Hechizos(Spell).Tipo = uPhysicalSkill Then
             If Not HandlePhysicalSkill(NpcIndex, eNpc, UserIndex, eUser, Spell, IsAlive) Then
                 Exit Sub
@@ -244,7 +244,7 @@ Sub NpcLanzaSpellSobreNpc(ByVal NpcIndex As Integer, ByVal TargetNPC As Integer,
         End If
     End If
     With NpcList(TargetNPC)
-        .Contadores.IntervaloLanzarHechizo = GetTickCount()
+        .Contadores.IntervaloLanzarHechizo = GetTickCountRaw()
         If IsSet(Hechizos(Spell).Effects, e_SpellEffects.eDoHeal) Then ' Cura
             Damage = RandomNumber(Hechizos(Spell).MinHp, Hechizos(Spell).MaxHp)
             Damage = Damage * NPCs.GetMagicHealingBonus(NpcList(NpcIndex))
@@ -343,7 +343,7 @@ Public Sub NpcLanzaSpellSobreArea(ByVal NpcIndex As Integer, ByVal SpellIndex As
     Dim x              As Long
     Dim y              As Long
     Dim mitadAreaRadio As Integer
-    NpcList(NpcIndex).Contadores.IntervaloLanzarHechizo = GetTickCount()
+    NpcList(NpcIndex).Contadores.IntervaloLanzarHechizo = GetTickCountRaw()
     With Hechizos(SpellIndex)
         afectaUsers = (.AreaAfecta = 1 Or .AreaAfecta = 3)
         afectaNPCs = (.AreaAfecta = 2 Or .AreaAfecta = 3)
@@ -578,9 +578,9 @@ Private Function PuedeLanzar(ByVal UserIndex As Integer, ByVal HechizoIndex As I
             End If
         End If
         If Hechizos(HechizoIndex).Cooldown > 0 And .Counters.UserHechizosInterval(Slot) > 0 Then
-            Dim Actual            As Long
+            Dim nowRaw             As Long
             Dim SegundosFaltantes As Long
-            Actual = GetTickCount()
+            nowRaw = GetTickCountRaw()
             Dim Cooldown As Long
             Cooldown = Hechizos(HechizoIndex).Cooldown
             'cooldown reduction for Elven Wood items
@@ -595,8 +595,10 @@ Private Function PuedeLanzar(ByVal UserIndex As Integer, ByVal HechizoIndex As I
                 End If
             End If
             Cooldown = Cooldown * 1000
-            If .Counters.UserHechizosInterval(Slot) + Cooldown > Actual Then
-                SegundosFaltantes = Int((.Counters.UserHechizosInterval(Slot) + Cooldown - Actual) / 1000)
+            Dim elapsedMs As Double
+            elapsedMs = TicksElapsed(.Counters.UserHechizosInterval(Slot), nowRaw)
+            If elapsedMs < Cooldown Then
+                SegundosFaltantes = Int((Cooldown - elapsedMs) / 1000)
                 Call WriteLocaleMsg(UserIndex, 1635, e_FontTypeNames.FONTTYPE_WARNING, SegundosFaltantes) 'Msg1635=Debes esperar ¬1 segundos para volver a tirar este hechizo.
                 Exit Function
             End If
@@ -1367,7 +1369,7 @@ Sub LanzarHechizo(ByVal Index As Integer, ByVal UserIndex As Integer)
     End If
     If SpellCastSuccess Then
         If Hechizos(uh).Cooldown > 0 Then
-            UserList(UserIndex).Counters.UserHechizosInterval(Index) = GetTickCount()
+            UserList(UserIndex).Counters.UserHechizosInterval(Index) = GetTickCountRaw()
             If Hechizos(uh).CdEffectId > 0 Then Call WriteSendSkillCdUpdate(UserIndex, Hechizos(uh).CdEffectId, -uh, CLng(Hechizos(uh).Cooldown) * 1000, CLng(Hechizos( _
                     uh).Cooldown) * 1000, eCD)
         End If

--- a/Codigo/modNetwork.bas
+++ b/Codigo/modNetwork.bas
@@ -131,13 +131,13 @@ Public Sub close_not_logged_sockets_if_timeout()
     On Error GoTo close_not_logged_sockets_if_timeout_ErrHandler:
     Dim i     As Integer
     Dim key   As Variant
-    Dim Ticks As Long, Delta As Long
-    Ticks = GetTickCount
+    Dim nowRaw As Long, Delta As Double
+    nowRaw = GetTickCountRaw()
     For Each key In PendingConnections.Keys
         With Mapping(key)
             Dim ConnectionID As Long
             ConnectionID = key
-            Delta = Ticks - Mapping(ConnectionID).ConnectionDetails.OnConnectTimestamp
+            Delta = TicksElapsed(Mapping(ConnectionID).ConnectionDetails.OnConnectTimestamp, nowRaw)
             If Delta > PendingConnectionTimeout Then
                 If IsValidUserRef(.UserRef) Then
                     LogError ("trying to kick an assigned connection: " & ConnectionID & " assigned to: " & .UserRef.ArrayIndex)
@@ -175,7 +175,7 @@ Private Sub OnServerConnect(ByVal Connection As Long, ByVal Address As String)
             .ConnectionDetails.ConnIDValida = True
             .ConnectionDetails.IP = Address
             .ConnectionDetails.ConnID = Connection
-            .ConnectionDetails.OnConnectTimestamp = GetTickCount()
+            .ConnectionDetails.OnConnectTimestamp = GetTickCountRaw()
             .PacketCount = 0
             .TimeLastReset = 0
         End With
@@ -282,13 +282,13 @@ Public Sub CheckDisconnectedUsers()
     End If
     Dim currentTime As Long
     Dim iUserIndex  As Integer
-    currentTime = GetTickCount()
+    currentTime = GetTickCountRaw()
     For iUserIndex = 1 To MaxUsers
         With UserList(iUserIndex)
             'Conexion activa? y es un usuario loggeado?
             If .ConnectionDetails.ConnIDValida = 0 And .flags.UserLogged Then
                 If .ConnectionDetails.ConnID > 0 Then
-                    If currentTime - Mapping(.ConnectionDetails.ConnID).TimeLastReset > DisconnectTimeout Then
+                    If TicksElapsed(Mapping(.ConnectionDetails.ConnID).TimeLastReset, currentTime) > DisconnectTimeout Then
                         'mato los comercios seguros
                         If .ComUsu.DestUsu.ArrayIndex > 0 Then
                             If IsValidUserRef(.ComUsu.DestUsu) And UserList(.ComUsu.DestUsu.ArrayIndex).flags.UserLogged Then
@@ -388,7 +388,7 @@ On Error GoTo CheckDisconnectedUsers_Err:
              .ConnIDValida = True
              .IP = "127.0.0.1"
              .ConnID = ConnectionID
-             .OnConnectTimestamp = GetTickCount()
+             .OnConnectTimestamp = GetTickCountRaw()
         End With
         UserList(FreeUser).ConnectionDetails = cdetail
  

--- a/Codigo/modNuevoTimer.bas
+++ b/Codigo/modNuevoTimer.bas
@@ -217,8 +217,11 @@ Public Function IntervaloPermiteMoverse(ByVal NpcIndex As Integer) As Boolean
     On Error GoTo IntervaloPermiteMoverse_Err
     Dim nowRaw As Long: nowRaw = GetTickCountRaw()
     With NpcList(NpcIndex)
-        If TicksElapsed(.Contadores.IntervaloMovimiento, nowRaw) >= (.IntervaloMovimiento / GetNpcSpeedModifiers(NpcIndex)) Then
-            .Contadores.IntervaloMovimiento = nowRaw
+        Dim interval As Long
+        interval = CLng(.IntervaloMovimiento / GetNpcSpeedModifiers(NpcIndex))
+        If interval < 0 Then interval = 0
+        If DeadlinePassed(nowRaw, .Contadores.IntervaloMovimiento) Then
+            .Contadores.IntervaloMovimiento = AddMod32(nowRaw, interval)
             IntervaloPermiteMoverse = True
         End If
     End With


### PR DESCRIPTION
## Summary
- replace legacy `GetTickCount` usages across gameplay and networking modules with `GetTickCountRaw` plus wrap-safe helpers
- update NPC movement, spell cooldowns, and user item timers to track deadlines with `AddMod32`/`TicksElapsed`
- refresh scenario and invasion timing code to compute elapsed milliseconds without masking

## Testing
- not run (VB6 project)

------
https://chatgpt.com/codex/tasks/task_e_68de57152b48832885f106c1a7b41ac9