### PR TITLE
Use EquippedWorkingToolObjIndex in tool checks

### DIFF
--- a/Codigo/ModLumberjack.bas
+++ b/Codigo/ModLumberjack.bas
@@ -79,7 +79,7 @@ Public Function CanUserExtractWood(ByVal UserIndex As Integer, ByVal TargetX As 
     With UserList(UserIndex)
         If .invent.EquippedWorkingToolObjIndex <= 0 Then Exit Function
         If ObjData(MapData(.pos.Map, TargetX, TargetY).ObjInfo.ObjIndex).Elfico > 0 Then
-            If Not ObjData(.invent.EquippedWeaponObjIndex).Elfico > 0 Then
+            If Not ObjData(.invent.EquippedWorkingToolObjIndex).Elfico > 0 Then
                 Call WriteLocaleMsg(UserIndex, MSG_ONLY_ELVISH_AXE_ALLOWED, FONTTYPE_INFO)
                 Exit Function
             End If

--- a/Codigo/ModMining.bas
+++ b/Codigo/ModMining.bas
@@ -23,8 +23,8 @@ Public Const BLODIUM_PICKAXE_REQUIRED_MSG As Integer = 597
 Public Function CanUserExtractMinerals(ByVal UserIndex As Integer, ByVal TargetX As Byte, ByVal TargetY As Byte) As Boolean
     With UserList(UserIndex)
         If .invent.EquippedWorkingToolObjIndex <= 0 Then Exit Function
-        If ObjData(MapData(.pos.Map, TargetX, TargetY).ObjInfo.ObjIndex).Blodium Then
-            If Not ObjData(.invent.EquippedWorkingToolObjIndex).Blodium Then
+        If ObjData(MapData(.pos.Map, TargetX, TargetY).ObjInfo.ObjIndex).Blodium > 0 Then
+            If Not ObjData(.invent.EquippedWorkingToolObjIndex).Blodium > 0 Then
                 Call WriteLocaleMsg(UserIndex, BLODIUM_PICKAXE_REQUIRED_MSG, FONTTYPE_INFO)
                 Exit Function
             End If

--- a/Codigo/ModMining.bas
+++ b/Codigo/ModMining.bas
@@ -24,7 +24,7 @@ Public Function CanUserExtractMinerals(ByVal UserIndex As Integer, ByVal TargetX
     With UserList(UserIndex)
         If .invent.EquippedWorkingToolObjIndex <= 0 Then Exit Function
         If ObjData(MapData(.pos.Map, TargetX, TargetY).ObjInfo.ObjIndex).Blodium Then
-            If Not ObjData(.invent.EquippedWeaponObjIndex).Blodium Then
+            If Not ObjData(.invent.EquippedWorkingToolObjIndex).Blodium Then
                 Call WriteLocaleMsg(UserIndex, BLODIUM_PICKAXE_REQUIRED_MSG, FONTTYPE_INFO)
                 Exit Function
             End If


### PR DESCRIPTION
Fix incorrect property checks in CanUserExtractWood and CanUserExtractMinerals: the code previously inspected EquippedWeaponObjIndex when validating tool-specific properties (Elfico/Blodium), causing wrong rejections. Replace those references with EquippedWorkingToolObjIndex so the correct equipped tool is validated before showing the error message and exiting.