### PR TITLE
Speed jinetes

### DIFF
--- a/Configuracion.ini
+++ b/Configuracion.ini
@@ -35,14 +35,14 @@ DeltaLevelExpPenalty=4
 InstanceMaps=100
 MaxJailTime=31680
 JineteLevel1Speed=1.05
-JineteLevel2Speed=1.07
-JineteLevel3Speed=1.10
-JineteLevel4Speed=1.15
-JineteLevel5Speed=1.20
-JineteLevel6Speed=1.25
-JineteLevel7Speed=1.30
-JineteLevel8Speed=1.45
-JineteLevel9Speed=1.50
+JineteLevel2Speed=1.10
+JineteLevel3Speed=1.15
+JineteLevel4Speed=1.20
+JineteLevel5Speed=1.25
+JineteLevel6Speed=1.30
+JineteLevel7Speed=1.35
+JineteLevel8Speed=1.40
+JineteLevel9Speed=1.45
 
 'Mientras mas alto sea DropMult menos probabilidad de tirar algun item.
 [DROPEO]


### PR DESCRIPTION
Updated JineteLevel2Speed through JineteLevel9Speed to increase progression increments. This change refines mount speed scaling for higher levels.