### PR TITLE
Mostrar tiempo restante para poder montar luego del combate

### DIFF
--- a/Codigo/Trabajo.bas
+++ b/Codigo/Trabajo.bas
@@ -2296,7 +2296,7 @@ Public Sub DoMontar(ByVal UserIndex As Integer, ByRef Montura As t_ObjData, ByVa
             Exit Sub
         End If
         If .flags.Montado = 0 And .Counters.EnCombate > 0 Then
-            Call WriteLocaleMsg(UserIndex, 1466, e_FontTypeNames.FONTTYPE_INFOBOLD)  ' Msg1466=Estás en combate, debes aguardar ¬1 segundo(s) para montar...
+            Call WriteLocaleMsg(UserIndex, 1466, e_FontTypeNames.FONTTYPE_INFOBOLD, .Counters.EnCombate)  ' Msg1466=Estás en combate, debes aguardar ¬1 segundo(s) para montar...
             Exit Sub
         End If
         If .flags.EnReto Then


### PR DESCRIPTION
Se modifica el envío del mensaje 1466. Ahora se muestra al jugador correctamente los segundos restantes para poder volver a utilizar la montura luego de entrar en combate.