### PR TITLE
Have ranged NPCs face targets and adjust retreat threshold

### DIFF
--- a/Codigo/AI_NPC.bas
+++ b/Codigo/AI_NPC.bas
@@ -318,6 +318,9 @@ Public Sub AI_RangeAttack(ByVal NpcIndex As Integer)
                 Call AI_CaminarConRumbo(NpcIndex, TargetPos)
             End If
         End If
+        If IsValidRef(CurrentTarget) Then
+            TargetPos = ModReferenceUtils.GetPosition(CurrentTarget)
+        End If
         'perform movement
         If NPCs.CanMove(.Contadores, .flags) Then
             Call TryFaceRangedTarget(NpcIndex, CurrentTarget)


### PR DESCRIPTION
### Motivation
- Ensure ranged NPCs visually face their targets before movement decisions are made to improve combat behavior and projectile direction.
- Make retreat logic inclusive of the preferred range boundary so NPCs that are exactly at `PreferedRange` do not incorrectly treat the target as too close.

### Description
- Added `TryFaceRangedTarget` helper to orient an NPC toward a target before movement decisions and call it from `AI_RangeAttack`, `AI_BGSupportBehavior`, and `AI_BGRangedBehavior`.
- Implemented `GetRangedFacingHeading` to compute the facing `e_Heading` based on NPC and target positions while preserving current heading on ties.
- Changed retreat condition comparisons from `< .PreferedRange` to `<= .PreferedRange` in the affected AI behaviors so NPCs treat being exactly at preferred range as a retreat condition.
- Kept fallback movement logic unchanged and used existing functions such as `ComputeNpcRangedRetreatDestination`, `AI_CaminarConRumbo`, and `MoveNPCChar` when appropriate.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1df16479883288d7ab12c0e75e0cf)