### PR TITLE
Split guild member deletion and guild_index reset scripts

### DIFF
--- a/ScriptsDB/20251205-01-delete all guild members excepts leaders.sql
+++ b/ScriptsDB/20251205-01-delete all guild members excepts leaders.sql
@@ -5,12 +5,3 @@ WHERE user_id NOT IN (
   FROM guilds
   WHERE leader_id IS NOT NULL
 );
-
--- 2. Resetear guild_index de los usuarios que no son líderes
-UPDATE user
-SET guild_index = 0
-WHERE id NOT IN (
-  SELECT leader_id
-  FROM guilds
-  WHERE leader_id IS NOT NULL
-);

--- a/ScriptsDB/20251205-02-delete all guild members excepts leaders.sql
+++ b/ScriptsDB/20251205-02-delete all guild members excepts leaders.sql
@@ -1,0 +1,8 @@
+-- 1. Resetear guild_index de los usuarios que no son líderes
+UPDATE user
+SET guild_index = 0
+WHERE id NOT IN (
+  SELECT leader_id
+  FROM guilds
+  WHERE leader_id IS NOT NULL
+);


### PR DESCRIPTION
Moved the logic for resetting guild_index of non-leader users into a new script (20251205-02). The original script (20251205-01) now only deletes non-leader guild members, improving script separation and clarity.