### PR TITLE
Add InstanceMaps setting to server config

### DIFF
--- a/Example.Server.ini
+++ b/Example.Server.ini
@@ -21,7 +21,11 @@ CentinelaActivado=1
 MinimumPriceMao=40000
 GoldPriceMao=10000
 MinimumLevelMao=20
+
+'max quantity of instanced maps (event organizer)
+'totalMaps = count(.csm) + instanceMaps
 InstanceMaps=50
+
 MinDados=16
 MaxDados=18
 


### PR DESCRIPTION
Introduced the InstanceMaps parameter with a value of 50 in Example.Server.ini to configure the number of instance maps available.