### PR TITLE
Restringir uso de barcas por nivel de personaje

### DIFF
--- a/Codigo/Trabajo.bas
+++ b/Codigo/Trabajo.bas
@@ -436,7 +436,13 @@ Public Sub DoNavega(ByVal UserIndex As Integer, ByRef Barco As t_ObjData, ByVal 
                         End If
                 End Select
             End If
+            Dim NivelRequerido As Integer
             Dim SkillNecesario As Byte
+            NivelRequerido = IIf(.clase = e_Class.Trabajador, 23, 25)
+            If .Stats.ELV < NivelRequerido Then
+                Call WriteConsoleMsg(UserIndex, PrepareMessageLocaleMsg(1926, NivelRequerido, e_FontTypeNames.FONTTYPE_INFO))
+                Exit Sub
+            End If
             SkillNecesario = IIf(.clase = e_Class.Trabajador Or .clase = e_Class.Pirat, Barco.MinSkill \ 2, Barco.MinSkill)
             ' Tiene el skill necesario?
             If .Stats.UserSkills(e_Skill.Navegacion) < SkillNecesario Then


### PR DESCRIPTION
## Summary
- agrega una validación de nivel mínimo antes de equipar barcas
- permite que trabajadores usen barcas desde nivel 23 y el resto desde nivel 25 reutilizando el mensaje localizado existente

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f81135785883339d3320c8ecde24e5