### PR TITLE
Rename game loop module to game events

### DIFF
--- a/Codigo/General.bas
+++ b/Codigo/General.bas
@@ -716,7 +716,6 @@ Sub Main()
     With frmMain
         .Minuto.Enabled = True
         .tPiqueteC.Enabled = True
-        .GameTimer.Enabled = True
         .Segundo.Enabled = True
         .KillLog.Enabled = True
         .T_UsersOnline.Enabled = True
@@ -731,6 +730,7 @@ Sub Main()
             MapInfo(BarcoNavegandoArghalForgat.Map).ForceUpdate = True
         End If
     End With
+    Call ResetGameEventsTimer
     Call ResetUserAutoSaveTimer
     Subasta.SubastaHabilitada = True
     Subasta.HaySubastaActiva = False
@@ -780,6 +780,8 @@ Sub Main()
         Call PerformTimeLimitCheck(PerformanceTimer, "General modNetwork.Tick")
         Call UpdateEffectOverTime
         Call PerformTimeLimitCheck(PerformanceTimer, "General Update Effects over time")
+        Call MaybeRunGameEvents
+        Call PerformTimeLimitCheck(PerformanceTimer, "General MaybeRunGameEvents")
         Call MaybeRunUserAutoSave
         Call PerformTimeLimitCheck(PerformanceTimer, "General MaybeRunUserAutoSave")
         Call MaybeUpdateNpcAI(GlobalFrameTime)

--- a/Codigo/frmMain.frm
+++ b/Codigo/frmMain.frm
@@ -359,12 +359,6 @@ Begin VB.Form frmMain
       Left            =   720
       Top             =   3060
    End
-   Begin VB.Timer GameTimer 
-      Enabled         =   0   'False
-      Interval        =   40
-      Left            =   1200
-      Top             =   3060
-   End
    Begin VB.Timer tPiqueteC 
       Enabled         =   0   'False
       Interval        =   6000
@@ -1475,43 +1469,6 @@ End Sub
 
 Private Sub Form_Unload(Cancel As Integer)
     Call CerrarServidor
-End Sub
-
-Private Sub GameTimer_Timer()
-    On Error GoTo HayError
-    Dim iUserIndex       As Long
-    Dim PerformanceTimer As Long
-    Call PerformanceTestStart(PerformanceTimer)
-    '<<<<<< Procesa eventos de los usuarios >>>>>>
-    For iUserIndex = 1 To LastUser
-        With UserList(iUserIndex)
-            If .flags.UserLogged Then
-                Call DoTileEvents(iUserIndex, .pos.Map, .pos.x, .pos.y)
-                If .flags.Muerto = 0 Then
-                    'Efectos en mapas
-                    If (.flags.Privilegios And e_PlayerType.User) <> 0 Then
-                        Call EfectoLava(iUserIndex)
-                        Call EfectoFrio(iUserIndex)
-                        If .flags.Envenenado <> 0 Then Call EfectoVeneno(iUserIndex)
-                        If .flags.Incinerado <> 0 Then Call EfectoIncineramiento(iUserIndex)
-                    End If
-                    If .flags.Meditando Then Call DoMeditar(iUserIndex)
-                    If .flags.Mimetizado <> 0 Then Call EfectoMimetismo(iUserIndex)
-                    If .flags.AdminInvisible <> 1 Then
-                        If .flags.Oculto = 1 Then Call DoPermanecerOculto(iUserIndex)
-                    End If
-                    If .NroMascotas > 0 Then Call TiempoInvocacion(iUserIndex)
-                    Call EfectoStamina(iUserIndex)
-                End If 'Muerto
-            End If 'UserLogged
-        End With
-    Next iUserIndex
-    Call PerformTimeLimitCheck(PerformanceTimer, "GameTimer_Timer User loop", 400)
-    Call CustomScenarios.UpdateAll
-    Call PerformTimeLimitCheck(PerformanceTimer, "GameTimer_Timer customScenarios", 100)
-    Exit Sub
-HayError:
-    Call TraceError(Err.Number, Err.Description & vbNewLine & "UserIndex:" & iUserIndex, "frmMain.GameTimer", Erl)
 End Sub
 
 Private Sub HoraFantasia_Timer()

--- a/Codigo/modGameEvents.bas
+++ b/Codigo/modGameEvents.bas
@@ -1,0 +1,84 @@
+Attribute VB_Name = "modGameEvents"
+' Argentum 20 Game Server
+'
+'    Copyright (C) 2023 Noland Studios LTD
+'
+'    This program is free software: you can redistribute it and/or modify
+'    it under the terms of the GNU Affero General Public License as published by
+'    the Free Software Foundation, either version 3 of the License, or
+'    (at your option) any later version.
+'
+'    This program is distributed in the hope that it will be useful,
+'    but WITHOUT ANY WARRANTY; without even the implied warranty of
+'    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+'    GNU Affero General Public License for more details.
+'
+'    You should have received a copy of the GNU Affero General Public License
+'    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+'
+'    This program was based on Argentum Online 0.11.6
+'    Copyright (C) 2002 Mrquez Pablo Ignacio
+Option Explicit
+
+Private Const GAME_EVENTS_INTERVAL_MS As Long = 40
+Private Const USER_LOOP_TIME_LIMIT_MS As Long = 400
+Private Const CUSTOM_SCENARIOS_TIME_LIMIT_MS As Long = 100
+
+Private m_LastGameEventsTick As Long
+
+Public Sub ResetGameEventsTimer()
+    m_LastGameEventsTick = GetTickCountRaw()
+End Sub
+
+Public Sub MaybeRunGameEvents()
+    On Error GoTo Handler
+
+    Dim nowRaw As Long
+    nowRaw = GetTickCountRaw()
+
+    If m_LastGameEventsTick = 0 Then
+        m_LastGameEventsTick = nowRaw
+        Exit Sub
+    End If
+
+    If TicksElapsed(m_LastGameEventsTick, nowRaw) < GAME_EVENTS_INTERVAL_MS Then Exit Sub
+
+    m_LastGameEventsTick = nowRaw
+
+    Dim iUserIndex       As Long
+    Dim PerformanceTimer As Long
+
+    Call PerformanceTestStart(PerformanceTimer)
+
+    For iUserIndex = 1 To LastUser
+        With UserList(iUserIndex)
+            If .flags.UserLogged Then
+                Call DoTileEvents(iUserIndex, .pos.Map, .pos.x, .pos.y)
+                If .flags.Muerto = 0 Then
+                    'Efectos en mapas
+                    If (.flags.Privilegios And e_PlayerType.User) <> 0 Then
+                        Call EfectoLava(iUserIndex)
+                        Call EfectoFrio(iUserIndex)
+                        If .flags.Envenenado <> 0 Then Call EfectoVeneno(iUserIndex)
+                        If .flags.Incinerado <> 0 Then Call EfectoIncineramiento(iUserIndex)
+                    End If
+                    If .flags.Meditando Then Call DoMeditar(iUserIndex)
+                    If .flags.Mimetizado <> 0 Then Call EfectoMimetismo(iUserIndex)
+                    If .flags.AdminInvisible <> 1 Then
+                        If .flags.Oculto = 1 Then Call DoPermanecerOculto(iUserIndex)
+                    End If
+                    If .NroMascotas > 0 Then Call TiempoInvocacion(iUserIndex)
+                    Call EfectoStamina(iUserIndex)
+                End If 'Muerto
+            End If 'UserLogged
+        End With
+    Next iUserIndex
+
+    Call PerformTimeLimitCheck(PerformanceTimer, "MaybeRunGameEvents User loop", USER_LOOP_TIME_LIMIT_MS)
+    Call CustomScenarios.UpdateAll
+    Call PerformTimeLimitCheck(PerformanceTimer, "MaybeRunGameEvents customScenarios", CUSTOM_SCENARIOS_TIME_LIMIT_MS)
+
+    Exit Sub
+Handler:
+    Call TraceError(Err.Number, Err.Description & vbNewLine & "UserIndex:" & iUserIndex, "modGameEvents.MaybeRunGameEvents")
+End Sub

--- a/Server.VBP
+++ b/Server.VBP
@@ -16,6 +16,7 @@ Module=ES; Codigo\FileIO.bas
 Module=Extra; Codigo\GameLogic.bas
 Module=General; Codigo\General.bas
 Module=modUserAutoSave; Codigo\modUserAutoSave.bas
+Module=modGameEvents; Codigo\modGameEvents.bas
 Module=InvNpc; Codigo\Modulo_InventANDobj.bas
 Module=NPCs; Codigo\MODULO_NPCs.bas
 Module=SysTray; Codigo\Modulo_SysTray.bas


### PR DESCRIPTION
### Summary

This PR removes the old `frmMain.GameTimer` (a VB6 form timer) and moves all game/user event processing into a new tick-driven module, `modGameEvents`. The server now updates game events from the main loop using `GetTickCountRaw` + `TicksElapsed`, consistent with the new auto-save system.

---

### Key changes

1. **Removed `GameTimer` from `frmMain`**

   * Deleted the timer control and the entire `GameTimer_Timer` event.
   * This eliminates UI-timer–based scheduling.

2. **Added new module `modGameEvents.bas`**

   * Implements `ResetGameEventsTimer` and `MaybeRunGameEvents`.
   * Runs every 40 ms using the same tick logic as autosave tasks.
   * Contains all logic previously found inside `GameTimer_Timer`:

     * Tile events
     * Map effects (lava, cold, poison, incineration)
     * Meditation, mimic, stealth maintenance
     * Pet invocation timers
     * Stamina updates
     * `CustomScenarios.UpdateAll`
   * Includes performance instrumentation using `PerformTimeLimitCheck`.

3. **Integrated into `General.Main`**

   * Added:

     ```
     Call ResetGameEventsTimer
     Call MaybeRunGameEvents
     ```
   * Game events now run inside the main server loop with profiling labels:

     * “General MaybeRunGameEvents”

4. **Updated project file**

   * Added `modGameEvents.bas` to `Server.VBP`.

---

### Benefits

* Centralises server timing logic in the main loop rather than a VB6 form timer.
* More stable and deterministic tick scheduling.
* Better instrumentation and easier debugging of event processing time.
* No functional changes to gameplay logic; behaviour remains identical.


