### PR TITLE
Add donor flag and treat donors as patrons

### DIFF
--- a/Codigo/CharacterPersistence.bas
+++ b/Codigo/CharacterPersistence.bas
@@ -221,6 +221,10 @@ Public Function LoadCharacterFromDB(ByVal UserIndex As Integer) As Boolean
 
         ' Set up the Patreon tier early (needed by subsequent initialization).
         .Stats.tipoUsuario = GetPatronTierFromAccountID(.AccountID)
+        .flags.is_donor = GetUserContributionStatusFromAccountID(.AccountID)
+        If .flags.is_donor > 0 Then
+            .Stats.tipoUsuario = e_TipoUsuario.tLeyenda
+        End If
         ' Check for ban status.
         If RS!is_banned Then
             Dim BanNick As String, BaneoMotivo As String
@@ -529,6 +533,18 @@ Public Function GetPatronTierFromAccountID(ByVal account_id) As e_TipoUsuario
     Exit Function
 ErrorHandler_GetPatronTierFromAccountID:
     Call LogDatabaseError("Error en GetPatronTierFromAccountID: " & account_id & ". " & Err.Number & " - " & Err.Description & ". Línea: " & Erl)
+End Function
+
+Public Function GetUserContributionStatusFromAccountID(ByVal account_id) As Byte
+    On Error GoTo ErrorHandler_GetUserContributionStatusFromAccountID
+    Dim RS As ADODB.Recordset
+    Set RS = Query("Select is_donor from account where id = ?", account_id)
+    If Not RS Is Nothing Then
+        GetUserContributionStatusFromAccountID = RS!is_donor
+    End If
+    Exit Function
+ErrorHandler_GetUserContributionStatusFromAccountID:
+    Call LogDatabaseError("Error en GetUserContributionStatusFromAccountID: " & account_id & ". " & Err.Number & " - " & Err.Description & ". Línea: " & Erl)
 End Function
 
 Public Sub LoadPatronCreditsFromDB(ByVal UserIndex As Integer)

--- a/Codigo/Declares.bas
+++ b/Codigo/Declares.bas
@@ -2557,6 +2557,7 @@ Public Type t_UserFlags
     Casado As Byte
     Candidato As t_UserReference
     pregunta As Byte
+    is_donor As Byte
     ' 0: no esta hechizada;
     'Cualquier otro valor si lo esta: 0.8 -> reduce un 20% de velocidad; 1.3 -> Aumenta un 30%
     VelocidadHechizada As Single

--- a/Codigo/Modulo_UsUaRiOs.bas
+++ b/Codigo/Modulo_UsUaRiOs.bas
@@ -78,7 +78,7 @@ Public Function IsPatreon(ByVal UserIndex As Integer) As Boolean
    On Error GoTo IsPatreon_Error
 
     With UserList(UserIndex).Stats
-        IsPatreon = .tipoUsuario = e_TipoUsuario.tAventurero Or .tipoUsuario = e_TipoUsuario.tHeroe Or .tipoUsuario = e_TipoUsuario.tLeyenda
+        IsPatreon = .tipoUsuario = e_TipoUsuario.tAventurero Or .tipoUsuario = e_TipoUsuario.tHeroe Or .tipoUsuario = e_TipoUsuario.tLeyenda Or UserList(UserIndex).flags.is_donor > 0
     End With
 
    On Error GoTo 0


### PR DESCRIPTION
Add a new is_donor flag to t_UserFlags, load it from the database when loading a character, and treat contributors as patron-level users. Introduces GetUserContributionStatusFromAccountID to query account.is_donor, sets UserList(...).flags.is_donor during LoadCharacterFromDB (and promotes tipoUsuario to tLeyenda if donor), and updates IsPatreon to return true for users with is_donor > 0. Error logging and existing DB error handling are preserved.