### PR TITLE
Fix: Visualización y cálculo correcto del promedio de vida

### DIFF
--- a/Codigo/Protocol.bas
+++ b/Codigo/Protocol.bas
@@ -5574,7 +5574,7 @@ End Sub
 Public Sub HandlePromedio(ByVal UserIndex As Integer)
     On Error GoTo handle
     With UserList(UserIndex)
-        Call WriteConsoleMsg(UserIndex, PrepareMessageLocaleMsg(1988, ListaClases(.clase) & "¬" & ListaRazas(.raza) & "¬" & .Stats.ELV, FONTTYPE_INFOBOLD)) ' Msg1988=¬1 ¬2 nivel ¬3.
+        Call WriteLocaleMsg(UserIndex, 1988, e_FontTypeNames.FONTTYPE_INFOBOLD, ListaClases(.clase) & "¬" & ListaRazas(.raza) & "¬" & .Stats.ELV)
         Dim Promedio As Double, Vida As Long
         Promedio = ModClase(.clase).Vida - (21 - .Stats.UserAtributos(e_Atributos.Constitucion)) * 0.5
         Vida = 18 + ModRaza(.raza).Constitucion + Promedio * (.Stats.ELV - 1)
@@ -5594,7 +5594,7 @@ Public Sub HandlePromedio(ByVal UserIndex As Integer)
             Signo = "+"
         End If
         'Msg1221= Vida actual: ¬1
-        Call WriteLocaleMsg(UserIndex, 1221, e_FontTypeNames.FONTTYPE_INFOBOLD, .Stats.MaxHp & " (" & Signo & Abs(Diff) & ")" & "¬" & Round(Promedio, 2) & Color)
+        Call WriteLocaleMsg(UserIndex, 1221, Color, .Stats.MaxHp & " (" & Signo & Abs(Diff) & ")" & "¬" & Round(Promedio, 2))
     End With
     Exit Sub
 handle:


### PR DESCRIPTION
-Se reemplazó el envío de mensajes WriteConsoleMsg(PrepareMessageLocaleMsg(...)) por WriteLocaleMsg directo, evitando el error de bytes extra (4 extra bytes found).
-Se corrigió la concatenación de valores numéricos al enviar el promedio de vida, usando Round(Promedio, 2) para mostrar correctamente los decimales.
-Se ajustó la inclusión del color en el mensaje para que se maneje de forma separada, evitando que interfiera con el valor numérico del promedio.

Ahora los mensajes al jugador muestran correctamente: 
-Vida esperada y promedio esperado
-Vida actual, diferencia y promedio actual
-Color del mensaje según si la vida actual es mayor, menor o igual al promedio.