### PR TITLE
Load BodyIdle for static NPCs when available

### DIFF
--- a/Codigo/Declares.bas
+++ b/Codigo/Declares.bas
@@ -3210,6 +3210,7 @@ Public Type t_NpcInfoCache
     ElementalTags As Long
     npcType As Integer
     Body As Integer
+    BodyIdle As Integer
     Head As Integer
     Heading As Integer
     CastAnimation As Integer

--- a/Codigo/MODULO_NPCs.bas
+++ b/Codigo/MODULO_NPCs.bas
@@ -989,6 +989,7 @@ Private Sub LoadNpcInfoIntoCache(ByVal NpcNumber As Integer)
         .GlobalQuestBossIndex = val(LeerNPCs.GetValue(SectionName, "GlobalQuestBossIndex"))
         .npcType = Val(LeerNPCs.GetValue(SectionName, "NpcType"))
         .Body = Val(LeerNPCs.GetValue(SectionName, "Body"))
+        .BodyIdle = Val(LeerNPCs.GetValue(SectionName, "BodyIdle", .Body))
         .Head = Val(LeerNPCs.GetValue(SectionName, "Head"))
         .Heading = Val(LeerNPCs.GetValue(SectionName, "Heading"))
         .CastAnimation = Val(LeerNPCs.GetValue(SectionName, "CastAnimation"))
@@ -1330,7 +1331,11 @@ Private Sub InitializeNpcFromInfo(ByVal NpcIndex As Integer, _
         .flags.Faccion = Info.Faccion
         .flags.ElementalTags = Info.ElementalTags
         .npcType = Info.npcType
-        .Char.body = Info.Body
+        If Info.Movement = Estatico And Info.BodyIdle > 0 Then
+            .Char.body = Info.BodyIdle
+        Else
+            .Char.body = Info.Body
+        End If
         .Char.head = Info.Head
         .Char.Heading = Info.Heading
         .Char.CastAnimation = Info.CastAnimation


### PR DESCRIPTION
### Motivation
- Some NPCs configured with `Movement=Estatico` should use a specialized idle body graphic when present in the NPC data to display a different appearance while static. 
- The NPC cache and initialization paths did not preserve or apply an optional `BodyIdle` field from the `NPCs.dat` source, causing static NPCs to always use the regular `Body` value.

### Description
- Added `BodyIdle` to the `t_NpcInfoCache` type in `Codigo/Declares.bas` to store an optional idle body value. 
- Updated `LoadNpcInfoIntoCache` in `Codigo/MODULO_NPCs.bas` to read `BodyIdle` with a fallback to `Body` when the key is absent (`LeerNPCs.GetValue(SectionName, "BodyIdle", .Body)`).
- Updated `InitializeNpcFromInfo` to set `.Char.body` to `Info.BodyIdle` when `Info.Movement = Estatico` and `Info.BodyIdle > 0`, otherwise keep `Info.Body`.

### Testing
- Performed codebase searches (`rg -n "BodyIdle" Codigo -S`) to ensure all usages are consistent and found the new references successfully. 
- Inspected the modified source lines with file line dumps (`nl -ba ... | sed -n`) to verify the `BodyIdle` read and initialization logic were inserted at the intended locations. 
- Performed basic repository sanity checks to confirm only the intended files (`Codigo/Declares.bas`, `Codigo/MODULO_NPCs.bas`) were changed and the code-level edits are present; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b28aa129bc8328a7cc7497d8d2e35f)