### PR TITLE
Cancel player trade when distance exceeds range

### DIFF
--- a/Codigo/Modulo_UsUaRiOs.bas
+++ b/Codigo/Modulo_UsUaRiOs.bas
@@ -1167,6 +1167,7 @@ Public Sub SwapTargetUserPos(ByVal TargetUser As Integer, ByRef NewTargetPos As 
     MapData(UserList(TargetUser).pos.Map, UserList(TargetUser).pos.x, UserList(TargetUser).pos.y).UserIndex = TargetUser
     'Actualizamos las areas de ser necesario
     Call ModAreas.CheckUpdateNeededUser(TargetUser, Heading, 0)
+    Call VerificarDistanciaComercio(TargetUser)
 End Sub
 
 Function TranslateUserPos(ByVal UserIndex As Integer, ByRef NewPos As t_WorldPos, ByVal Speed As Long)
@@ -1203,6 +1204,7 @@ Function TranslateUserPos(ByVal UserIndex As Integer, ByRef NewPos As t_WorldPos
             Call WriteMacroTrabajoToggle(UserIndex, False)
         End If
     End With
+    Call VerificarDistanciaComercio(UserIndex)
     Exit Function
 TranslateUserPos_Err:
     Call LogError("Error en la subrutina TranslateUserPos - Error : " & Err.Number & " - Description : " & Err.Description)
@@ -1352,6 +1354,7 @@ Function MoveUserChar(ByVal UserIndex As Integer, ByVal nHeading As e_Heading) A
         End If
         If .Counters.Ocultando Then .Counters.Ocultando = .Counters.Ocultando - 1
     End With
+    Call VerificarDistanciaComercio(UserIndex)
     MoveUserChar = True
     Exit Function
 MoveUserChar_Err:
@@ -2133,15 +2136,7 @@ Sub WarpUserChar(ByVal UserIndex As Integer, ByVal Map As Integer, ByVal x As In
     Dim OldY   As Integer
     With UserList(UserIndex)
         If Map <= 0 Then Exit Sub
-        If IsValidUserRef(.ComUsu.DestUsu) Then
-            If UserList(.ComUsu.DestUsu.ArrayIndex).flags.UserLogged Then
-                If UserList(.ComUsu.DestUsu.ArrayIndex).ComUsu.DestUsu.ArrayIndex = UserIndex Then
-                    'Msg1101= Comercio cancelado por el otro usuario
-                    Call WriteLocaleMsg(.ComUsu.DestUsu.ArrayIndex, "1101", e_FontTypeNames.FONTTYPE_TALK)
-                    Call FinComerciarUsu(.ComUsu.DestUsu.ArrayIndex)
-                End If
-            End If
-        End If
+        Call CancelarComercioUsuario(UserIndex, 1844)
         'Quitar el dialogo
         Call SendData(SendTarget.ToPCArea, UserIndex, PrepareMessageRemoveCharDialog(.Char.charindex))
         Call WriteRemoveAllDialogs(UserIndex)
@@ -2216,6 +2211,7 @@ Sub WarpUserChar(ByVal UserIndex As Integer, ByVal Map As Integer, ByVal x As In
                 Call DoMontar(UserIndex, ObjData(.invent.EquippedSaddleObjIndex), .invent.EquippedSaddleSlot)
             End If
         End If
+        Call VerificarDistanciaComercio(UserIndex)
     End With
     Exit Sub
 WarpUserChar_Err:

--- a/Codigo/mdlCOmercioConUsuario.bas
+++ b/Codigo/mdlCOmercioConUsuario.bas
@@ -64,6 +64,85 @@ ErrHandler:
     Call LogError("Error en IniciarComercioConUsuario: " & Err.Description)
 End Function
 
+Public Sub CancelarComercioUsuario(ByVal UserIndex As Integer, Optional ByVal ReasonMsgId As Integer = 0)
+    On Error GoTo CancelarComercioUsuario_Err
+    Dim OtherUserIndex As Integer
+    If UserIndex <= 0 Or UserIndex > MaxUsers Then Exit Sub
+    With UserList(UserIndex)
+        If Not .flags.Comerciando Then Exit Sub
+        If Not IsValidUserRef(.ComUsu.DestUsu) Then
+            Call FinComerciarUsu(UserIndex)
+            Exit Sub
+        End If
+        OtherUserIndex = .ComUsu.DestUsu.ArrayIndex
+    End With
+    If OtherUserIndex <= 0 Or OtherUserIndex > MaxUsers Then
+        Call FinComerciarUsu(UserIndex)
+        Exit Sub
+    End If
+    If Not UserList(OtherUserIndex).flags.Comerciando Then
+        Call FinComerciarUsu(UserIndex)
+        Exit Sub
+    End If
+    If UserList(OtherUserIndex).ComUsu.DestUsu.ArrayIndex <> UserIndex Then
+        Call FinComerciarUsu(UserIndex)
+        Exit Sub
+    End If
+    If ReasonMsgId <> 0 Then
+        If UserList(OtherUserIndex).flags.UserLogged Then
+            Call WriteConsoleMsg(OtherUserIndex, PrepareMessageLocaleMsg(ReasonMsgId, vbNullString, e_FontTypeNames.FONTTYPE_TALK))
+        End If
+    End If
+    Call FinComerciarUsu(OtherUserIndex)
+    Call FinComerciarUsu(UserIndex)
+    Exit Sub
+CancelarComercioUsuario_Err:
+    Call TraceError(Err.Number, Err.Description, "mdlCOmercioConUsuario.CancelarComercioUsuario", Erl)
+End Sub
+
+Public Sub VerificarDistanciaComercio(ByVal UserIndex As Integer)
+    On Error GoTo VerificarDistanciaComercio_Err
+    Dim OtherUserIndex As Integer
+    If UserIndex <= 0 Or UserIndex > MaxUsers Then Exit Sub
+    With UserList(UserIndex)
+        If Not .flags.Comerciando Then Exit Sub
+        If Not IsValidUserRef(.ComUsu.DestUsu) Then
+            Call FinComerciarUsu(UserIndex)
+            Exit Sub
+        End If
+        OtherUserIndex = .ComUsu.DestUsu.ArrayIndex
+    End With
+    If OtherUserIndex <= 0 Or OtherUserIndex > MaxUsers Then
+        Call FinComerciarUsu(UserIndex)
+        Exit Sub
+    End If
+    If Not UserList(OtherUserIndex).flags.UserLogged Then
+        Call CancelarComercioUsuario(UserIndex, 1844)
+        Exit Sub
+    End If
+    If Not UserList(OtherUserIndex).flags.Comerciando Then
+        Call FinComerciarUsu(UserIndex)
+        Exit Sub
+    End If
+    If UserList(OtherUserIndex).ComUsu.DestUsu.ArrayIndex <> UserIndex Then
+        Call FinComerciarUsu(UserIndex)
+        Exit Sub
+    End If
+    If UserList(UserIndex).pos.Map <> UserList(OtherUserIndex).pos.Map Then
+        Call CancelarComercioUsuario(UserIndex, 1844)
+        Exit Sub
+    End If
+    Dim separation As Double
+    separation = Distance(UserList(UserIndex).pos.x, UserList(UserIndex).pos.y, _
+        UserList(OtherUserIndex).pos.x, UserList(OtherUserIndex).pos.y)
+    If separation > 4 Then
+        Call CancelarComercioUsuario(UserIndex, 1844)
+    End If
+    Exit Sub
+VerificarDistanciaComercio_Err:
+    Call TraceError(Err.Number, Err.Description, "mdlCOmercioConUsuario.VerificarDistanciaComercio", Erl)
+End Sub
+
 Public Sub EnviarObjetoTransaccion(ByVal AQuien As Integer, ByVal UserIndex As Integer, ByRef ObjAEnviar As t_Obj)
     On Error GoTo EnviarObjetoTransaccion_Err
     Dim FirstEmptyPos     As Byte


### PR DESCRIPTION
## Summary
- add helper functions to centralize user-trade cancellation and distance validation
- cancel active trades when trading partners change maps or move more than four tiles apart
- invoke the distance check from user movement, swapping, and warp routines to keep trades synchronized

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68fb5fb7a2a483339c4e55be6d0ecf1c