### PR TITLE
Refactor HandleGovernorNpcInteraction with guard clauses

### DIFF
--- a/Codigo/WorldActions.bas
+++ b/Codigo/WorldActions.bas
@@ -291,63 +291,68 @@ Private Sub HandleFactionRecruiterNpcInteraction(ByVal UserIndex As Integer, ByV
     End If
 End Sub
 
+Private Function GetCityName(ByVal city As e_Ciudad) As String
+    Select Case city
+        Case e_Ciudad.cUllathorpe
+            GetCityName = "Ullathorpe"
+        Case e_Ciudad.cNix
+            GetCityName = "Nix"
+        Case e_Ciudad.cBanderbill
+            GetCityName = "Banderbill"
+        Case e_Ciudad.cLindos
+            GetCityName = "Lindos"
+        Case e_Ciudad.cArghal
+            GetCityName = "Arghal"
+        Case e_Ciudad.cForgat
+            GetCityName = "Forgat"
+        Case e_Ciudad.cEldoria
+            GetCityName = "Eldoria"
+        Case e_Ciudad.cArkhein
+            GetCityName = "Arkhein"
+        Case e_Ciudad.cPenthar
+            GetCityName = "Penthar"
+        Case Else
+            GetCityName = "Ullathorpe"
+    End Select
+End Function
+
 Private Sub HandleGovernorNpcInteraction(ByVal UserIndex As Integer, ByVal NpcIndex As Integer)
     If UserList(UserIndex).flags.Muerto = 1 Then
         'Msg77=¡¡Estás muerto!!.
         Call WriteLocaleMsg(UserIndex, MSG_MUERTO, e_FontTypeNames.FONTTYPE_INFOIAO)
         Exit Sub
     End If
+
     If Distancia(NpcList(NpcIndex).pos, UserList(UserIndex).pos) > 3 Then
         Call WriteLocaleMsg(UserIndex, MSG_SACERDOTE_PUEDE_CURARTE_DEBIDO_DEMASIADO_LEJOS, e_FontTypeNames.FONTTYPE_INFO)
         'Msg8=Estas demasiado lejos del gobernador.
         Exit Sub
     End If
+
     Dim DeDonde    As String
     Dim Gobernador As t_Npc
+
     Gobernador = NpcList(NpcIndex)
+
     If UserList(UserIndex).Hogar = Gobernador.GobernadorDe Then
         Call WriteLocaleChatOverHead(UserIndex, 1349, "", Gobernador.Char.charindex, vbWhite) ' Msg1349=Ya perteneces a esta ciudad. Gracias por ser uno más de nosotros.
         Exit Sub
     End If
-    If UserList(UserIndex).Faccion.Status = 0 Or UserList(UserIndex).Faccion.Status = 2 Then
-        If Gobernador.GobernadorDe = e_Ciudad.cBanderbill Then
-            Call WriteLocaleChatOverHead(UserIndex, "1350", "", Gobernador.Char.charindex, vbWhite) ' Msg1350=Aquí no aceptamos criminales.
-            Exit Sub
-        End If
+
+    If (UserList(UserIndex).Faccion.Status = 0 Or UserList(UserIndex).Faccion.Status = 2) And Gobernador.GobernadorDe = e_Ciudad.cBanderbill Then
+        Call WriteLocaleChatOverHead(UserIndex, "1350", "", Gobernador.Char.charindex, vbWhite) ' Msg1350=Aquí no aceptamos criminales.
+        Exit Sub
     End If
-    If UserList(UserIndex).Faccion.Status = 3 Or UserList(UserIndex).Faccion.Status = 1 Then
-        If Gobernador.GobernadorDe = e_Ciudad.cArkhein Then
-            Call WriteLocaleChatOverHead(UserIndex, "1351", "", Gobernador.Char.charindex, vbWhite) ' Msg1351=¡¡Sal de aquí ciudadano asqueroso!!
-            Exit Sub
-        End If
+
+    If (UserList(UserIndex).Faccion.Status = 3 Or UserList(UserIndex).Faccion.Status = 1) And Gobernador.GobernadorDe = e_Ciudad.cArkhein Then
+        Call WriteLocaleChatOverHead(UserIndex, "1351", "", Gobernador.Char.charindex, vbWhite) ' Msg1351=¡¡Sal de aquí ciudadano asqueroso!!
+        Exit Sub
     End If
-    If UserList(UserIndex).Hogar <> Gobernador.GobernadorDe Then
-        UserList(UserIndex).PosibleHogar = Gobernador.GobernadorDe
-        Select Case UserList(UserIndex).PosibleHogar
-            Case e_Ciudad.cUllathorpe
-                DeDonde = "Ullathorpe"
-            Case e_Ciudad.cNix
-                DeDonde = "Nix"
-            Case e_Ciudad.cBanderbill
-                DeDonde = "Banderbill"
-            Case e_Ciudad.cLindos
-                DeDonde = "Lindos"
-            Case e_Ciudad.cArghal
-                DeDonde = "Arghal"
-            Case e_Ciudad.cForgat
-                DeDonde = "Forgat"
-            Case e_Ciudad.cEldoria
-                DeDonde = "Eldoria"
-            Case e_Ciudad.cArkhein
-                DeDonde = "Arkhein"
-            Case e_Ciudad.cPenthar
-                DeDonde = "Penthar"
-            Case Else
-                DeDonde = "Ullathorpe"
-        End Select
-        UserList(UserIndex).flags.pregunta = 3
-        Call WritePreguntaBox(UserIndex, 1592, DeDonde)
-    End If
+
+    UserList(UserIndex).PosibleHogar = Gobernador.GobernadorDe
+    DeDonde = GetCityName(UserList(UserIndex).PosibleHogar)
+    UserList(UserIndex).flags.pregunta = 3
+    Call WritePreguntaBox(UserIndex, 1592, DeDonde)
 End Sub
 
 Private Sub HandleFishingDeliveryNpcInteraction(ByVal UserIndex As Integer, ByVal NpcIndex As Integer)


### PR DESCRIPTION
### Motivation

- Make `HandleGovernorNpcInteraction` easier to read and maintain by flattening nested conditionals into guard clauses while preserving the original control flow and behavior. 
- Isolate the city-name mapping into a small helper to remove an inline `Select Case` and reduce cognitive load when reading the handler. 

### Description

- Added a helper function `GetCityName(ByVal city As e_Ciudad) As String` that contains the original city-to-string mapping exactly as before, including the default case. 
- Reworked `HandleGovernorNpcInteraction` to use guard-style early exits for the dead check, distance check, same-home check, and faction rejection checks while preserving message IDs, strings, check ordering, and `flags.pregunta` behavior. 
- Replaced the inline `Select Case` mapping with `DeDonde = GetCityName(UserList(UserIndex).PosibleHogar)` and left all side-effects (assignment of `PosibleHogar`, `flags.pregunta`, and `WritePreguntaBox`) intact. 

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc15a043cc8328b72ae759455b1947)