### PR TITLE
Permitir agresión de NPCs por cercanía pese a nivel

### DIFF
--- a/Codigo/AI_NPC.bas
+++ b/Codigo/AI_NPC.bas
@@ -1269,8 +1269,11 @@ Private Function EsObjetivoValido(ByVal NpcIndex As Integer, ByVal UserIndex As 
     ' Esta condicion debe ejecutarse independiemente de el modo de busqueda.
     EsObjetivoValido = EnRangoVision(NpcIndex, UserIndex)
     If NpcList(NpcIndex).nivel > 0 Then
-        EsObjetivoValido = EsObjetivoValido And (UserList(UserIndex).Stats.ELV - NpcList(NpcIndex).nivel <= CInt(SvrConfig.GetValue("NpcDeltaLevelPenalties")))
-        EsObjetivoValido = EsObjetivoValido Or (AgressorIndex = UserIndex)
+        Dim tieneNivelPermitido As Boolean
+        Dim estaCercaPorNivel As Boolean
+        tieneNivelPermitido = (UserList(UserIndex).Stats.ELV - NpcList(NpcIndex).nivel <= CInt(SvrConfig.GetValue("NpcDeltaLevelPenalties")))
+        estaCercaPorNivel = DistanciaRadial(NpcList(NpcIndex).pos, UserList(UserIndex).pos) <= CInt(SvrConfig.GetValue("NpcDeltaLevelCloseRange"))
+        EsObjetivoValido = EsObjetivoValido And (tieneNivelPermitido Or estaCercaPorNivel Or (AgressorIndex = UserIndex))
     End If
     EsObjetivoValido = EsObjetivoValido And EsEnemigo(NpcIndex, UserIndex)
     EsObjetivoValido = EsObjetivoValido And UserList(UserIndex).flags.Muerto = 0

--- a/Codigo/ServerConfig.cls
+++ b/Codigo/ServerConfig.cls
@@ -95,6 +95,7 @@ Public Function LoadSettings(ByVal Filename As String) As Long
     mSettings.Add "PartyELVwLeadership", CInt(val(reader.GetValue("CONFIGURACIONES", "PartyELVwLeadership", "5")))
     mSettings.Add "PenaltyExpUserPerLevel", CSng(val(reader.GetValue("CONFIGURACIONES", "PenaltyExpUserPerLevel", "0.05")))
     mSettings.Add "NpcDeltaLevelPenalties", CInt(val(reader.GetValue("CONFIGURACIONES", "NpcDeltaLevelPenalties", "4")))
+    mSettings.Add "NpcDeltaLevelCloseRange", CInt(val(reader.GetValue("CONFIGURACIONES", "NpcDeltaLevelCloseRange", "3")))
     mSettings.Add "LeadershipExpPartyBonus", CDbl(val(reader.GetValue("CONFIGURACIONES", "LeadershipExpPartyBonus", "1.01")))
     mSettings.Add "JineteLevel1Speed", CSng(val(reader.GetValue("CONFIGURACIONES", "JineteLevel1Speed", "1.05")))
     mSettings.Add "JineteLevel2Speed", CSng(val(reader.GetValue("CONFIGURACIONES", "JineteLevel2Speed", "1.07")))

--- a/Configuracion.ini
+++ b/Configuracion.ini
@@ -33,6 +33,7 @@ PartyELVwLeadership=5
 LeadershipExpPartyBonus=1.01
 PenaltyExpUserPerLevel=0.05
 NpcDeltaLevelPenalties=4
+NpcDeltaLevelCloseRange=3
 InstanceMaps=100
 MaxJailTime=31680
 JineteLevel1Speed=1.05


### PR DESCRIPTION
### Motivation
- Actualmente los NPC con `Nivel=` aplican un filtro por diferencia de nivel (`NpcDeltaLevelPenalties`) que impide que atacen a usuarios de mucha diferencia de nivel aunque estén cerca. 
- Se desea que esos NPC sí puedan agredir si el usuario está a X tiles, independientemente de la penalización por nivel. 
- El cambio agrega una excepción por proximidad para mantener la protección por nivel a distancia pero permitir agresión en corto alcance. 

### Description
- Modifica la función `EsObjetivoValido` en `Codigo/AI_NPC.bas` para permitir objetivo cuando la distancia radial al usuario es menor o igual a un umbral configurable. 
- Usa la función `DistanciaRadial` para la comprobación de cercanía y combina la condición con la existente `NpcDeltaLevelPenalties`. 
- Añade la nueva clave de configuración `NpcDeltaLevelCloseRange` en `Codigo/ServerConfig.cls` para leer el valor (default `3`). 
- Documenta el nuevo parámetro en `Configuracion.ini` con `NpcDeltaLevelCloseRange=3`. 

### Testing
- Se ejecutaron pruebas LocalHost

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69623b6e5c40832880158a326d118e79)