### PR TITLE
Migrates character autosave from a VB6 Timer control on frmMain to a loop-driven

### DIFF
--- a/Codigo/Admin.bas
+++ b/Codigo/Admin.bas
@@ -93,7 +93,7 @@ Public IntervaloEnCombate            As Long
 Public IntervaloPuedeSerAtacado      As Long
 Public IntervaloGuardarUsuarios      As Long
 Public LimiteGuardarUsuarios         As Integer
-Public IntervaloTimerGuardarUsuarios As Integer
+Public IntervaloTimerGuardarUsuarios As Long
 Public IntervaloMensajeGlobal        As Long
 Public Const IntervaloConsultaGM     As Long = 300000
 'BALANCE

--- a/Codigo/General.bas
+++ b/Codigo/General.bas
@@ -525,8 +525,6 @@ Sub Main()
     Next LoopC
     With frmMain
         .Minuto.Enabled = True
-        .TimerGuardarUsuarios.Enabled = True
-        .TimerGuardarUsuarios.Interval = IntervaloTimerGuardarUsuarios
         .tPiqueteC.Enabled = True
         .GameTimer.Enabled = True
         .Segundo.Enabled = True
@@ -544,6 +542,7 @@ Sub Main()
             MapInfo(BarcoNavegandoArghalForgat.Map).ForceUpdate = True
         End If
     End With
+    Call ResetUserAutoSaveTimer
     Subasta.SubastaHabilitada = True
     Subasta.HaySubastaActiva = False
     Call ResetMeteo
@@ -592,6 +591,8 @@ Sub Main()
         Call PerformTimeLimitCheck(PerformanceTimer, "General modNetwork.Tick")
         Call UpdateEffectOverTime
         Call PerformTimeLimitCheck(PerformanceTimer, "General Update Effects over time")
+        Call MaybeRunUserAutoSave
+        Call PerformTimeLimitCheck(PerformanceTimer, "General MaybeRunUserAutoSave")
         DoEvents
         Call PerformTimeLimitCheck(PerformanceTimer, "Do events")
         Call AntiCheatUpdate
@@ -682,6 +683,7 @@ Sub Restart()
     Call LoadMD5
     Call LoadPrivateKey
     Call LoadIntervalos
+    Call ResetUserAutoSaveTimer
     Call LoadOBJData
     Call LoadPesca
     Call LoadRecursosEspeciales

--- a/Codigo/frmMain.frm
+++ b/Codigo/frmMain.frm
@@ -98,12 +98,6 @@ Begin VB.Form frmMain
       Left            =   3120
       Top             =   4200
    End
-   Begin VB.Timer TimerGuardarUsuarios 
-      Enabled         =   0   'False
-      Interval        =   30000
-      Left            =   2640
-      Top             =   3120
-   End
    Begin VB.CommandButton Command4 
       BackColor       =   &H00C0FFC0&
       Caption         =   "Guardar y cerrar"
@@ -1106,34 +1100,7 @@ Private Sub UpdateBarcoArghalForgat()
     Next TileX
 End Sub
 
-Private Sub TimerGuardarUsuarios_Timer()
-    On Error GoTo Handler
-    If IsFeatureEnabled("auto_save_chars") Then
-        ' Guardar usuarios (solo si pasó el tiempo mínimo para guardar)
-        Dim UserIndex        As Integer, UserGuardados As Integer
-        Dim PerformanceTimer As Long
-        Dim nowRaw           As Long
-        Call PerformanceTestStart(PerformanceTimer)
-        For UserIndex = 1 To LastUser
-            With UserList(UserIndex)
-                If .flags.UserLogged Then
-                    nowRaw = GetTickCountRaw()
-                    If TicksElapsed(.Counters.LastSave, nowRaw) > IntervaloGuardarUsuarios Then
-                        Call SaveUser(UserIndex)
-                        UserGuardados = UserGuardados + 1
-                        If UserGuardados > NumUsers Then Exit For
-                        'limit the amount of time we block the only thread we have here, lets save some user on the next loop
-                        If TicksElapsed(PerformanceTimer, GetTickCountRaw()) > 100 Then Exit For
-                    End If
-                End If
-            End With
-        Next
-        Call PerformTimeLimitCheck(PerformanceTimer, "TimerGuardarUsuarios_Timer", 100)
-    End If
-    Exit Sub
-Handler:
-    Call TraceError(Err.Number, Err.Description, "frmMain.TimreGuardarUsuarios_Timer")
-End Sub
+
 
 Private Sub Minuto_Timer()
     On Error GoTo ErrHandler

--- a/Codigo/modUserAutoSave.bas
+++ b/Codigo/modUserAutoSave.bas
@@ -1,0 +1,70 @@
+Attribute VB_Name = "modUserAutoSave"
+' Argentum 20 Game Server
+'
+'    Copyright (C) 2023 Noland Studios LTD
+'
+'    This program is free software: you can redistribute it and/or modify
+'    it under the terms of the GNU Affero General Public License as published by
+'    the Free Software Foundation, either version 3 of the License, or
+'    (at your option) any later version.
+'
+'    This program is distributed in the hope that it will be useful,
+'    but WITHOUT ANY WARRANTY; without even the implied warranty of
+'    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+'    GNU Affero General Public License for more details.
+'
+'    You should have received a copy of the GNU Affero General Public License
+'    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+'
+'    This program was based on Argentum Online 0.11.6
+'    Copyright (C) 2002 Mrquez Pablo Ignacio
+Option Explicit
+
+Private m_LastAutoSaveAttempt As Long
+
+Public Sub ResetUserAutoSaveTimer()
+    m_LastAutoSaveAttempt = GetTickCountRaw()
+End Sub
+
+Public Sub MaybeRunUserAutoSave()
+    On Error GoTo Handler
+
+    If Not IsFeatureEnabled("auto_save_chars") Then Exit Sub
+
+    Dim nowRaw As Long
+    nowRaw = GetTickCountRaw()
+
+    If m_LastAutoSaveAttempt = 0 Then
+        m_LastAutoSaveAttempt = nowRaw
+        Exit Sub
+    End If
+
+    If TicksElapsed(m_LastAutoSaveAttempt, nowRaw) < IntervaloTimerGuardarUsuarios Then Exit Sub
+
+    m_LastAutoSaveAttempt = nowRaw
+
+    Dim UserIndex        As Integer
+    Dim UserGuardados    As Integer
+    Dim PerformanceTimer As Long
+
+    Call PerformanceTestStart(PerformanceTimer)
+
+    For UserIndex = 1 To LastUser
+        With UserList(UserIndex)
+            If .flags.UserLogged Then
+                nowRaw = GetTickCountRaw()
+                If TicksElapsed(.Counters.LastSave, nowRaw) > IntervaloGuardarUsuarios Then
+                    Call SaveUser(UserIndex)
+                    UserGuardados = UserGuardados + 1
+                    If UserGuardados > NumUsers Then Exit For
+                    If TicksElapsed(PerformanceTimer, GetTickCountRaw()) > 100 Then Exit For
+                End If
+            End If
+        End With
+    Next
+
+    Call PerformTimeLimitCheck(PerformanceTimer, "modUserAutoSave.MaybeRunUserAutoSave", 100)
+    Exit Sub
+Handler:
+    Call TraceError(Err.Number, Err.Description, "modUserAutoSave.MaybeRunUserAutoSave")
+End Sub

--- a/Server.VBP
+++ b/Server.VBP
@@ -15,6 +15,7 @@ Module=Declaraciones; Codigo\Declares.bas
 Module=ES; Codigo\FileIO.bas
 Module=Extra; Codigo\GameLogic.bas
 Module=General; Codigo\General.bas
+Module=modUserAutoSave; Codigo\modUserAutoSave.bas
 Module=InvNpc; Codigo\Modulo_InventANDobj.bas
 Module=NPCs; Codigo\MODULO_NPCs.bas
 Module=SysTray; Codigo\Modulo_SysTray.bas


### PR DESCRIPTION
## Summary

This PR migrates character autosave from a VB6 `Timer` control on `frmMain` to a loop-driven, wrap-safe scheduler that runs inside the main server loop. It also fixes a type-size bug by changing `IntervaloTimerGuardarUsuarios` from `Integer` to `Long` to correctly represent millisecond values beyond 32.7s.

## Why

* **Determinism & robustness:** Form timers can drift, pause on modal operations, and don’t integrate with our per-frame performance budgets. Running in the main loop ensures predictable cadence and observability with existing performance instrumentation.
* **Wrap safety:** All timing now uses `GetTickCountRaw` + `TicksElapsed`, avoiding failures at 32-bit tick wrap (~49.7d).
* **Overflow fix:** `IntervaloTimerGuardarUsuarios` as `Integer` could truncate/overflow >32,767 ms; using `Long` matches our millisecond tick domain.

## What changed

* **New module:** `Codigo/modUserAutoSave.bas`

  * `ResetUserAutoSaveTimer`: initializes the autosave cadence.
  * `MaybeRunUserAutoSave`: if `auto_save_chars` is enabled and the cadence gate (`IntervaloTimerGuardarUsuarios`) has elapsed, iterate users and save those whose per-user delay `IntervaloGuardarUsuarios` has elapsed. Enforces a ~100 ms budget using `PerformanceTestStart`/`PerformTimeLimitCheck`. All comparisons use `TicksElapsed(GetTickCountRaw())`.
* **Main loop integration:**

  * In `General.Sub Main`: call `MaybeRunUserAutoSave` each tick (with a perf marker) and reset the cadence once during startup.
  * In `General.Restart`: reset cadence after reloading intervals.
* **Config type fix:** `IntervaloTimerGuardarUsuarios` is now `Long`.
* **UI timer removal:**

  * Deleted `TimerGuardarUsuarios` control and its handler from `frmMain`.
  * Removed `.TimerGuardarUsuarios.Enabled/Interval` setting code.
* **Project file:** `Server.VBP` includes `modUserAutoSave`.

## Behavior details

* **Feature flag:** Autosave runs only if `IsFeatureEnabled("auto_save_chars")` is true.
* **Per-user guard:** A user is saved only if `TicksElapsed(.Counters.LastSave, nowRaw) > IntervaloGuardarUsuarios`.
* **Work spreading:** Caps work to ~100 ms per loop to avoid stalling the single server thread. If many users are due, work spills to subsequent ticks (as before, but now budgeted deterministically).
* **Wrap-safe timing:** All time arithmetic uses `TicksElapsed` and `GetTickCountRaw`.

## Performance & stability

* Eliminates form-timer jitter and interaction with UI message pump.
* Keeps the server responsive under load by enforcing a 100 ms autosave slice budget.
* Safer long-uptime operation due to wrap-safe comparisons.

## Configuration / migration

* **Action:** Ensure `IntervaloTimerGuardarUsuarios` is defined as a millisecond **Long** in the intervals loader (`LoadIntervalos`). No change to the INI key name expected.
* **Heads-up:** If any scripts or tooling referenced `frmMain.TimerGuardarUsuarios`, those references must be removed (none expected in server build).
* No data format or save-file changes.

## Testing done

1. **Cadence gate sanity:**

   * Set `IntervaloTimerGuardarUsuarios` low (e.g., 1–2s) and confirmed periodic runs in logs via `PerformTimeLimitCheck` tag `General MaybeRunUserAutoSave`.
2. **Per-user spacing:**

   * Set `IntervaloGuardarUsuarios` low (e.g., 5–10s), observed `.Counters.LastSave` advance and users saved no more frequently than configured.
3. **Budget enforcement:**

   * With many logged users and slow IO, observed exit from loop when `TicksElapsed(PerformanceTimer, GetTickCountRaw()) > 100` and continuation next tick.
4. **Wrap safety:**

   * Simulated near-wrap values for `m_LastAutoSaveAttempt` and verified autosave still triggers correctly (unit/instrumented testing).
5. **Restart path:**

   * Called `Restart` and verified `ResetUserAutoSaveTimer` re-primes the cadence after `LoadIntervalos`.

## Risks / considerations

* The loop budget is currently fixed at **100 ms**; if autosave throughput is insufficient under extreme load, consider making this tunable (INI) or adding a per-tick save cap independent of `NumUsers`.
* In `MaybeRunUserAutoSave`, `If UserGuardados > NumUsers Then Exit For` preserves existing behavior, but is effectively a no-op cap; we may want a separate explicit per-tick cap (e.g., `MaxSavesPerTick`) if needed.

## Rollback plan

* Revert this PR; restore `frmMain.TimerGuardarUsuarios` control and handler, and change `IntervaloTimerGuardarUsuarios` back to `Integer`. (Not recommended due to overflow and wrap issues.)

---

### TL;DR (ES)

* **Autosave** se mueve del `Timer` del formulario al **bucle principal** con comparaciones **wrap-safe** (`TicksElapsed`).
* `IntervaloTimerGuardarUsuarios` pasa de `Integer` a **`Long`** para evitar overflow en milisegundos.
* Se elimina el control `TimerGuardarUsuarios` y su handler; se añade `modUserAutoSave` con `ResetUserAutoSaveTimer` y `MaybeRunUserAutoSave`.
* Presupuesto de ~100 ms por tick para no bloquear el hilo único.
