### PR TITLE
Improve MakeNPCChar error logging

### DIFF
--- a/Codigo/MODULO_NPCs.bas
+++ b/Codigo/MODULO_NPCs.bas
@@ -653,10 +653,21 @@ MakeNPCChar_Err:
     contextInfo = "Params: toMap=" & CStr(toMap) & ", sndIndex=" & sndIndex & ", NpcIndex=" & NpcIndex & ", Map=" & Map & _
                   ", x=" & x & ", y=" & y
 
+    Dim npcLowerBound As Long
+    Dim npcUpperBound As Long
+
     On Error Resume Next
-    contextInfo = contextInfo & ", NpcName=" & NpcList(NpcIndex).name & NpcList(NpcIndex).SubName
-    contextInfo = contextInfo & ", CharIndex=" & NpcList(NpcIndex).Char.charindex
-    contextInfo = contextInfo & ", NPCType=" & NpcList(NpcIndex).npcType
+    npcLowerBound = LBound(NpcList)
+    npcUpperBound = UBound(NpcList)
+
+    If NpcIndex >= npcLowerBound And NpcIndex <= npcUpperBound Then
+        contextInfo = contextInfo & ", NpcName=" & NpcList(NpcIndex).name & NpcList(NpcIndex).SubName
+        contextInfo = contextInfo & ", CharIndex=" & NpcList(NpcIndex).Char.charindex
+        contextInfo = contextInfo & ", NPCType=" & NpcList(NpcIndex).npcType
+    Else
+        contextInfo = contextInfo & ", NpcIndexOutOfBounds=True (Bounds " & npcLowerBound & "-" & npcUpperBound & ")"
+    End If
+
     On Error GoTo 0
 
     Call TraceError(errNumber, errDescription & " | " & contextInfo, "NPCs.MakeNPCChar", Erl)


### PR DESCRIPTION
## Summary
- capture parameter and NPC context when MakeNPCChar fails
- include the additional context in TraceError to help diagnose subscript errors

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cbf69ed4c8328a4ef08ef6536c94b)