### PR TITLE
Reduce [Hide] packet Limit to 100

### DIFF
--- a/PacketRatePolicy.ini
+++ b/PacketRatePolicy.ini
@@ -61,7 +61,7 @@ Limit=94
 Iterations=3
 
 [Hide]
-Limit=225
+Limit=100
 Iterations=2
 
 


### PR DESCRIPTION
Update PacketRatePolicy.ini to lower the [Hide] section's Limit from 225 to 100. Iterations remains 2. This lessens the allowed packet rate for the Hide policy.