### PR TITLE
WIP Cancel trade prompts when players move

### DIFF
--- a/Codigo/Modulo_UsUaRiOs.bas
+++ b/Codigo/Modulo_UsUaRiOs.bas
@@ -1197,6 +1197,7 @@ Function TranslateUserPos(ByVal UserIndex As Integer, ByRef NewPos As t_WorldPos
         .pos = NewPos
         MapData(.pos.Map, .pos.x, .pos.y).UserIndex = UserIndex
         Call WritePosUpdate(UserIndex)
+        Call CancelarInvitacionComercioPorMovimiento(UserIndex)
         'Actualizamos las áreas de ser necesario
         Call ModAreas.CheckUpdateNeededUser(UserIndex, .Char.Heading, 0)
         If .Counters.Trabajando Then
@@ -1345,6 +1346,7 @@ Function MoveUserChar(ByVal UserIndex As Integer, ByVal nHeading As e_Heading) A
         .pos = nPos
         .Char.Heading = nHeading
         MapData(.pos.Map, .pos.x, .pos.y).UserIndex = UserIndex
+        Call CancelarInvitacionComercioPorMovimiento(UserIndex)
         'Actualizamos las áreas de ser necesario
         Call ModAreas.CheckUpdateNeededUser(UserIndex, nHeading, 0)
         If .Counters.Trabajando Then
@@ -2133,6 +2135,7 @@ Sub WarpUserChar(ByVal UserIndex As Integer, ByVal Map As Integer, ByVal x As In
     Dim OldY   As Integer
     With UserList(UserIndex)
         If Map <= 0 Then Exit Sub
+        Call CancelarInvitacionComercioPorMovimiento(UserIndex)
         If IsValidUserRef(.ComUsu.DestUsu) Then
             If UserList(.ComUsu.DestUsu.ArrayIndex).flags.UserLogged Then
                 If UserList(.ComUsu.DestUsu.ArrayIndex).ComUsu.DestUsu.ArrayIndex = UserIndex Then

--- a/Codigo/Protocol.bas
+++ b/Codigo/Protocol.bas
@@ -6553,6 +6553,8 @@ Private Sub HandleResponderPregunta(ByVal UserIndex As Integer)
         UserList(UserIndex).flags.RespondiendoPregunta = False
         If respuesta Then
             Select Case UserList(UserIndex).flags.pregunta
+                Case 0
+                    Exit Sub
                 Case 1
                     Log = "Repuesta Afirmativa 1"
                     If UserList(UserIndex).Grupo.EnGrupo Then
@@ -6678,6 +6680,8 @@ Private Sub HandleResponderPregunta(ByVal UserIndex As Integer)
         Else
             Log = "Repuesta negativa"
             Select Case UserList(UserIndex).flags.pregunta
+                Case 0
+                    Exit Sub
                 Case 1
                     Log = "Repuesta negativa 1"
                     If IsValidUserRef(UserList(UserIndex).Grupo.PropuestaDe) Then


### PR DESCRIPTION
## Summary
- add CancelarComercioPorMovimiento to clean up commerce sessions and pending prompts when a participant moves
- invoke the new helper from swap, translate, move, and warp routines so the trade window closes as soon as someone walks away

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68fb5fb7a2a483339c4e55be6d0ecf1c