### PR TITLE
Optimize persistence: batch replace inventory skins via async Execute

### DIFF
--- a/Codigo/CharacterPersistence.bas
+++ b/Codigo/CharacterPersistence.bas
@@ -1543,35 +1543,51 @@ Function SaveInventorySkins(ByVal UserIndex As Integer) As Boolean
 
 Dim i                           As Integer
 Dim sQuery                      As cStringBuilder    'About
-Dim RS                          As ADODB.Recordset
+Dim Params()                    As Variant
+Dim ParamC                      As Long
+Dim UpsertRowsCount             As Long
+Dim SkinID                      As Long
 
     On Error GoTo SaveInventorySkins_Error
 
     With UserList(UserIndex)
         If .Id > 0 And .Invent_Skins.count > 0 Then
-            Set sQuery = New cStringBuilder
-
             For i = 1 To .Invent_Skins.count
                 If .Invent_Skins.Object(i).ObjIndex > 0 And Not .Invent_Skins.Object(i).Deleted Then
-                    If Not Database_Queries.Exists("inventory_item_skins", "user_id", CStr(.Id), "skin_id", .Invent_Skins.Object(i).ObjIndex) Then
-                        sQuery.Append "INSERT INTO inventory_item_skins (user_id, skin_id, type_skin, skin_equipped) Values (" & .Id & "," & .Invent_Skins.Object(i).ObjIndex & "," & ObjData(.Invent_Skins.Object(i).ObjIndex).OBJType & "," & IIf(.Invent_Skins.Object(i).Equipped, "1", "0") & ")"
-                        Database.Execute sQuery.ToString
-                        sQuery.Clear
-                    Else
-                        sQuery.Append "UPDATE inventory_item_skins SET SKIN_EQUIPPED=" & IIf(.Invent_Skins.Object(i).Equipped, "1", "0") & " WHERE USER_ID=" & .Id & " AND SKIN_ID=" & .Invent_Skins.Object(i).ObjIndex
-                        Database.Execute sQuery.ToString
-                        sQuery.Clear
-                    End If
-                Else
-                    If .Invent_Skins.Object(i).Deleted Then
-                        sQuery.Append "DELETE FROM inventory_item_skins WHERE USER_ID=" & .Id & " AND SKIN_ID=" & .Invent_Skins.Object(i).ObjIndex
-                        Database.Execute sQuery.ToString
-                        sQuery.Clear
-                    End If
+                    UpsertRowsCount = UpsertRowsCount + 1
                 End If
             Next i
 
-            Set sQuery = Nothing
+            Call Execute("DELETE FROM inventory_item_skins WHERE user_id = ?;", .Id)
+
+            If UpsertRowsCount > 0 Then
+                Set sQuery = New cStringBuilder
+                sQuery.Append "INSERT INTO inventory_item_skins (user_id, skin_id, type_skin, skin_equipped) VALUES "
+
+                ReDim Params(UpsertRowsCount * 4 - 1)
+                ParamC = 0
+
+                For i = 1 To .Invent_Skins.count
+                    If .Invent_Skins.Object(i).ObjIndex > 0 And Not .Invent_Skins.Object(i).Deleted Then
+                        If ParamC > 0 Then
+                            sQuery.Append ", "
+                        End If
+
+                        sQuery.Append "(?, ?, ?, ?)"
+
+                        SkinID = .Invent_Skins.Object(i).ObjIndex
+                        Params(ParamC) = .Id
+                        Params(ParamC + 1) = SkinID
+                        Params(ParamC + 2) = ObjData(SkinID).OBJType
+                        Params(ParamC + 3) = IIf(.Invent_Skins.Object(i).Equipped, 1, 0)
+                        ParamC = ParamC + 4
+                    End If
+                Next i
+
+                Call Execute(sQuery.ToString(), Params)
+                Set sQuery = Nothing
+            End If
+
             SaveInventorySkins = True
         Else
             SaveInventorySkins = False


### PR DESCRIPTION
### Motivation
- `SaveInventorySkins` previously performed a per-skin `Database_Queries.Exists(...)` SELECT followed by per-skin `Database.Execute` INSERT/UPDATE/DELETE calls, producing many synchronous DB round-trips and contributing ~23ms to save time. 
- The goal is to eliminate per-item SQL round-trips and schedule persistence via the existing async `Execute(...)` helper (which uses `Connection_async` + `adAsyncExecute`) without changing the schema. 

### Description
- Removed per-item `Database_Queries.Exists(...)` lookups and per-item `Database.Execute` calls inside `SaveInventorySkins` in `Codigo/CharacterPersistence.bas` and replaced them with a batch strategy. 
- Implemented deterministic delete-then-insert persistence: schedule a single async `DELETE FROM inventory_item_skins WHERE user_id = ?;` and, when there are valid rows, build one parameterized bulk `INSERT INTO inventory_item_skins (user_id, skin_id, type_skin, skin_equipped) VALUES (?, ?, ?, ?), ...` using `cStringBuilder` and a `Params()` `Variant` array where `type_skin` is `ObjData(skin_id).OBJType` and `skin_equipped` is derived from `Equipped`. 
- Preserved original semantics and error handling by keeping `On Error GoTo SaveInventorySkins_Error`, returning `False` when `.Id <= 0` or no skins exist, and returning `True` once async operations are scheduled. 
