### PR TITLE
fix_LocketNotShowingNakedBody

### DIFF
--- a/Codigo/Modulo_UsUaRiOs.bas
+++ b/Codigo/Modulo_UsUaRiOs.bas
@@ -767,8 +767,8 @@ Sub RevivirUsuario(ByVal UserIndex As Integer, Optional ByVal MedianteHechizo As
         .flags.Muerto = 0
         .Stats.MinHp = .Stats.MaxHp
         ' El comportamiento cambia si usamos el hechizo Resucitar
-        If MedianteHechizo Then
-            If IsFeatureEnabled("healers_and_tanks") And CasterUserIndex > 0 And UserList(CasterUserIndex).flags.DivineBlood > 0 Then
+        If MedianteHechizo And CasterUserIndex > 0 Then
+            If IsFeatureEnabled("healers_and_tanks") And UserList(CasterUserIndex).flags.DivineBlood > 0 Then
                 .Stats.MinHp = .Stats.MaxHp
             Else
                 .Stats.MinHp = 1


### PR DESCRIPTION
Moved CasterUserIndex > 0 up to short circuit if the resurrection comes from an item (locket). This caused a bug where the module was Subscripting out of range when the locket was used that prevented the game server to properly distribute status across clients resulting in player showing as ghosts instead of naked bodies