### PR TITLE
Use UserMod.DoDamageOrHeal for life-steal

### DIFF
--- a/Codigo/SistemaCombate.bas
+++ b/Codigo/SistemaCombate.bas
@@ -408,7 +408,7 @@ Private Sub UserDamageNpc(ByVal UserIndex As Integer, ByVal NpcIndex As Integer,
             Dim Calc As Long
             Calc = Damage * WarriorLifeStealOnHitMultiplier
             If Calc >= .Stats.MaxHp Then
-                Calc = .Stats.MaxHp´
+                Calc = .Stats.MaxHp
             End If
             Call UserMod.DoDamageOrHeal(UserIndex, UserIndex, eUser, Calc, e_phisical, UserIndex)
         End If

--- a/Codigo/SistemaCombate.bas
+++ b/Codigo/SistemaCombate.bas
@@ -408,13 +408,9 @@ Private Sub UserDamageNpc(ByVal UserIndex As Integer, ByVal NpcIndex As Integer,
             Dim Calc As Long
             Calc = Damage * WarriorLifeStealOnHitMultiplier
             If Calc >= .Stats.MaxHp Then
-                .Stats.MinHp = .Stats.MaxHp
-            Else
-                .Stats.MinHp = .Stats.MinHp + Calc
+                Calc = .Stats.MaxHp´
             End If
-            Call WriteUpdateHP(UserIndex)
-            'no wrapper senddata because of extra params
-            Call modSendData.SendData(ToIndex, UserIndex, PrepareMessageTextOverTile(Calc, .pos.x, .pos.y, vbGreen, 1300, -10, True))
+            Call UserMod.DoDamageOrHeal(UserIndex, UserIndex, eUser, Calc, e_phisical, UserIndex)
         End If
         ' Golpe crítico
         If PuedeGolpeCritico(UserIndex) Then


### PR DESCRIPTION
Replace direct Stats.MinHp mutation and manual SendData/WriteUpdateHP calls with a single UserMod.DoDamageOrHeal invocation in UserDamageNpc. The calculated life-steal amount (Calc) is capped to the target's MaxHp and passed to DoDamageOrHeal so HP changes and notifications are handled centrally.