### PR TITLE
Add Recursos/init/EsArbol.ini to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ AOACServer.pdb
 .aider*
 *.pdb
 /dumps
+Recursos/init/EsArbol.ini


### PR DESCRIPTION
Ignore the Recursos/init/EsArbol.ini file to avoid committing a local/resource-specific INI configuration. Keeps repository clean of environment or machine-specific settings.