### PR TITLE
WIP Soportar BodyIdle para NPCs inmovilizados/paralizados

### DIFF
--- a/Codigo/Declares.bas
+++ b/Codigo/Declares.bas
@@ -3210,6 +3210,7 @@ Public Type t_NpcInfoCache
     ElementalTags As Long
     npcType As Integer
     Body As Integer
+    BodyIdle As Integer
     Head As Integer
     Heading As Integer
     CastAnimation As Integer
@@ -3356,6 +3357,8 @@ Public Type t_Npc
     name As String
     SubName As String
     Char As t_Char 'Define como se vera
+    BodyNormal As Integer
+    BodyIdle As Integer
     Desc As String
     DescExtra As String
     showName As Byte

--- a/Codigo/MODULO_NPCs.bas
+++ b/Codigo/MODULO_NPCs.bas
@@ -989,6 +989,7 @@ Private Sub LoadNpcInfoIntoCache(ByVal NpcNumber As Integer)
         .GlobalQuestBossIndex = val(LeerNPCs.GetValue(SectionName, "GlobalQuestBossIndex"))
         .npcType = Val(LeerNPCs.GetValue(SectionName, "NpcType"))
         .Body = Val(LeerNPCs.GetValue(SectionName, "Body"))
+        .BodyIdle = Val(LeerNPCs.GetValue(SectionName, "BodyIdle", 0))
         .Head = Val(LeerNPCs.GetValue(SectionName, "Head"))
         .Heading = Val(LeerNPCs.GetValue(SectionName, "Heading"))
         .CastAnimation = Val(LeerNPCs.GetValue(SectionName, "CastAnimation"))
@@ -1331,6 +1332,8 @@ Private Sub InitializeNpcFromInfo(ByVal NpcIndex As Integer, _
         .flags.ElementalTags = Info.ElementalTags
         .npcType = Info.npcType
         .Char.body = Info.Body
+        .BodyNormal = Info.Body
+        .BodyIdle = Info.BodyIdle
         .Char.head = Info.Head
         .Char.Heading = Info.Heading
         .Char.CastAnimation = Info.CastAnimation
@@ -1697,9 +1700,17 @@ End Sub
 
 Sub AnimacionIdle(ByVal NpcIndex As Integer, ByVal Show As Boolean)
     On Error GoTo Handler
+    Dim BodyToUse As Integer
     With NpcList(NpcIndex)
-        If .flags.NPCIdle = Show Then Exit Sub
+        BodyToUse = .BodyNormal
+        If Show And .BodyIdle > 0 Then
+            BodyToUse = .BodyIdle
+        End If
+
+        If .flags.NPCIdle = Show And .Char.body = BodyToUse Then Exit Sub
+
         .flags.NPCIdle = Show
+        .Char.body = BodyToUse
         Call ChangeNPCChar(NpcIndex, .Char.body, .Char.head, .Char.Heading)
     End With
     Exit Sub

--- a/Codigo/SistemaCombate.bas
+++ b/Codigo/SistemaCombate.bas
@@ -796,6 +796,7 @@ Public Sub UsuarioAtacaNpc(ByVal UserIndex As Integer, ByVal NpcIndex As Integer
                 If NpcList(NpcIndex).flags.AfectaParalisis = 0 Then
                     NpcList(NpcIndex).flags.Paralizado = 1
                     NpcList(NpcIndex).Contadores.Paralisis = (IntervaloParalizado / 3) * 7
+                    Call AnimacionIdle(NpcIndex, True)
                     If UserList(UserIndex).ChatCombate = 1 Then
                         Call WriteLocaleMsg(UserIndex, MSG_ATTACK_PARALYZED_CREATURE, e_FontTypeNames.FONTTYPE_FIGHT)
                     End If

--- a/Codigo/modHechizos.bas
+++ b/Codigo/modHechizos.bas
@@ -2188,7 +2188,7 @@ Sub HechizoEstadoNPC(ByVal NpcIndex As Integer, ByVal hIndex As Integer, ByRef b
             NpcList(NpcIndex).Contadores.Paralisis = (Hechizos(hIndex).Duration * 6.5) * 6
             NpcList(NpcIndex).flags.Inmovilizado = 0
             NpcList(NpcIndex).Contadores.Inmovilizado = 0
-            Call AnimacionIdle(NpcIndex, False)
+            Call AnimacionIdle(NpcIndex, True)
             b = True
         Else
             Call WriteLocaleMsg(UserIndex, MSG_NPC_IMMUNE_TO_THIS_SPELL, e_FontTypeNames.FONTTYPE_INFOIAO)


### PR DESCRIPTION
### Motivation
- Permitir que los NPCs cambien visualmente su `body` cuando quedan inmovilizados o paralizados usando un `BodyIdle` opcional en la definición del NPC.

### Description
- Agregué `BodyIdle` a `t_NpcInfoCache` y `BodyNormal`/`BodyIdle` a `t_Npc` en `Codigo/Declares.bas` para guardar el body original y el body idle en runtime. 
- La carga de NPCs ahora lee `BodyIdle` (opcional, default `0`) en `LoadNpcInfoIntoCache` y `InitializeNpcFromInfo` guarda ambos valores (`BodyNormal` y `BodyIdle`) en `Codigo/MODULO_NPCs.bas`.
- Reescribí `AnimacionIdle` para elegir `BodyIdle` cuando `Show=True` y restaurar `BodyNormal` al salir de idle, evitando actualizaciones redundantes mediante la comparación con `.Char.body` antes de llamar a `ChangeNPCChar` en `Codigo/MODULO_NPCs.bas`.
- Hice que los flujos que paralizan/inmovilizan NPCs llamen a `AnimacionIdle(..., True)` para aplicar el `BodyIdle` también en estados de parálisis/ inmo, cambiando comportamiento en `Codigo/modHechizos.bas` y `Codigo/SistemaCombate.bas`.

### Testing
- Ejecuté `git diff --check` para verificar problemas de formato y no se reportaron errores; la verificación pasó. 
- Busqué referencias con `rg` para `BodyIdle`, `BodyNormal` y `AnimacionIdle(NpcIndex, True)` en los archivos modificados para asegurar consistencia, y las referencias esperadas fueron encontradas. 
- Confirmé que los cambios están incluidos en el commit y que los archivos modificados son `Codigo/Declares.bas`, `Codigo/MODULO_NPCs.bas`, `Codigo/modHechizos.bas` y `Codigo/SistemaCombate.bas`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0a0925bc88328a12fbb62569f2ba2)