### PR TITLE
fix_GlobalInstallmentsOnActiveQuests

### DIFF
--- a/Codigo/ModGlobalQuests.bas
+++ b/Codigo/ModGlobalQuests.bas
@@ -102,7 +102,7 @@ Public Sub LoadGlobalQuests()
                 Set RS = Query(SUM_TOTAL_AMOUNT_FROM_USER_CONTRIBUTION, i)
                 If Not IsNull(RS!total_amount) Then
                     .GatheringGlobalCounter = RS!total_amount
-                    .GatheringGlobalInstallments = RS!total_amount
+                    .GatheringGlobalInstallments = RS!total_amount + .GatheringInitialInstallments
                 End If
             End If
         End With


### PR DESCRIPTION
-Added assignment to set GatheringGlobalInstallments to the value of total_amount when loading global quests, ensuring both counters are updated consistently.
-This caused a bug where the server spawned a boss every delivery because of the desync between the global counter and this one