### PR TITLE
Replace magic-number message IDs in PrepareLocalizedChatOverHead with named constants

### DIFF
--- a/Codigo/General.bas
+++ b/Codigo/General.bas
@@ -846,7 +846,7 @@ Public Sub EfectoFrio(ByVal UserIndex As Integer)
         Else
             If MapInfo(.pos.Map).terrain = Nieve Then
                 'Msg2130=¡Tengo mucho frío!
-                Call SendData(SendTarget.ToIndex, UserIndex, PrepareLocalizedChatOverHead(2130, UserList(UserIndex).Char.charindex, vbWhite))
+                Call SendData(SendTarget.ToIndex, UserIndex, PrepareLocalizedChatOverHead(MSG_TOO_COLD, UserList(UserIndex).Char.charindex, vbWhite))
                 ' Msg512=¡Estás muriendo de frío, abrígate o morirás!
                 Call WriteLocaleMsg(UserIndex, MSG_MURIENDO_FRIO_ABRIGATE_MORIRAS, e_FontTypeNames.FONTTYPE_INFO)
                 '  Sin ropa perdés vida más rápido que con una ropa no-invernal

--- a/Codigo/InvUsuario.bas
+++ b/Codigo/InvUsuario.bas
@@ -1809,7 +1809,7 @@ Sub UseInvItem(ByVal UserIndex As Integer, ByVal Slot As Byte, ByVal ByClick As 
                 End If
                 If Not .Stats.MinSta > 0 Then
                     'Msg2129=¡No tengo energía!
-                    Call SendData(SendTarget.ToIndex, UserIndex, PrepareLocalizedChatOverHead(2129, UserList(UserIndex).Char.charindex, vbWhite))
+                    Call SendData(SendTarget.ToIndex, UserIndex, PrepareLocalizedChatOverHead(MSG_NO_ENERGY, UserList(UserIndex).Char.charindex, vbWhite))
                     'Msg93=Estás muy cansado
                     Call WriteLocaleMsg(UserIndex, MSG_MUY_CANSADO, e_FontTypeNames.FONTTYPE_INFO)
                     Exit Sub
@@ -1838,7 +1838,7 @@ Sub UseInvItem(ByVal UserIndex As Integer, ByVal Slot As Byte, ByVal ByClick As 
                 End If
                 If Not .Stats.MinSta > 0 Then
                     'Msg2129=¡No tengo energía!
-                    Call SendData(SendTarget.ToIndex, UserIndex, PrepareLocalizedChatOverHead(2129, UserList(UserIndex).Char.charindex, vbWhite))
+                    Call SendData(SendTarget.ToIndex, UserIndex, PrepareLocalizedChatOverHead(MSG_NO_ENERGY, UserList(UserIndex).Char.charindex, vbWhite))
                     'Msg93=Estás muy cansado
                     Call WriteLocaleMsg(UserIndex, MSG_MUY_CANSADO, e_FontTypeNames.FONTTYPE_INFO)
                     Exit Sub
@@ -3003,7 +3003,7 @@ Public Sub UserTargetableItem(ByVal UserIndex As Integer, ByVal TileX As Integer
             End If
             If .MinSta > UserList(UserIndex).Stats.MinSta Then
                 'Msg2129=¡No tengo energía!
-                Call SendData(SendTarget.ToIndex, UserIndex, PrepareLocalizedChatOverHead(2129, UserList(UserIndex).Char.charindex, vbWhite))
+                Call SendData(SendTarget.ToIndex, UserIndex, PrepareLocalizedChatOverHead(MSG_NO_ENERGY, UserList(UserIndex).Char.charindex, vbWhite))
                 'Msg420=Estas muy cansado para realizar esta acción.
                 Call WriteLocaleMsg(UserIndex, MsgTiredToPerformAction, e_FontTypeNames.FONTTYPE_INFO)
                 Exit Sub

--- a/Codigo/ModAutomatedActions.bas
+++ b/Codigo/ModAutomatedActions.bas
@@ -61,7 +61,7 @@ Public Function DecreaseUserStamina(ByVal UserIndex As Integer, ByVal StaminaReq
             DecreaseUserStamina = True
         Else
             'Msg2129=¡No tengo energía!
-            Call SendData(SendTarget.ToIndex, UserIndex, PrepareLocalizedChatOverHead(2129, UserList(UserIndex).Char.charindex, vbWhite))
+            Call SendData(SendTarget.ToIndex, UserIndex, PrepareLocalizedChatOverHead(MSG_NO_ENERGY, UserList(UserIndex).Char.charindex, vbWhite))
             'Msg93=Estás muy cansado
             Call WriteLocaleMsg(UserIndex, MSG_MUY_CANSADO, e_FontTypeNames.FONTTYPE_INFO)
             Call ResetUserAutomatedActions(UserIndex)

--- a/Codigo/Protocol.bas
+++ b/Codigo/Protocol.bas
@@ -2544,7 +2544,7 @@ Private Sub HandleWorkLeftClick(ByVal UserIndex As Integer)
                     Call QuitarSta(UserIndex, RandomNumber(1, 10))
                 Else
                     'Msg2129=¡No tengo energía!
-                    Call SendData(SendTarget.ToIndex, UserIndex, PrepareLocalizedChatOverHead(2129, UserList(UserIndex).Char.charindex, vbWhite))
+                    Call SendData(SendTarget.ToIndex, UserIndex, PrepareLocalizedChatOverHead(MSG_NO_ENERGY, UserList(UserIndex).Char.charindex, vbWhite))
                     'Msg1128= Estás muy cansado para luchar.
                     Call WriteLocaleMsg(UserIndex, MSG_MUY_CANSADO_LUCHAR, e_FontTypeNames.FONTTYPE_INFO)
                     Call WriteWorkRequestTarget(UserIndex, 0)
@@ -2917,7 +2917,7 @@ Private Sub HandleWorkLeftClick(ByVal UserIndex As Integer)
                 If .Stats.MinSta < ObjData(.invent.Object(.flags.TargetObjInvSlot).ObjIndex).MinSta Then
                     Call WriteLocaleMsg(UserIndex, MsgNotEnoughtStamina, e_FontTypeNames.FONTTYPE_INFO)
                     'Msg2129=¡No tengo energía!
-                    Call SendData(SendTarget.ToIndex, UserIndex, PrepareLocalizedChatOverHead(2129, UserList(UserIndex).Char.charindex, vbWhite))
+                    Call SendData(SendTarget.ToIndex, UserIndex, PrepareLocalizedChatOverHead(MSG_NO_ENERGY, UserList(UserIndex).Char.charindex, vbWhite))
                     Exit Sub
                 End If
                 Call LookatTile(UserIndex, UserList(UserIndex).pos.Map, x, y)
@@ -3156,7 +3156,7 @@ Private Sub HandleTrain(ByVal UserIndex As Integer)
                 End If
             End If
         Else
-            Call SendData(SendTarget.ToPCAliveArea, UserIndex, PrepareLocalizedChatOverHead(2082, NpcList(.flags.TargetNPC.ArrayIndex).Char.charindex, vbWhite))
+            Call SendData(SendTarget.ToPCAliveArea, UserIndex, PrepareLocalizedChatOverHead(MSG_CANNOT_SUMMON_MORE_THAN_FIVE_CREATURES, NpcList(.flags.TargetNPC.ArrayIndex).Char.charindex, vbWhite))
         End If
     End With
     Exit Sub
@@ -3184,7 +3184,7 @@ Private Sub HandleCommerceBuy(ByVal UserIndex As Integer)
         If Not IsValidNpcRef(.flags.TargetNPC) Then Exit Sub
         'íEl NPC puede comerciar?
         If NpcList(.flags.TargetNPC.ArrayIndex).Comercia = 0 Then
-            Call SendData(SendTarget.ToPCAliveArea, UserIndex, PrepareLocalizedChatOverHead(2084, NpcList(.flags.TargetNPC.ArrayIndex).Char.charindex, vbWhite))
+            Call SendData(SendTarget.ToPCAliveArea, UserIndex, PrepareLocalizedChatOverHead(MSG_NOT_INTERESTED_IN_TRADING, NpcList(.flags.TargetNPC.ArrayIndex).Char.charindex, vbWhite))
             Exit Sub
         End If
         'Only if in commerce mode....
@@ -3252,7 +3252,7 @@ Private Sub HandleCommerceSell(ByVal UserIndex As Integer)
         If Not IsValidNpcRef(.flags.TargetNPC) Then Exit Sub
         'íEl NPC puede comerciar?
         If NpcList(.flags.TargetNPC.ArrayIndex).Comercia = 0 Then
-            Call SendData(SendTarget.ToPCAliveArea, UserIndex, PrepareLocalizedChatOverHead(2084, NpcList(.flags.TargetNPC.ArrayIndex).Char.charindex, vbWhite))
+            Call SendData(SendTarget.ToPCAliveArea, UserIndex, PrepareLocalizedChatOverHead(MSG_NOT_INTERESTED_IN_TRADING, NpcList(.flags.TargetNPC.ArrayIndex).Char.charindex, vbWhite))
             Exit Sub
         End If
         'User compra el item del slot
@@ -7042,10 +7042,10 @@ Public Sub HandleQuest(ByVal UserIndex As Integer)
     End If
     'El NPC hace quests?
     If NpcList(NpcIndex).NumQuest = 0 Then
-        Call SendData(SendTarget.ToIndex, UserIndex, PrepareLocalizedChatOverHead(2085, NpcList(NpcIndex).Char.charindex, vbWhite))
+        Call SendData(SendTarget.ToIndex, UserIndex, PrepareLocalizedChatOverHead(MSG_NO_MISSION_FOR_YOU, NpcList(NpcIndex).Char.charindex, vbWhite))
         Exit Sub
     End If
-    Call SendData(SendTarget.ToIndex, UserIndex, PrepareLocalizedChatOverHead(2086, NpcList(NpcIndex).Char.charindex, vbWhite))
+    Call SendData(SendTarget.ToIndex, UserIndex, PrepareLocalizedChatOverHead(MSG_TOO_MANY_ACTIVE_MISSIONS, NpcList(NpcIndex).Char.charindex, vbWhite))
     Exit Sub
 HandleQuest_Err:
     Call TraceError(Err.Number, Err.Description, "Protocol.HandleQuest", Erl)

--- a/Codigo/SistemaCombate.bas
+++ b/Codigo/SistemaCombate.bas
@@ -906,7 +906,7 @@ Public Sub UsuarioAtaca(ByVal UserIndex As Integer)
             'Msg93=Estás muy cansado
             Call WriteLocaleMsg(UserIndex, MSG_MUY_CANSADO, e_FontTypeNames.FONTTYPE_INFO)
             'Msg2129=¡No tengo energía!
-            Call SendData(SendTarget.ToIndex, UserIndex, PrepareLocalizedChatOverHead(2129, UserList(UserIndex).Char.charindex, vbWhite))
+            Call SendData(SendTarget.ToIndex, UserIndex, PrepareLocalizedChatOverHead(MSG_NO_ENERGY, UserList(UserIndex).Char.charindex, vbWhite))
             Exit Sub
         End If
         Call QuitarSta(UserIndex, RandomNumber(1, 10))

--- a/Codigo/Trabajo.bas
+++ b/Codigo/Trabajo.bas
@@ -1014,7 +1014,7 @@ Public Sub CarpinteroConstruirItem(ByVal UserIndex As Integer, ByVal ItemIndex A
             'Msg93=Estás muy cansado para trabajar.
             Call WriteLocaleMsg(UserIndex, MSG_MUY_CANSADO, e_FontTypeNames.FONTTYPE_INFO)
             'Msg2129=¡No tengo energía!
-            Call SendData(SendTarget.ToIndex, UserIndex, PrepareLocalizedChatOverHead(2129, UserList(UserIndex).Char.charindex, vbWhite))
+            Call SendData(SendTarget.ToIndex, UserIndex, PrepareLocalizedChatOverHead(MSG_NO_ENERGY, UserList(UserIndex).Char.charindex, vbWhite))
             Call WriteMacroTrabajoToggle(UserIndex, False)
             Exit Sub
         End If
@@ -1051,7 +1051,7 @@ Public Sub AlquimistaConstruirItem(ByVal UserIndex As Integer, ByVal ItemIndex A
     On Error GoTo AlquimistaConstruirItem_Err
     If Not UserList(UserIndex).Stats.MinSta > 0 Then
         'Msg2129=¡No tengo energía!
-        Call SendData(SendTarget.ToIndex, UserIndex, PrepareLocalizedChatOverHead(2129, UserList(UserIndex).Char.charindex, vbWhite))
+        Call SendData(SendTarget.ToIndex, UserIndex, PrepareLocalizedChatOverHead(MSG_NO_ENERGY, UserList(UserIndex).Char.charindex, vbWhite))
         'Msg93=Estás muy cansado
         Call WriteLocaleMsg(UserIndex, MSG_MUY_CANSADO, e_FontTypeNames.FONTTYPE_INFO)
         Exit Sub
@@ -1110,7 +1110,7 @@ Public Sub SastreConstruirItem(ByVal UserIndex As Integer, ByVal ItemIndex As In
     If Not IntervaloPermiteTrabajarConstruir(UserIndex) Then Exit Sub
     If Not UserList(UserIndex).Stats.MinSta > 0 Then
         'Msg2129=¡No tengo energía!
-        Call SendData(SendTarget.ToIndex, UserIndex, PrepareLocalizedChatOverHead(2129, UserList(UserIndex).Char.charindex, vbWhite))
+        Call SendData(SendTarget.ToIndex, UserIndex, PrepareLocalizedChatOverHead(MSG_NO_ENERGY, UserList(UserIndex).Char.charindex, vbWhite))
         'Msg93=Estás muy cansado
         Call WriteLocaleMsg(UserIndex, MSG_MUY_CANSADO, e_FontTypeNames.FONTTYPE_INFO)
         Exit Sub
@@ -1349,12 +1349,12 @@ Public Sub DoRobar(ByVal LadronIndex As Integer, ByVal VictimaIndex As Integer)
         If .Stats.MinSta < 15 Then
             If .genero = e_Genero.Hombre Then
                 'Msg2129=¡No tengo energía!
-                Call SendData(SendTarget.ToIndex, LadronIndex, PrepareLocalizedChatOverHead(2129, UserList(LadronIndex).Char.charindex, vbWhite))
+                Call SendData(SendTarget.ToIndex, LadronIndex, PrepareLocalizedChatOverHead(MSG_NO_ENERGY, UserList(LadronIndex).Char.charindex, vbWhite))
                 'Msg1034= Estás muy cansado para robar.
                 Call WriteLocaleMsg(LadronIndex, "1034", e_FontTypeNames.FONTTYPE_INFO)
             Else
                 'Msg2129=¡No tengo energía!
-                Call SendData(SendTarget.ToIndex, LadronIndex, PrepareLocalizedChatOverHead(2129, UserList(LadronIndex).Char.charindex, vbWhite))
+                Call SendData(SendTarget.ToIndex, LadronIndex, PrepareLocalizedChatOverHead(MSG_NO_ENERGY, UserList(LadronIndex).Char.charindex, vbWhite))
                 'Msg1035= Estás muy cansada para robar.
                 Call WriteLocaleMsg(LadronIndex, "1035", e_FontTypeNames.FONTTYPE_INFO)
             End If

--- a/Codigo/modHechizos.bas
+++ b/Codigo/modHechizos.bas
@@ -622,7 +622,7 @@ Private Function PuedeLanzar(ByVal UserIndex As Integer, ByVal HechizoIndex As I
             'Msg93=Estás muy cansado
             Call WriteLocaleMsg(UserIndex, MSG_MUY_CANSADO, e_FontTypeNames.FONTTYPE_INFO)
             'Msg2129=¡No tengo energía!
-            Call SendData(SendTarget.ToIndex, UserIndex, PrepareLocalizedChatOverHead(2129, UserList(UserIndex).Char.charindex, vbWhite))
+            Call SendData(SendTarget.ToIndex, UserIndex, PrepareLocalizedChatOverHead(MSG_NO_ENERGY, UserList(UserIndex).Char.charindex, vbWhite))
             Exit Function
         End If
         If .clase = e_Class.Mage And Not IsFeatureEnabled("remove-staff-requirements") Then

--- a/Codigo/modMessageIDs.bas
+++ b/Codigo/modMessageIDs.bas
@@ -62,6 +62,12 @@ Public Const MSG_CANNOT_TRADE_IN_JAIL                          As Integer = 2111
 Public Const MSG_CANNOT_USE_HOME_IN_JAIL                       As Integer = 2112
 Public Const MAP_HOME_IN_JAIL                                  As Integer = 66
 Public Const MSG_QUEST_ALREADY_COMPLETED                       As Integer = 2114
+Public Const MSG_CANNOT_SUMMON_MORE_THAN_FIVE_CREATURES        As Integer = 2082
+Public Const MSG_NOT_INTERESTED_IN_TRADING                     As Integer = 2084
+Public Const MSG_NO_MISSION_FOR_YOU                            As Integer = 2085
+Public Const MSG_TOO_MANY_ACTIVE_MISSIONS                      As Integer = 2086
+Public Const MSG_NO_ENERGY                                     As Integer = 2129
+Public Const MSG_TOO_COLD                                      As Integer = 2130
 
 
 

--- a/Codigo/modSmelting.bas
+++ b/Codigo/modSmelting.bas
@@ -66,7 +66,7 @@ Public Sub CraftIngots(ByVal UserIndex As Integer)
     If UserList(UserIndex).Stats.MinSta > 2 Then
         Call QuitarSta(UserIndex, 2)
     Else
-        Call SendData(SendTarget.ToIndex, UserIndex, PrepareLocalizedChatOverHead(2129, UserList(UserIndex).Char.charindex, vbWhite))
+        Call SendData(SendTarget.ToIndex, UserIndex, PrepareLocalizedChatOverHead(MSG_NO_ENERGY, UserList(UserIndex).Char.charindex, vbWhite))
         Call WriteLocaleMsg(UserIndex, MSG_MUY_CANSADO, e_FontTypeNames.FONTTYPE_INFO)
         Call WriteMacroTrabajoToggle(UserIndex, False)
         Exit Sub


### PR DESCRIPTION
### Motivation
- Remove hard-coded numeric locale IDs from calls to `PrepareLocalizedChatOverHead` and replace them with descriptive constants to improve readability and maintainability.
- Ensure `Codigo/modMessageIDs.bas` is the single source of truth for these message IDs so message meanings from `SP_LocalMsg.dat` are explicit in code.

### Description
- Added six exact constants to `Codigo/modMessageIDs.bas`: `MSG_CANNOT_SUMMON_MORE_THAN_FIVE_CREATURES = 2082`, `MSG_NOT_INTERESTED_IN_TRADING = 2084`, `MSG_NO_MISSION_FOR_YOU = 2085`, `MSG_TOO_MANY_ACTIVE_MISSIONS = 2086`, `MSG_NO_ENERGY = 2129`, and `MSG_TOO_COLD = 2130`.
- Replaced all literal numeric usages in `PrepareLocalizedChatOverHead(...)` across gameplay modules with the corresponding named constants in `Codigo/Protocol.bas`, `Codigo/General.bas`, `Codigo/InvUsuario.bas`, `Codigo/ModAutomatedActions.bas`, `Codigo/Trabajo.bas`, `Codigo/modHechizos.bas`, `Codigo/modSmelting.bas`, and `Codigo/SistemaCombate.bas`.
- Performed the replacements via a targeted script to ensure only the `PrepareLocalizedChatOverHead` call sites were modified and left other message usages unchanged.
- Committed the updated files so the codebase no longer contains the targeted magic-number message IDs in these overhead chat calls.

