### PR TITLE
Validate headings and normalize rotation

### DIFF
--- a/Codigo/GameLogic.bas
+++ b/Codigo/GameLogic.bas
@@ -733,11 +733,19 @@ Sub GetHeadingRight(ByVal head As e_Heading, ByRef pos As t_WorldPos)
     pos.y = nY
 End Sub
 
-' Autor: WyroX - 20/01/2021
-' Retorna el heading recibo como parámetro pero rotado, según el valor R.
-' Si R es 1, rota en sentido horario. Si R es -1, en sentido antihorario.
 Function Rotate_Heading(ByVal Heading As e_Heading, ByVal r As Integer) As e_Heading
-    Rotate_Heading = (Heading + r + 3) Mod 4 + 1
+    ' Validate input to prevent overflow
+    If Heading < 1 Then Heading = 1
+    If Heading > 4 Then Heading = 4
+    
+    ' Normalize r to -1, 0, or 1
+    If r > 0 Then r = 1
+    If r < 0 Then r = -1
+    
+    ' Calculate new heading (1-4 range)
+    Dim result As Integer
+    result = ((Heading - 1 + r + 4) Mod 4) + 1
+    Rotate_Heading = result
 End Function
 
 Function LegalPos(ByVal Map As Integer, _

--- a/Codigo/MODULO_NPCs.bas
+++ b/Codigo/MODULO_NPCs.bas
@@ -1746,22 +1746,35 @@ Sub WarpNpcChar(ByVal NpcIndex As Integer, ByVal Map As Byte, ByVal x As Integer
     End If
 End Sub
 
-' Autor: WyroX - 20/01/2021
-' Intenta moverlo hacia un "costado" según el heading indicado. Se usa para mover NPCs del camino de otro char.
-' Si no hay un lugar válido a los lados, lo mueve a la posición válida más cercana.
 Sub MoveNpcToSide(ByVal NpcIndex As Integer, ByVal Heading As e_Heading)
     On Error GoTo Handler
     With NpcList(NpcIndex)
+        ' Validate heading parameter
+        If Heading < e_Heading.NORTH Or Heading > e_Heading.WEST Then
+            Call LogError("MoveNpcToSide: Invalid heading " & Heading & " for NPC " & NpcIndex)
+            Exit Sub
+        End If
+        
         ' Elegimos un lado al azar
         Dim r As Integer
         r = RandomNumber(0, 1) * 2 - 1 ' -1 o 1
+        
         ' Roto el heading original hacia ese lado
         Heading = Rotate_Heading(Heading, r)
+        
         ' Intento moverlo para ese lado
         If MoveNPCChar(NpcIndex, Heading) Then Exit Sub
+        
         ' Si falló, intento moverlo para el lado opuesto
         Heading = InvertHeading(Heading)
+        
+        ' Validate after invert
+        If Heading < e_Heading.NORTH Or Heading > e_Heading.WEST Then
+            Heading = e_Heading.NORTH ' Fallback to default
+        End If
+        
         If MoveNPCChar(NpcIndex, Heading) Then Exit Sub
+        
         ' Si ambos fallan, entonces lo dejo en la posición válida más cercana
         Dim NuevaPos As t_WorldPos
         Call ClosestLegalPos(.pos, NuevaPos, .flags.AguaValida, .flags.TierraInvalida = 0)
@@ -1769,7 +1782,7 @@ Sub MoveNpcToSide(ByVal NpcIndex As Integer, ByVal Heading As e_Heading)
     End With
     Exit Sub
 Handler:
-    Call TraceError(Err.Number, Err.Description, "NPCs.MoveNpcToSide", Erl)
+    Call TraceError(Err.Number, Err.Description, "NPCs.MoveNpcToSide [Heading=" & Heading & "]", Erl)
 End Sub
 
 Public Sub DummyTargetAttacked(ByVal NpcIndex As Integer)


### PR DESCRIPTION
Add input validation and normalization for heading rotation and NPC side movement. Rotate_Heading now clamps Heading to 1-4, normalizes r to -1/0/1 and uses a safer calculation to produce a 1-4 result. MoveNpcToSide now validates the incoming Heading, logs and exits on invalid values, ensures the rotated/inverted heading stays valid with a fallback, and includes the Heading in the TraceError call for better diagnostics. These changes improve robustness and error logging for heading-related operations.

6 - Error number: 6 | Description: Overflow
Component: NPCs.MoveNpcToSide | Line number: 0