### PR TITLE
Deshabilito el seguro legionario

### DIFF
--- a/Codigo/Modulo_UsUaRiOs.bas
+++ b/Codigo/Modulo_UsUaRiOs.bas
@@ -702,8 +702,8 @@ Dim tStr                        As String
         If Status(UserIndex) = e_Facciones.Criminal Or Status(UserIndex) = e_Facciones.Caos Or Status(UserIndex) = e_Facciones.concilio Then
             Call WriteSafeModeOff(UserIndex)
             .flags.Seguro = False
-            Call WriteLegionarySecure(UserIndex, False)
-            .flags.LegionarySecure = False
+            Call WriteLegionarySecure(UserIndex, True)
+            .flags.LegionarySecure = True
         Else
             .flags.Seguro = True
             Call WriteSafeModeOn(UserIndex)


### PR DESCRIPTION
Deshabilito el seguro de facción legionario hasta tener un mejor sistema de penalización para el atacante. 
Necesario aceptar pr del cliente  https://github.com/ao-org/argentum-online-client/pull/675 para que el usuario no pueda desactivarlo.