### PR TITLE
Add script to remove non-leader guild members

### DIFF
--- a/ScriptsDB/20251205-01-delete all guild members excepts leaders
+++ b/ScriptsDB/20251205-01-delete all guild members excepts leaders
@@ -1,0 +1,16 @@
+-- 1. Borrar miembros que no son líderes
+DELETE FROM guild_members
+WHERE user_id NOT IN (
+  SELECT leader_id
+  FROM guilds
+  WHERE leader_id IS NOT NULL
+);
+
+-- 2. Resetear guild_index de los usuarios que no son líderes
+UPDATE user
+SET guild_index = 0
+WHERE id NOT IN (
+  SELECT leader_id
+  FROM guilds
+  WHERE leader_id IS NOT NULL
+);


### PR DESCRIPTION
Introduces a SQL script that deletes all guild members except for leaders and resets the guild_index for users who are not leaders. This helps maintain guild integrity by ensuring only leaders remain associated with their guilds.