### PR TITLE
fix_AdjustCasterLevelForNpcsOnUserWarp

### DIFF
--- a/Codigo/Modulo_UsUaRiOs.bas
+++ b/Codigo/Modulo_UsUaRiOs.bas
@@ -2402,6 +2402,7 @@ Private Sub WarpMascotas(ByVal UserIndex As Integer)
                 If iMinHP Then NpcList(Index).Stats.MinHp = iMinHP
                 Call SetUserRef(NpcList(Index).MaestroUser, UserIndex)
                 Call FollowAmo(Index)
+                Call AdjustNpcStatWithCasterLevel(UserIndex, Index)
             Else
                 SpawnInvalido = True
             End If

--- a/Codigo/modHechizos.bas
+++ b/Codigo/modHechizos.bas
@@ -4130,7 +4130,7 @@ AreaHechizo_Err:
     Call TraceError(Err.Number, Err.Description, "modHechizos.AreaHechizo", Erl)
 End Sub
 
-Private Sub AdjustNpcStatWithCasterLevel(ByVal UserIndex As Integer, ByVal NpcIndex As Integer)
+Public Sub AdjustNpcStatWithCasterLevel(ByVal UserIndex As Integer, ByVal NpcIndex As Integer)
     Dim BaseHit       As Integer
     Dim BonusDamage   As Single
     Dim BonusFromItem As Integer


### PR DESCRIPTION
-Changed AdjustNpcStatWithCasterLevel from Private to Public in modHechizos.bas and added a call to it in WarpMascotas within Modulo_UsUaRiOs.bas.
-This allows pet stats to be adjusted based on the caster's level when warping pets.
-This corrects a bug where whenever a player changed map or got teleported the damage and the hit chance of the pets were being "reset" to the natural ones instead of taking into consideration the caster level