### PR TITLE
fix SkinsWings = 37 pasa a 38

### DIFF
--- a/Codigo/Declares.bas
+++ b/Codigo/Declares.bas
@@ -1499,8 +1499,8 @@ Public Enum e_OBJType
     otFullBottle = 34
     otRingAccesory = 35
     otPassageTicket = 36
-    otSkinsWings = 37           'Skins de Alas
-    otMap = 38
+    otMap = 37
+    otSkinsWings = 38          'Skins de Alas
     otSkinsArmours = 39         'Skins de Armaduras
     otSkinsShields = 40         'Skins de Escudos
     otSkinsHelmets = 41         'Skins de Cascos o Sombreros, o todo lo que vaya en la cabeza


### PR DESCRIPTION
I release 38 for skins by mistake the SkinsWings = 37 skin was made and there are already non-skin objects type 37 the objtype 38 there is only one and it is the argentum map it stops at 37 leaving 38 free for Skins the Obj has already been modified.