### PR TITLE
fix_ModQuest2

### DIFF
--- a/Codigo/ModQuest.bas
+++ b/Codigo/ModQuest.bas
@@ -662,6 +662,23 @@ Public Function CanUserAcceptQuest(ByVal UserIndex As Integer, ByVal NpcIndex As
             Exit Function
         End If
     End If
+    If tmpQuest.GlobalQuestIndex > 0 Then
+        If tmpQuest.GlobalQuestThresholdNeeded > 0 Then
+            If tmpQuest.GlobalQuestThresholdNeeded > GlobalQuestInfo(tmpQuest.GlobalQuestIndex).GatheringGlobalCounter Then
+                Call WriteLocaleMsg(UserIndex, 2123, FONTTYPE_WARNING, GlobalQuestInfo(tmpQuest.GlobalQuestIndex).GatheringGlobalCounter & "¬" & GlobalQuestInfo(tmpQuest.GlobalQuestIndex).GatheringThreshold & "¬" & tmpQuest.GlobalQuestThresholdNeeded)
+                Exit Function
+            End If
+        Else
+            If Not GlobalQuestInfo(tmpQuest.GlobalQuestIndex).IsActive Then
+                Call WriteLocaleMsg(UserIndex, 2124, FONTTYPE_WARNING)
+                Exit Function
+            End If
+            If GlobalQuestInfo(tmpQuest.GlobalQuestIndex).IsBossAlive Then
+                Call WriteLocaleMsg(UserIndex, 2121, FONTTYPE_WARNING)
+                Exit Function
+            End If
+        End If
+    End If
     CanUserAcceptQuest = True
     Exit Function
 ErrHandler:

--- a/Codigo/Protocol_Writes.bas
+++ b/Codigo/Protocol_Writes.bas
@@ -2977,6 +2977,17 @@ Public Sub WriteNpcQuestListSend(ByVal UserIndex As Integer, ByVal NpcIndex As I
                         PuedeHacerla = False
                     End If
                 End If
+                If QuestList(QuestIndex).GlobalQuestIndex > 0 Then
+                    If Not GlobalQuestInfo(QuestList(QuestIndex).GlobalQuestIndex).IsActive Then
+                        PuedeHacerla = False
+                    End If
+                    If GlobalQuestInfo(QuestList(QuestIndex).GlobalQuestIndex).IsBossAlive Then
+                        PuedeHacerla = False
+                    End If
+                    If QuestList(QuestIndex).GlobalQuestThresholdNeeded > GlobalQuestInfo(QuestList(QuestIndex).GlobalQuestIndex).GatheringGlobalCounter Then
+                        PuedeHacerla = False
+                    End If
+                End If
                 If PuedeHacerla Then
                     Call Writer.WriteInt8(0)
                 Else


### PR DESCRIPTION
-Updated CanUserAcceptQuest and WriteNpcQuestListSend to check global quest activity, boss status, and threshold before allowing quest acceptance.
-This ensures users can only accept quests when global conditions are met.