### PR TITLE
Stop updating immutable identity fields on character save

### DIFF
--- a/Codigo/CharacterPersistence.bas
+++ b/Codigo/CharacterPersistence.bas
@@ -529,14 +529,10 @@ End Sub
 Private Sub SaveCharacterMainDB(ByRef U As t_User, ByRef QueryBreakdown As String)
     Dim QueryTimer As Long
     Dim Params() As Variant
-    ReDim Params(65)
+    ReDim Params(61)
     Dim i As Integer
-    Params(post_increment(i)) = U.name
     Params(post_increment(i)) = U.Stats.ELV
     Params(post_increment(i)) = U.Stats.Exp
-    Params(post_increment(i)) = U.genero
-    Params(post_increment(i)) = U.raza
-    Params(post_increment(i)) = U.clase
     Params(post_increment(i)) = U.Hogar
     Params(post_increment(i)) = U.Desc
     Params(post_increment(i)) = U.Stats.GLD
@@ -598,6 +594,7 @@ Private Sub SaveCharacterMainDB(ByRef U As t_User, ByRef QueryBreakdown As Strin
     Params(post_increment(i)) = U.Char.BackpackAnim
     ' WHERE block
     Params(post_increment(i)) = U.Id
+    Debug.Assert i = UBound(Params) + 1
     QueryTimer = GetTickCountRaw()
     Call Execute(QUERY_UPDATE_MAINPJ, Params)
     Call AppendQueryDuration(QueryBreakdown, "update main", QueryTimer)
@@ -1190,15 +1187,11 @@ Public Sub SaveChangesInUser(ByVal UserIndex As Integer)
             Exit Sub
         End If
 
-        ReDim Params(65)
+        ReDim Params(61)
         Dim i As Integer
         i = 0
-        Params(post_increment(i)) = .name
         Params(post_increment(i)) = .Stats.ELV
         Params(post_increment(i)) = .Stats.Exp
-        Params(post_increment(i)) = .genero
-        Params(post_increment(i)) = .raza
-        Params(post_increment(i)) = .clase
         Params(post_increment(i)) = .Hogar
         Params(post_increment(i)) = .Desc
         Params(post_increment(i)) = .Stats.GLD
@@ -1260,6 +1253,7 @@ Public Sub SaveChangesInUser(ByVal UserIndex As Integer)
         Params(post_increment(i)) = .Char.BackpackAnim
         Params(post_increment(i)) = .Id
 
+        Debug.Assert i = UBound(Params) + 1
         Call Execute(QUERY_UPDATE_MAINPJ, Params)
         Call PerformTimeLimitCheck(PerformanceTimer, "SaveChangesInUser [" & .name & "] main data id:" & .Id, 50)
 

--- a/Codigo/Database_Queries.bas
+++ b/Codigo/Database_Queries.bas
@@ -242,12 +242,8 @@ End Sub
 Private Sub ConstruirQuery_GuardarPersonaje()
     Dim LoopC As Long
     QueryBuilder.Append "UPDATE user SET "
-    QueryBuilder.Append "name = ?, "
     QueryBuilder.Append "level = ?, "
     QueryBuilder.Append "exp = ?, "
-    QueryBuilder.Append "genre_id = ?, "
-    QueryBuilder.Append "race_id = ?, "
-    QueryBuilder.Append "class_id = ?, "
     QueryBuilder.Append "home_id = ?, "
     QueryBuilder.Append "description = ?, "
     QueryBuilder.Append "gold = ?, "


### PR DESCRIPTION
### Motivation
- Immutable identity columns `name`, `genre_id` (genero), `race_id` (raza) and `class_id` (clase) must only be set at creation or via admin tools, not on the regular character save hot path.
- Prevent accidental overwrites of identity data during frequent `UPDATE` saves and remove unnecessary parameter traffic on the hot path.

### Description
- Removed `name = ?`, `genre_id = ?`, `race_id = ?` and `class_id = ?` from the `QUERY_UPDATE_MAINPJ` builder in `Codigo/Database_Queries.bas` so the `UPDATE user SET ... WHERE id = ?` no longer updates identity fields.
- Removed packing of the corresponding VB params (`U.name`, `U.genero`, `U.raza`, `U.clase` / `.name`, `.genero`, `.raza`, `.clase`) from `SaveCharacterMainDB` and `SaveChangesInUser` in `Codigo/CharacterPersistence.bas` and adjusted `ReDim Params` from `65` to `61` to match the new placeholder count.
- Added `Debug.Assert i = UBound(Params) + 1` immediately before `Execute(QUERY_UPDATE_MAINPJ, Params)` in both save paths to catch future mismatches between SQL placeholders and packed params.

### Testing
- Searched for `QUERY_UPDATE_MAINPJ` and save callsites with `rg` to verify all callsites still exist and are kept consistent, and found the two callsites (`SaveCharacterMainDB`, `SaveChangesInUser`) and the query builder definition updated successfully (search succeeded).
- Ran a small script to count SQL placeholders and packed params with `python` and confirmed the update query contains `62` placeholders and both `SaveCharacterMainDB` and `SaveChangesInUser` pack `62` params, so placeholder/param counts match (success).
- Verified occurrences of the removed fields were deleted from the update builder and param packing by searching for the specific strings (success).
- Note: a full VB6 project compile/run was not performed in this environment, so compile-time verification should be run in CI or locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699af78f3d0083289c5dfb8f2eb07ced)