### PR TITLE
EquipArrow: validate inventory/ObjData indexes and log username

### DIFF
--- a/Codigo/InvUsuario.bas
+++ b/Codigo/InvUsuario.bas
@@ -4085,13 +4085,23 @@ Public Sub EquipArrow(ByVal UserIndex As Integer, ByVal Slot As Integer)
     Dim BowCategory   As Byte
     Dim ArrowCategory As Byte
     Dim ArrowObjIndex As Integer
+    Dim maxItemsInventory As Integer
 
     With UserList(UserIndex).invent
-        Debug.Assert ObjData(Slot).OBJType = e_OBJType.otArrows
+        maxItemsInventory = get_num_inv_slots_from_tier(UserList(UserIndex).Stats.tipoUsuario)
+        If Slot < 1 Or Slot > maxItemsInventory Then
+            Call LogError("EquipArrow invalid slot: " & Slot & " max=" & maxItemsInventory & " user=" & UserList(UserIndex).name)
+            Exit Sub
+        End If
+
         ArrowObjIndex = .Object(Slot).ObjIndex
+        If ArrowObjIndex < LBound(ObjData) Or ArrowObjIndex > UBound(ObjData) Then
+            Call LogError("EquipArrow invalid arrow index: " & ArrowObjIndex & " slot=" & Slot & " user=" & UserList(UserIndex).name)
+            Exit Sub
+        End If
+        Debug.Assert ObjData(ArrowObjIndex).OBJType = e_OBJType.otArrows
+
         bowIndex = .EquippedWeaponObjIndex
-        BowCategory = ObjData(bowIndex).BowCategory
-        ArrowCategory = ObjData(ArrowObjIndex).ArrowCategory
         
         ' No hay arco equipado
         If bowIndex <= 0 Then
@@ -4099,6 +4109,13 @@ Public Sub EquipArrow(ByVal UserIndex As Integer, ByVal Slot As Integer)
             Call WriteLocaleMsg(UserIndex, 2145, e_FontTypeNames.FONTTYPE_INFO)
             Exit Sub
         End If
+
+        If bowIndex < LBound(ObjData) Or bowIndex > UBound(ObjData) Then
+            Call LogError("EquipArrow invalid bow index: " & bowIndex & " user=" & UserList(UserIndex).name)
+            Exit Sub
+        End If
+        BowCategory = ObjData(bowIndex).BowCategory
+        ArrowCategory = ObjData(ArrowObjIndex).ArrowCategory
 
         ' El arma equipada no es un arco
         If ObjData(bowIndex).WeaponType <> eBow Then


### PR DESCRIPTION
### Motivation

- Prevent runtime errors in `EquipArrow` by validating inventory slot and object table indexes before accessing `ObjData` and provide better context in logs.  

### Description

- Added a local `maxItemsInventory` and a range check for `Slot` using `get_num_inv_slots_from_tier`, logging out-of-range slots and exiting early.  
- Added bounds checks for `ArrowObjIndex` and `bowIndex` against `LBound(ObjData)`/`UBound(ObjData)` and log out-of-range arrow and bow indexes before exiting.  
- Moved reads of `BowCategory`/`ArrowCategory` to after the new validations and preserved the `Debug.Assert ObjData(ArrowObjIndex).OBJType = e_OBJType.otArrows` check.  
- Updated log messages to include the user name via `UserList(UserIndex).name` instead of the numeric `UserIndex` in `Codigo/InvUsuario.bas` within the `Public Sub EquipArrow` routine.  

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69710c3392688328a8d4a893842a6595)