### PR TITLE
Add summoned invocation timer bar[SERVER]

### DIFF
--- a/Codigo/PacketId.bas
+++ b/Codigo/PacketId.bas
@@ -208,6 +208,7 @@ Public Enum ServerPacketID
     eChangeSkinSlot
     eGuildConfig
     eShowPickUpObj
+    eSummonedInvocationBarFx
     eMaxPacket
     [PacketCount]
 End Enum

--- a/Codigo/Protocol_Writes.bas
+++ b/Codigo/Protocol_Writes.bas
@@ -4571,3 +4571,13 @@ WriteShowPickUpObj_Err:
     Call Writer.Clear
     Call TraceError(Err.Number, Err.Description, "Argentum20Server.Protocol_Writes.WriteShowPickUpObj", Erl)
 End Sub
+Public Function PrepareSummonedInvocationBarFx(ByVal charindex As Integer, ByVal time As Integer)
+    On Error GoTo PrepareSummonedInvocationBarFx_Err
+    Call Writer.WriteInt16(ServerPacketID.eSummonedInvocationBarFx)
+    Call Writer.WriteInt16(charindex)
+    Call Writer.WriteInt16(time)
+    Exit Function
+PrepareSummonedInvocationBarFx_Err:
+    Call Writer.Clear
+    Call TraceError(Err.Number, Err.Description, "Argentum20Server.Protocol_Writes.SummonedInvocationBar", Erl)
+End Function

--- a/Codigo/modHechizos.bas
+++ b/Codigo/modHechizos.bas
@@ -779,6 +779,8 @@ Sub HechizoInvocacion(ByVal UserIndex As Integer, ByRef b As Boolean)
                         .MascotasType(Index) = NpcList(ind).Numero
                         Call SetUserRef(NpcList(ind).MaestroUser, UserIndex)
                         NpcList(ind).Contadores.TiempoExistencia = IntervaloInvocacion
+                        Call SendData(SendTarget.ToIndex, UserIndex, _
+                                PrepareSummonedInvocationBarFx(NpcList(ind).Char.charindex, IntervaloInvocacion / 25))
                         NpcList(ind).GiveGLD = 0
                         If IsFeatureEnabled("addjust-npc-with-caster") And IsSet(Hechizos(h).Effects, AdjustStatsWithCaster) Then
                             Call AdjustNpcStatWithCasterLevel(UserIndex, ind)


### PR DESCRIPTION
Add support for displaying a remaining lifetime bar for summoned elementals on the client.

This PR introduces a new server packet `eSummonedInvocationBarFx` that sends the invocation duration to the client so it can render a countdown bar above the NPC.

Changes included:

• Added new packet ID `eSummonedInvocationBarFx`.
• Implemented `PrepareSummonedInvocationBarFx` in Protocol_Writes. 
• When a summoning spell creates an elemental (`HechizoInvocacion`), the server sends the invocation duration to the caster's client.

The client uses this information to calculate and render the remaining lifetime of the summoned creature.
No gameplay behavior is modified on the server side; this change only exposes existing invocation timing information for UI purposes.

Client: https://github.com/ao-org/argentum-online-client/pull/771