### PR TITLE
WIP Add admin 'take item' (/QITEM) packet and handler

### DIFF
--- a/Codigo/PacketId.bas
+++ b/Codigo/PacketId.bas
@@ -529,6 +529,7 @@ Public Enum ClientPacketID
     eChangeSkinSlot
     eStartAutomatedAction
     ePetFollowAll
+    eTakeItem                '/QITEM
     eMaxPacket
     [PacketCount]
 End Enum

--- a/Codigo/Protocol.bas
+++ b/Codigo/Protocol.bas
@@ -712,6 +712,8 @@ Public Function HandleIncomingData(ByVal ConnectionID As Long, ByVal Message As 
             Call HandlePromedio(UserIndex)
         Case ClientPacketID.eGiveItem
             Call HandleGiveItem(UserIndex)
+        Case ClientPacketID.eTakeItem
+            Call HandleTakeItem(UserIndex)
         Case ClientPacketID.eOfertaInicial
             Call HandleOfertaInicial(UserIndex)
         Case ClientPacketID.eOfertaDeSubasta

--- a/Codigo/Protocol_GmCommands.bas
+++ b/Codigo/Protocol_GmCommands.bas
@@ -3404,6 +3404,61 @@ ErrHandler:
     Call TraceError(Err.Number, Err.Description, "Protocol.HandleGiveItem", Erl)
 End Sub
 
+Public Sub HandleTakeItem(ByVal UserIndex As Integer)
+    On Error GoTo ErrHandler
+    With UserList(UserIndex)
+        Dim username As String
+        Dim Slot     As Byte
+        Dim Cantidad As Integer
+        Dim Motivo   As String
+        Dim tUser    As t_UserReference
+
+        username = reader.ReadString8()
+        Slot = reader.ReadInt8()
+        Cantidad = reader.ReadInt16()
+        Motivo = reader.ReadString8()
+
+        If (.flags.Privilegios And e_PlayerType.Admin) Then
+            If Cantidad <= 0 Then Exit Sub
+
+            tUser = NameIndex(username)
+            If Not IsValidUserRef(tUser) Then
+                Call WriteLocaleMsg(UserIndex, MSG_NO_USUARIO_CONECTADO, e_FontTypeNames.FONTTYPE_INFO)
+                Exit Sub
+            End If
+
+            If Slot < 1 Or Slot > UserList(tUser.ArrayIndex).CurrentInventorySlots Then
+                Call WriteLocaleMsg(UserIndex, MSG_SLOT_INVILIDO, e_FontTypeNames.FONTTYPE_TALK)
+                Exit Sub
+            End If
+
+            If UserList(tUser.ArrayIndex).invent.Object(Slot).ObjIndex <= 0 Then
+                Call WriteLocaleMsg(UserIndex, MSG_NO_HAY_OBJETO_SLOT_SELECCIONADO, e_FontTypeNames.FONTTYPE_INFO)
+                Exit Sub
+            End If
+
+            If Cantidad > UserList(tUser.ArrayIndex).invent.Object(Slot).amount Then
+                Cantidad = UserList(tUser.ArrayIndex).invent.Object(Slot).amount
+            End If
+
+            Dim objName As String
+            objName = ObjData(UserList(tUser.ArrayIndex).invent.Object(Slot).ObjIndex).name
+
+            Call QuitarUserInvItem(tUser.ArrayIndex, Slot, Cantidad)
+            Call UpdateUserInv(False, tUser.ArrayIndex, Slot)
+
+            Call WriteConsoleMsg(UserIndex, "Quitaste " & Cantidad & " " & objName & " de " & UserList(tUser.ArrayIndex).name & " (slot " & Slot & ").", e_FontTypeNames.FONTTYPE_INFO)
+            Call WriteConsoleMsg(tUser.ArrayIndex, "Un Admin te quitó " & Cantidad & " " & objName & ". Motivo: " & Motivo, e_FontTypeNames.FONTTYPE_INFO)
+            Call LogGM(GetUserRealName(UserIndex), "/QITEM " & username & " SLOT:" & Slot & " ITEM:" & objName & " CANT:" & Cantidad & " MOTIVO:" & Motivo)
+        Else
+            Call WriteLocaleMsg(UserIndex, MSG_SERVIDOR_COMANDO_DESHABILITADO_CARGO_DEBES_PEDIR_ADMIN, e_FontTypeNames.FONTTYPE_INFO)
+        End If
+    End With
+    Exit Sub
+ErrHandler:
+    Call TraceError(Err.Number, Err.Description, "Protocol.HandleTakeItem", Erl)
+End Sub
+
 Public Sub HandleQuestionGM(ByVal UserIndex As Integer)
     Dim nowRaw    As Long
     Dim elapsedMs As Double

--- a/Codigo/modDebugUtils.bas
+++ b/Codigo/modDebugUtils.bas
@@ -463,6 +463,8 @@ Public Function PacketID_to_string(ByVal PacketId As ClientPacketID) As String
             PacketID_to_string = "ePromedio"
         Case ClientPacketID.eGiveItem
             PacketID_to_string = "eGiveItem"
+        Case ClientPacketID.eTakeItem
+            PacketID_to_string = "eTakeItem"
         Case ClientPacketID.eOfertaInicial
             PacketID_to_string = "eOfertaInicial"
         Case ClientPacketID.eOfertaDeSubasta


### PR DESCRIPTION
### Motivation
- Add server-side support for an admin command to remove items from a player's inventory (`/QITEM`).
- Wire a new client packet identifier so the server can receive take-item requests from tools or GM clients.
- Ensure debug/logging and packet-to-string mapping include the new packet for visibility and tracing.

### Description
- Introduces a new packet ID `ClientPacketID.eTakeItem` in `PacketId.bas` and adds its string mapping in `modDebugUtils.bas` via `PacketID_to_string`.
- Registers the new packet in the main dispatch in `Protocol.bas` so `HandleTakeItem` is invoked on `ClientPacketID.eTakeItem` arrivals.
- Adds `HandleTakeItem` in `Protocol_GmCommands.bas`, which reads `username`, `slot`, `amount`, and `motivo`, validates admin privileges and slot/item presence, clamps amounts, removes the item via `QuitarUserInvItem`, updates the inventory with `UpdateUserInv`, sends console messages to both parties, and logs the GM action with `/QITEM` semantics.
- Adds error handling and uses existing locale messages to inform callers of invalid users, invalid slots, missing items, or insufficient privileges.

### Testing
- No automated tests exist for these handlers in the repository, so no automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b14a9d42c0832887d6a45fe725ea04)