### PR TITLE
Log regular bank transfer events

### DIFF
--- a/Codigo/Logging.bas
+++ b/Codigo/Logging.bas
@@ -59,6 +59,7 @@ Private Enum eType_Log
     Premios = 17
     DatabaseError = 18
     Security = 19
+    BankTransfer = 20
 End Enum
 
 Private Type t_CircularBuffer
@@ -246,6 +247,20 @@ Public Sub LogSecurity(str As String)
     Exit Sub
 ErrHandler:
 End Sub
+Public Sub LogBankTransfer(ByVal originUser As String, ByVal targetUser As String, ByVal amount As Long, Optional ByVal receiverOnline As Boolean = False)
+    On Error GoTo ErrHandler
+    Dim transferContext As String
+    If receiverOnline Then
+        transferContext = "destinatario en línea"
+    Else
+        transferContext = "destinatario fuera de línea"
+    End If
+    Call LogThis(eType_Log.BankTransfer, "[BankTransfers.log] " & originUser & " transfirió " & amount & " monedas a " & targetUser & " (" & transferContext & ")", vbLogEventTypeInformation)
+    Exit Sub
+ErrHandler:
+End Sub
+
+
 
 Public Sub TraceError(ByVal Numero As Long, ByVal Descripcion As String, ByVal Componente As String, Optional ByVal Linea As Integer)
     #If DEBUGGING = 1 Then

--- a/Codigo/Protocol.bas
+++ b/Codigo/Protocol.bas
@@ -5971,6 +5971,7 @@ Private Sub HandleTransFerGold(ByVal UserIndex As Integer)
                         Else
                             UserList(UserIndex).Stats.Banco = UserList(UserIndex).Stats.Banco - val(Cantidad) 'Quitamos el oro al usuario
                         End If
+                        Call LogBankTransfer(.name, username, Cantidad, False)
                         .Counters.LastTransferGold = nowRaw
                     Else
                         Call WriteLocaleChatOverHead(UserIndex, 1410, vbNullString, NpcList(.flags.TargetNPC.ArrayIndex).Char.charindex, vbWhite)  ' Msg1410=El usuario no existe.
@@ -5983,6 +5984,7 @@ Private Sub HandleTransFerGold(ByVal UserIndex As Integer)
             Else
                 UserList(UserIndex).Stats.Banco = UserList(UserIndex).Stats.Banco - val(Cantidad) 'Quitamos el oro al usuario
                 UserList(tUser.ArrayIndex).Stats.Banco = UserList(tUser.ArrayIndex).Stats.Banco + val(Cantidad) 'Se lo damos al otro.
+                Call LogBankTransfer(.name, username, Cantidad, True)
             End If
             Call WriteLocaleChatOverHead(UserIndex, 1435, "", str$(NpcList(.flags.TargetNPC.ArrayIndex).Char.charindex), vbWhite) ' Msg1435=¡El envío se ha realizado con éxito! Gracias por utilizar los servicios de Finanzas Goliath
         Else


### PR DESCRIPTION
## Summary
- add a bank-transfer log category and helper
- record successful player bank transfers for both online and offline recipients

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911fdbd54188328b1344f9a935cc039)