### PR TITLE
Optimize persistence: skip bank inventory save when unchanged

### DIFF
--- a/Codigo/CharacterPersistence.bas
+++ b/Codigo/CharacterPersistence.bas
@@ -511,7 +511,12 @@ Public Sub SaveCharacterDB(ByVal UserIndex As Integer)
         Call SaveCharacterMainDB(UserList(UserIndex), QueryBreakdown)
         Call SaveCharacterSpellsDB(UserList(UserIndex), QueryBreakdown)
         Call SaveCharacterInventoryDB(UserList(UserIndex), QueryBreakdown)
-        Call SaveCharacterBankInventoryDB(UserList(UserIndex), QueryBreakdown)
+        If HasBankChanged(UserIndex) Then
+            Call SaveCharacterBankInventoryDB(UserList(UserIndex), QueryBreakdown)
+        Else
+            If LenB(QueryBreakdown) <> 0 Then QueryBreakdown = QueryBreakdown & "; "
+            QueryBreakdown = QueryBreakdown & "save bank inventory: skipped"
+        End If
         Call SaveCharacterSkillsDB(UserList(UserIndex), QueryBreakdown)
         Call SaveCharacterPetsDB(UserList(UserIndex), QueryBreakdown)
         ' ************************** User quests *********************************


### PR DESCRIPTION
### Motivation

- `SaveCharacterDB` unconditionally invoked bank persistence causing unnecessary `bank_item` writes and measurable overhead in performance logs (~18ms in prior profiling). 
- The repository already exposes snapshot/diff helpers such as `HasBankChanged(UserIndex)` and `InitUserPersistSnapshot(UserIndex)` that make it possible to avoid redundant writes. 
- The intent is to reduce persistence latency by skipping bank saves when the in-memory bank matches the last persisted snapshot.

### Description

- Add a guard in `SaveCharacterDB` to call `SaveCharacterBankInventoryDB` only when `HasBankChanged(UserIndex)` returns `True`.
- When the bank is unchanged, skip the call and append `"save bank inventory: skipped"` to `QueryBreakdown` while preserving the existing `"; "` delimiter behavior.
- Preserved all existing behavior and ordering including the `InitUserPersistSnapshot(UserIndex)` call and the unchanged implementation of `SaveCharacterBankInventoryDB`.
- This is a minimal, localized, non-schema change that relies on existing snapshot/diff infrastructure and does not alter SQL or snapshot logic.

