### PR TITLE
Propiedad DisabledInBattleServer al tipo de datos de NPC.

### DIFF
--- a/Codigo/Declares.bas
+++ b/Codigo/Declares.bas
@@ -3426,6 +3426,7 @@ Public Type t_Npc
     CaminataActual As Byte
     PuedeInvocar As Byte
     Humanoide As Boolean
+    DisabledInBattleServer As Byte
 End Type
 
 '**********************************************************

--- a/Codigo/MODULO_NPCs.bas
+++ b/Codigo/MODULO_NPCs.bas
@@ -1383,6 +1383,7 @@ Private Sub InitializeNpcFromInfo(ByVal NpcIndex As Integer, _
         .MinTameLevel = Info.MinTameLevel
         .OnlyForGuilds = Info.OnlyForGuilds
         .ShowKillerConsole = Info.ShowKillerConsole
+        .DisabledInBattleServer = Info.DisabledInBattleServer
         If .IntervaloMovimiento = 0 Then
             .IntervaloMovimiento = 380
             .Char.speeding = IntervaloNPCAI / 330


### PR DESCRIPTION
Este campo permite marcar qué NPCs deben ser excluidos automáticamente cuando el servidor corre en modo BattleServer.

Impacto: En servidores normales (BattleServer = 0), no hay cambios: todos los NPCs se cargan igual que antes. En BattleServer (BattleServer = 1), los NPCs con DisabledInBattleServer = 1 no se cargan ni figuran en listados. Esto evita que aparezcan NPCs irrelevantes o prohibidos en el contexto de batalla.

El objetivo es limitar la visibilidad y carga de NPCs en BattleServer, manteniendo la coherencia del modo de juego y evitando que se muestren entidades que no deberían estar disponibles.