### PR TITLE
Optimize persistence: upsert only dirty skills instead of full NUMSKILLS batch

### DIFF
--- a/Codigo/CharacterPersistence.bas
+++ b/Codigo/CharacterPersistence.bas
@@ -374,13 +374,19 @@ End Sub
 
 Private Sub SetupUserSkills(ByRef User As t_User)
     Dim RS As ADODB.Recordset
+    Dim LoopC As Long
     Set RS = Query("SELECT number, value FROM skillpoint WHERE user_id = ?;", User.Id)
     If Not RS Is Nothing Then
         While Not RS.EOF
             User.Stats.UserSkills(RS!Number) = RS!value
+            User.Stats.SkillDirty(RS!Number) = False
             RS.MoveNext
         Wend
     End If
+
+    For LoopC = 1 To NUMSKILLS
+        User.Stats.SkillDirty(LoopC) = False
+    Next LoopC
 End Sub
 
 Private Sub SetupUserQuests(ByRef User As t_User)
@@ -678,19 +684,50 @@ Private Sub SaveCharacterSkillsDB(ByRef U As t_User, ByRef QueryBreakdown As Str
     Dim Params() As Variant
     Dim LoopC As Long
     Dim ParamC As Long
-    ReDim Params(NUMSKILLS * 3 - 1)
+    Dim DirtyCount As Long
+
+    For LoopC = 1 To NUMSKILLS
+        If U.Stats.SkillDirty(LoopC) Then
+            DirtyCount = DirtyCount + 1
+        End If
+    Next LoopC
+
+    If DirtyCount = 0 Then
+        If LenB(QueryBreakdown) <> 0 Then QueryBreakdown = QueryBreakdown & "; "
+        QueryBreakdown = QueryBreakdown & "upsert skills: skipped"
+        Exit Sub
+    End If
+
+    Call Builder.Clear
+    Builder.Append "REPLACE INTO skillpoint (user_id, number, value) VALUES "
+    For LoopC = 1 To DirtyCount
+        Builder.Append "(?, ?, ?)"
+        If LoopC < DirtyCount Then
+            Builder.Append ", "
+        End If
+    Next LoopC
+
+    ReDim Params(DirtyCount * 3 - 1)
     ParamC = 0
     For LoopC = 1 To NUMSKILLS
-        Params(ParamC) = U.Id
-        Params(ParamC + 1) = LoopC
-        Params(ParamC + 2) = U.Stats.UserSkills(LoopC)
-        ParamC = ParamC + 3
+        If U.Stats.SkillDirty(LoopC) Then
+            Params(ParamC) = U.Id
+            Params(ParamC + 1) = LoopC
+            Params(ParamC + 2) = U.Stats.UserSkills(LoopC)
+            ParamC = ParamC + 3
+        End If
     Next LoopC
+
     QueryTimer = GetTickCountRaw()
-    Call Execute(QUERY_UPSERT_SKILLS, Params)
+    Call Execute(Builder.ToString(), Params)
     Call AppendQueryDuration(QueryBreakdown, "upsert skills", QueryTimer)
+    Call Builder.Clear
+
     For LoopC = 1 To NUMSKILLS
-        U.Persist.LastSkills(LoopC) = U.Stats.UserSkills(LoopC)
+        If U.Stats.SkillDirty(LoopC) Then
+            U.Stats.SkillDirty(LoopC) = False
+            U.Persist.LastSkills(LoopC) = U.Stats.UserSkills(LoopC)
+        End If
     Next LoopC
 End Sub
 
@@ -1057,7 +1094,7 @@ Public Function HaveSkillsChanged(ByVal UserIndex As Integer) As Boolean
     Dim i As Long
     With UserList(UserIndex)
         For i = 1 To NUMSKILLS
-            If .Stats.UserSkills(i) <> .Persist.LastSkills(i) Then
+            If .Stats.SkillDirty(i) Then
                 HaveSkillsChanged = True
                 Exit Function
             End If
@@ -1070,6 +1107,7 @@ Public Sub UpdateSavedSkills(ByVal UserIndex As Integer)
     With UserList(UserIndex)
         For i = 1 To NUMSKILLS
             .Persist.LastSkills(i) = .Stats.UserSkills(i)
+            .Stats.SkillDirty(i) = False
         Next i
     End With
 End Sub

--- a/Codigo/Declares.bas
+++ b/Codigo/Declares.bas
@@ -2509,6 +2509,7 @@ Public Type t_UserStats
     ELV As Byte
     ELO As Long
     UserSkills(1 To NUMSKILLS) As Byte
+    SkillDirty(1 To NUMSKILLS) As Boolean
     UserAtributos(1 To NUMATRIBUTOS) As Byte
     UserAtributosBackUP(1 To NUMATRIBUTOS) As Byte
     UserHechizos(1 To MAXUSERHECHIZOS) As Integer

--- a/Codigo/GameLogic.bas
+++ b/Codigo/GameLogic.bas
@@ -1382,6 +1382,7 @@ Public Sub resetPj(ByVal UserIndex As Integer, Optional ByVal borrarHechizos As 
         Dim i As Long
         For i = 1 To NUMSKILLS
             .Stats.UserSkills(i) = 100
+            .Stats.SkillDirty(i) = True
         Next i
         .Char.WeaponAnim = NingunArma
         .Char.ShieldAnim = NingunEscudo

--- a/Codigo/InvUsuario.bas
+++ b/Codigo/InvUsuario.bas
@@ -726,6 +726,7 @@ Dim obj                         As t_ObjData
                         Case e_MagicItemEffect.eModifySkills
                             If obj.Que_Skill <> 0 Then
                                 .Stats.UserSkills(obj.Que_Skill) = .Stats.UserSkills(obj.Que_Skill) - obj.CuantoAumento
+                                .Stats.SkillDirty(obj.Que_Skill) = True
                             End If
                         Case e_MagicItemEffect.eRegenerateHealth
                             .flags.RegeneracionHP = 0
@@ -1293,6 +1294,7 @@ Dim Ropaje                      As Integer
                         Call WriteFYA(UserIndex)
                     Case e_MagicItemEffect.eModifySkills
                         .Stats.UserSkills(obj.Que_Skill) = .Stats.UserSkills(obj.Que_Skill) + obj.CuantoAumento
+                        .Stats.SkillDirty(obj.Que_Skill) = True
                     Case e_MagicItemEffect.eRegenerateHealth
                         .flags.RegeneracionHP = 1
                     Case e_MagicItemEffect.eRegenerateMana

--- a/Codigo/Modulo_UsUaRiOs.bas
+++ b/Codigo/Modulo_UsUaRiOs.bas
@@ -1648,6 +1648,7 @@ Sub SubirSkill(ByVal UserIndex As Integer, ByVal Skill As Integer)
     End If
     If Aumenta >= cutoff Then Exit Sub
     UserList(UserIndex).Stats.UserSkills(Skill) = UserList(UserIndex).Stats.UserSkills(Skill) + 1
+    UserList(UserIndex).Stats.SkillDirty(Skill) = True
     Call WriteLocaleMsg(UserIndex, 1626, e_FontTypeNames.FONTTYPE_INFO, SkillsNames(Skill) & "¬" & UserList(UserIndex).Stats.UserSkills(Skill))
     Dim BonusExp As Long
     BonusExp = 5& * SvrConfig.GetValue("ExpMult")

--- a/Codigo/Protocol.bas
+++ b/Codigo/Protocol.bas
@@ -2973,10 +2973,12 @@ Private Sub HandleModifySkills(ByVal UserIndex As Integer)
                 .SkillPts = .SkillPts - points(i)
                 If .UserSkills(i) <> .UserSkills(i) + points(i) Then
                     .UserSkills(i) = .UserSkills(i) + points(i)
+                    .SkillDirty(i) = True
                     'Client should prevent this, but just in case...
                     If .UserSkills(i) > 100 Then
                         .SkillPts = .SkillPts + .UserSkills(i) - 100
                         .UserSkills(i) = 100
+                        .SkillDirty(i) = True
                     End If
                     UserList(UserIndex).flags.ModificoSkills = True
                 End If
@@ -7575,6 +7577,7 @@ Private Sub HandleResetChar(ByVal UserIndex As Integer)
                 Dim i As Integer
                 For i = 1 To NUMSKILLS
                     .Stats.UserSkills(i) = 0
+                    .Stats.SkillDirty(i) = True
                 Next
                 .Stats.MaxAGU = 100
                 .Stats.MinAGU = 100

--- a/Codigo/Protocol_GmCommands.bas
+++ b/Codigo/Protocol_GmCommands.bas
@@ -1144,6 +1144,7 @@ Public Sub HandleEditChar(ByVal UserIndex As Integer)
                         Call WriteLocaleMsg(UserIndex, 1485, e_FontTypeNames.FONTTYPE_INFO, username) ' Msg1485=Usuario Offline Alterado: ¬1
                     Else
                         UserList(tUser.ArrayIndex).Stats.UserSkills(LoopC) = val(Arg2)
+                        UserList(tUser.ArrayIndex).Stats.SkillDirty(LoopC) = True
                     End If
                 End If
             Case e_EditOptions.eo_SkillPointsLeft
@@ -3568,6 +3569,7 @@ Public Sub HandleGenio(ByVal UserIndex As Integer)
         Dim i As Byte
         For i = 1 To NUMSKILLS
             .Stats.UserSkills(i) = 100
+            .Stats.SkillDirty(i) = True
         Next i
         ' Msg555=Tus skills fueron editados.
         Call WriteLocaleMsg(UserIndex, 555, e_FontTypeNames.FONTTYPE_INFOIAO)

--- a/Codigo/TCP.bas
+++ b/Codigo/TCP.bas
@@ -412,7 +412,10 @@ Function Validate_Skills(ByVal UserIndex As Integer) As Boolean
     For LoopC = 1 To NUMSKILLS
         If UserList(UserIndex).Stats.UserSkills(LoopC) < 0 Then
             Exit Function
-            If UserList(UserIndex).Stats.UserSkills(LoopC) > 100 Then UserList(UserIndex).Stats.UserSkills(LoopC) = 100
+        End If
+        If UserList(UserIndex).Stats.UserSkills(LoopC) > 100 Then
+            UserList(UserIndex).Stats.UserSkills(LoopC) = 100
+            UserList(UserIndex).Stats.SkillDirty(LoopC) = True
         End If
     Next LoopC
     Validate_Skills = True
@@ -1237,6 +1240,7 @@ Sub ResetUserSkills(ByVal UserIndex As Integer)
     Dim LoopC As Long
     For LoopC = 1 To NUMSKILLS
         UserList(UserIndex).Stats.UserSkills(LoopC) = 0
+        UserList(UserIndex).Stats.SkillDirty(LoopC) = True
     Next LoopC
     Exit Sub
 ResetUserSkills_Err:


### PR DESCRIPTION
### Motivation
- Previous skill persistence always built a fixed-size `REPLACE INTO skillpoint` batch with `NUMSKILLS` tuples, causing excessive ADO parameter plumbing and unnecessary DB writes when only a subset of skills changed.
- The change reduces DB/parameter overhead by persisting only the skills that actually changed (dirty skills), improving save performance.

### Description
- Added per-skill runtime flags `SkillDirty(1 To NUMSKILLS) As Boolean` to the `t_UserStats` type to track modified skills without schema changes.
- Initialize dirty flags to `False` when loading a character in `SetupUserSkills`, and clear flags for saved entries in `UpdateSavedSkills` so loaded/saved state starts clean.
- Mark dirty flags at all skill mutation points (examples: `SubirSkill`, `HandleModifySkills`, GM/manual edits, `ResetUserSkills`, item effects) so only real changes are tracked.
- Reworked `SaveCharacterSkillsDB` to count dirty skills and, if any, build a dynamic `REPLACE INTO skillpoint (user_id, number, value) VALUES (?, ?, ?), ...` sized to `dirtyCount`, bind only `dirtyCount * 3` params in ascending skill index order using the existing `Builder`, call `Execute(Builder.ToString(), Params)`, then clear the saved skill dirty flags and update `Persist.LastSkills` for persisted indices; if no dirty skills, the save is skipped and `upsert skills: skipped` is appended to the query breakdown.
- Changed `HaveSkillsChanged` to return `True` if any `SkillDirty(i)` is `True`, providing a fast/accurate dirty test; no database schema changes were made and the `skillpoint` table/columns remain unchanged.

