### PR TITLE
Use locale message 2164 for home gold check

### DIFF
--- a/Codigo/Protocol.bas
+++ b/Codigo/Protocol.bas
@@ -7321,7 +7321,8 @@ Private Sub HandleHome(ByVal UserIndex As Integer)
                 End If
                 
                 If .Stats.GLD < homeCostGLD Then
-                    Call WriteLocaleMsg(UserIndex, 2163, e_FontTypeNames.FONTTYPE_INFO, homeCostGLD)
+                    'Msg2164=Para utilizar este comando necesitas ¬1 monedas de oro.
+                    Call WriteLocaleMsg(UserIndex, 2164, e_FontTypeNames.FONTTYPE_INFO, homeCostGLD)
                     Exit Sub
                 End If
                 


### PR DESCRIPTION
Update HandleHome in Protocol.bas to call locale message 2164 instead of 2163 for the insufficient-gold case.