### PR TITLE
Centralize quests-done change check and log skipped saves

### DIFF
--- a/Codigo/CharacterPersistence.bas
+++ b/Codigo/CharacterPersistence.bas
@@ -776,6 +776,12 @@ Private Sub SaveCharacterQuestsDoneDB(ByRef U As t_User, ByRef QueryBreakdown As
     Dim Params() As Variant
     Dim LoopC As Long
     Dim ParamC As Long
+
+    If Not HaveQuestsDoneChanged(U) Then
+        If Len(QueryBreakdown) > 0 Then QueryBreakdown = QueryBreakdown & "; "
+        QueryBreakdown = QueryBreakdown & "quests done skipped"
+        Exit Sub
+    End If
     If U.QuestStats.NumQuestsDone > 0 Then
         SqlBuilder.Append "REPLACE INTO quest_done (user_id, quest_id) VALUES "
         For LoopC = 1 To U.QuestStats.NumQuestsDone
@@ -1333,10 +1339,8 @@ Public Sub SaveChangesInUser(ByVal UserIndex As Integer)
             Call PerformTimeLimitCheck(PerformanceTimer, "SaveChangesInUser [" & .name & "] quests update id:" & .Id, 50)
         End If
 
-        If HaveQuestsDoneChanged(UserIndex) Then
-            Call SaveCharacterQuestsDoneDB(UserList(UserIndex), QueryBreakdown, Builder)
-            Call PerformTimeLimitCheck(PerformanceTimer, "SaveChangesInUser [" & .name & "] quests done update id:" & .Id, 50)
-        End If
+        Call SaveCharacterQuestsDoneDB(UserList(UserIndex), QueryBreakdown, Builder)
+        Call PerformTimeLimitCheck(PerformanceTimer, "SaveChangesInUser [" & .name & "] quests done update id:" & .Id, 50)
 
         Call SaveCharacterInventorySkinsDB(UserIndex, QueryBreakdown)
         Call PerformTimeLimitCheck(PerformanceTimer, "SaveChangesInUser [" & .name & "] inventory skins update id:" & .Id, 50)


### PR DESCRIPTION
### Motivation
- Avoid duplicating change-detection logic in the caller and ensure skipped "quests done" saves are recorded in the query breakdown.

### Description
- Move the `HaveQuestsDoneChanged` check into `SaveCharacterQuestsDoneDB` so the function early-exits (and appends "quests done skipped" to `QueryBreakdown`) when there is no change, and remove the caller-side conditional so the save routine is always invoked from `SaveChangesInUser`.

