### PR TITLE
Refactor the type_log enumeration

### DIFF
--- a/Codigo/Logging.bas
+++ b/Codigo/Logging.bas
@@ -38,57 +38,57 @@ Private Declare Function ReportEvent _
                                       plpStrings As String, _
                                       lpRawData As Long) As Long
 
-Private Enum type_log
-    e_LogearEventoDeSubasta = 0
-    e_LogBan = 1
-    e_LogCreditosPatreon = 2
-    e_LogShopTransactions = 3
-    e_LogShopErrors = 4
-    e_LogEdicionPaquete = 5
-    e_LogMacroServidor = 6
-    e_LogMacroCliente = 7
-    e_LogVentaCasa = 8
-    e_LogCriticEvent = 9
-    e_LogEjercitoReal = 10
-    e_LogEjercitoCaos = 11
-    e_LogError = 12
-    e_LogPerformance = 13
-    e_LogConsulta = 14
-    e_LogClanes = 15
-    e_LogGM = 16
-    e_LogPremios = 17
-    e_LogDatabaseError = 18
-    e_LogSecurity = 19
+Private Enum eType_Log
+    EventoDeSubasta = 0
+    Ban = 1
+    CreditosPatreon = 2
+    ShopTransactions = 3
+    ShopErrors = 4
+    EdicionPaquete = 5
+    MacroServidor = 6
+    MacroCliente = 7
+    VentaCasa = 8
+    CriticEvent = 9
+    EjercitoReal = 10
+    EjercitoCaos = 11
+    Error = 12
+    Performance = 13
+    Consulta = 14
+    Clanes = 15
+    GM = 16
+    Premios = 17
+    DatabaseError = 18
+    Security = 19
 End Enum
 
 Private Type t_CircularBuffer
     currentIndex As Integer
     Messages() As String
-    Size As Integer
+    size As Integer
 End Type
 
 Public CircularLogBuffer As t_CircularBuffer
 Private Declare Function RegisterEventSource Lib "advapi32.dll" Alias "RegisterEventSourceA" (ByVal lpUNCServerName As String, ByVal lpSourceName As String) As Long
 
-Public Sub InitializeCircularLogBuffer(Optional ByVal Size As Integer = 30)
-    CircularLogBuffer.Size = Size
+Public Sub InitializeCircularLogBuffer(Optional ByVal size As Integer = 30)
+    CircularLogBuffer.size = size
     CircularLogBuffer.currentIndex = 0
-    ReDim CircularLogBuffer.Messages(0 To Size)
+    ReDim CircularLogBuffer.Messages(0 To size)
 End Sub
 
 Public Sub AddLogToCircularBuffer(Message As String)
     CircularLogBuffer.currentIndex = CircularLogBuffer.currentIndex + 1
-    CircularLogBuffer.currentIndex = (CircularLogBuffer.currentIndex Mod CircularLogBuffer.Size)
+    CircularLogBuffer.currentIndex = (CircularLogBuffer.currentIndex Mod CircularLogBuffer.size)
     CircularLogBuffer.Messages(CircularLogBuffer.currentIndex) = Message
 End Sub
 
 Public Function GetLastMessages() As String()
     Dim errorList() As String
-    ReDim errorList(CircularLogBuffer.Size)
+    ReDim errorList(CircularLogBuffer.size)
     Dim i             As Integer
     Dim circularIndex As Integer
-    For i = 1 To CircularLogBuffer.Size
-        circularIndex = ((CircularLogBuffer.currentIndex + i) Mod CircularLogBuffer.Size)
+    For i = 1 To CircularLogBuffer.size
+        circularIndex = ((CircularLogBuffer.currentIndex + i) Mod CircularLogBuffer.size)
         errorList(i) = CircularLogBuffer.Messages(circularIndex)
     Next i
     GetLastMessages = errorList
@@ -105,7 +105,7 @@ End Sub
 
 Public Sub LogearEventoDeSubasta(s As String)
     On Error GoTo ErrHandler
-    Call LogThis(type_log.e_LogearEventoDeSubasta, "[Subastas.log] " & s, vbLogEventTypeInformation)
+    Call LogThis(eType_Log.EventoDeSubasta, "[Subastas.log] " & s, vbLogEventTypeInformation)
     Exit Sub
 ErrHandler:
 End Sub
@@ -114,112 +114,112 @@ Sub LogBan(ByVal BannedIndex As Integer, ByVal UserIndex As Integer, ByVal Motiv
     On Error GoTo ErrHandler
     Dim s As String
     s = UserList(BannedIndex).name & " BannedBy " & UserList(UserIndex).name & " Reason " & Motivo
-    Call LogThis(type_log.e_LogBan, "[Bans] " & s, vbLogEventTypeInformation)
+    Call LogThis(eType_Log.Ban, "[Bans] " & s, vbLogEventTypeInformation)
     Exit Sub
 ErrHandler:
 End Sub
 
 Public Sub LogCreditosPatreon(Desc As String)
     On Error GoTo ErrHandler
-    Call LogThis(type_log.e_LogCreditosPatreon, "[MonetizationCreditosPatreon.log] " & Desc, vbLogEventTypeInformation)
+    Call LogThis(eType_Log.CreditosPatreon, "[MonetizationCreditosPatreon.log] " & Desc, vbLogEventTypeInformation)
     Exit Sub
 ErrHandler:
 End Sub
 
 Public Sub LogShopTransactions(Desc As String)
     On Error GoTo ErrHandler
-    Call LogThis(type_log.e_LogShopTransactions, "[MonetizationShopTransactions.log] " & Desc, vbLogEventTypeInformation)
+    Call LogThis(eType_Log.ShopTransactions, "[MonetizationShopTransactions.log] " & Desc, vbLogEventTypeInformation)
     Exit Sub
 ErrHandler:
 End Sub
 
 Public Sub LogShopErrors(Desc As String)
     On Error GoTo ErrHandler
-    Call LogThis(type_log.e_LogShopErrors, "[MonetizationShopErrors.log] " & Desc, vbLogEventTypeError)
+    Call LogThis(eType_Log.ShopErrors, "[MonetizationShopErrors.log] " & Desc, vbLogEventTypeError)
     Exit Sub
 ErrHandler:
 End Sub
 
 Public Sub LogEdicionPaquete(texto As String)
     On Error GoTo ErrHandler
-    Call LogThis(type_log.e_LogEdicionPaquete, "[EdicionPaquete.log] " & texto, vbLogEventTypeWarning)
+    Call LogThis(eType_Log.EdicionPaquete, "[EdicionPaquete.log] " & texto, vbLogEventTypeWarning)
     Exit Sub
 ErrHandler:
 End Sub
 
 Public Sub LogMacroServidor(texto As String)
     On Error GoTo ErrHandler
-    Call LogThis(type_log.e_LogMacroServidor, "[MacroServidor] " & texto, vbLogEventTypeInformation)
+    Call LogThis(eType_Log.MacroServidor, "[MacroServidor] " & texto, vbLogEventTypeInformation)
     Exit Sub
 ErrHandler:
 End Sub
 
 Public Sub LogMacroCliente(texto As String)
     On Error GoTo ErrHandler
-    Call LogThis(type_log.e_LogMacroCliente, "[MacroCliente] " & texto, vbLogEventTypeInformation)
+    Call LogThis(eType_Log.MacroCliente, "[MacroCliente] " & texto, vbLogEventTypeInformation)
     Exit Sub
 ErrHandler:
 End Sub
 
 Public Sub logVentaCasa(ByVal texto As String)
     On Error GoTo ErrHandler
-    Call LogThis(type_log.e_LogVentaCasa, "[Propiedades] " & texto, vbLogEventTypeInformation)
+    Call LogThis(eType_Log.VentaCasa, "[Propiedades] " & texto, vbLogEventTypeInformation)
     Exit Sub
 ErrHandler:
 End Sub
 
 Public Sub LogCriticEvent(Desc As String)
     On Error GoTo ErrHandler
-    Call LogThis(type_log.e_LogCriticEvent, "[Eventos.log] " & Desc, vbLogEventTypeWarning)
+    Call LogThis(eType_Log.CriticEvent, "[Eventos.log] " & Desc, vbLogEventTypeWarning)
     Exit Sub
 ErrHandler:
 End Sub
 
 Public Sub LogEjercitoReal(Desc As String)
     On Error GoTo ErrHandler
-    Call LogThis(type_log.e_LogEjercitoReal, "[EjercitoReal.log] " & Desc, vbLogEventTypeInformation)
+    Call LogThis(eType_Log.EjercitoReal, "[EjercitoReal.log] " & Desc, vbLogEventTypeInformation)
     Exit Sub
 ErrHandler:
 End Sub
 
 Public Sub LogEjercitoCaos(Desc As String)
     On Error GoTo ErrHandler
-    Call LogThis(type_log.e_LogEjercitoCaos, "[EjercitoCaos.log] " & Desc, vbLogEventTypeInformation)
+    Call LogThis(eType_Log.EjercitoCaos, "[EjercitoCaos.log] " & Desc, vbLogEventTypeInformation)
     Exit Sub
 ErrHandler:
 End Sub
 
 Public Sub LogError(Desc As String)
     On Error GoTo ErrHandler
-    Call LogThis(type_log.e_LogError, "[Errores.log] " & Desc, vbLogEventTypeError)
+    Call LogThis(eType_Log.Error, "[Errores.log] " & Desc, vbLogEventTypeError)
     Exit Sub
 ErrHandler:
 End Sub
 
 Public Sub LogPerformance(Desc As String)
     On Error GoTo ErrHandler
-    Call LogThis(type_log.e_LogPerformance, "[Performance.log] " & Desc, vbLogEventTypeInformation)
+    Call LogThis(eType_Log.Performance, "[Performance.log] " & Desc, vbLogEventTypeInformation)
     Exit Sub
 ErrHandler:
 End Sub
 
 Public Sub LogConsulta(Desc As String)
     On Error GoTo ErrHandler
-    Call LogThis(type_log.e_LogConsulta, "[obtenemos.log] " & Desc, vbLogEventTypeInformation)
+    Call LogThis(eType_Log.Consulta, "[obtenemos.log] " & Desc, vbLogEventTypeInformation)
     Exit Sub
 ErrHandler:
 End Sub
 
 Public Sub LogClanes(ByVal str As String)
     On Error GoTo ErrHandler
-    Call LogThis(type_log.e_LogClanes, "[Clans.log] " & str, vbLogEventTypeInformation)
+    Call LogThis(eType_Log.Clanes, "[Clans.log] " & str, vbLogEventTypeInformation)
     Exit Sub
 ErrHandler:
 End Sub
 
 Public Sub LogGM(name As String, Desc As String)
     On Error GoTo ErrHandler
-    Call LogThis(type_log.e_LogGM, "[" & name & "] " & Desc, vbLogEventTypeInformation)
+    Call LogThis(eType_Log.GM, "[" & name & "] " & Desc, vbLogEventTypeInformation)
     Exit Sub
 ErrHandler:
 End Sub
@@ -228,21 +228,21 @@ Public Sub LogPremios(GM As String, username As String, ByVal ObjIndex As Intege
     On Error GoTo ErrHandler
     Dim s As String
     s = "Item: " & ObjData(ObjIndex).name & " (" & ObjIndex & ") Cantidad: " & Cantidad & vbNewLine & "Motivo: " & Motivo & vbNewLine & vbNewLine
-    Call LogThis(type_log.e_LogPremios, s, vbLogEventTypeInformation)
+    Call LogThis(eType_Log.Premios, s, vbLogEventTypeInformation)
     Exit Sub
 ErrHandler:
 End Sub
 
 Public Sub LogDatabaseError(Desc As String)
     On Error GoTo ErrHandler
-    Call LogThis(type_log.e_LogDatabaseError, "[Database.log] " & Desc, vbLogEventTypeError)
+    Call LogThis(eType_Log.DatabaseError, "[Database.log] " & Desc, vbLogEventTypeError)
     Exit Sub
 ErrHandler:
 End Sub
 
 Public Sub LogSecurity(str As String)
     On Error GoTo ErrHandler
-    Call LogThis(type_log.e_LogSecurity, "[Cheating.log] " & str, vbLogEventTypeWarning)
+    Call LogThis(eType_Log.Security, "[Cheating.log] " & str, vbLogEventTypeWarning)
     Exit Sub
 ErrHandler:
 End Sub


### PR DESCRIPTION
This PR refactors the type_log enumeration to improve naming consistency and readability.
The previous enum used redundant prefixes (e_ and e_Log) in every member, which go against modern and conventional VB6 naming practices.