### PR TITLE
fix(ciudades): derivar NUMCIUDADES desde e_Ciudad

### DIFF
--- a/Codigo/Declares.bas
+++ b/Codigo/Declares.bas
@@ -347,6 +347,7 @@ Public Enum e_Ciudad
     cEldoria
     cPenthar
     cMorgrim
+    cCiudadCount
 End Enum
 
 Public Enum e_Raza

--- a/Codigo/Hogar.bas
+++ b/Codigo/Hogar.bas
@@ -27,7 +27,8 @@ Attribute VB_Name = "Hogar"
 '
 '
 Option Explicit
-Public Const NUMCIUDADES          As Byte = 10
+' NUMCIUDADES se deriva de e_Ciudad; no actualizar manualmente.
+Public Const NUMCIUDADES          As Byte = cCiudadCount - 1
 Public Ciudades(1 To NUMCIUDADES) As t_WorldPos
 
 Public Sub goHome(ByVal UserIndex As Integer)


### PR DESCRIPTION
### Motivation
- Prevent array breakage when adding new cities by making the city count authoritative in the enum rather than a separately maintained constant.
- Keep all existing city numeric values stable so adding entries does not renumber existing cities.

### Description
- Add a sentinel `cCiudadCount` at the end of `e_Ciudad` in `Codigo/Declares.bas` without renumbering any existing city entries.
- Replace the manual `NUMCIUDADES` value in `Codigo/Hogar.bas` with `Public Const NUMCIUDADES As Byte = cCiudadCount - 1` and add a short comment (in Spanish) indicating the value is derived and should not be updated manually.
- Make no other runtime or control-flow changes and do not refactor `CargarCiudades` or existing city `Select Case` blocks.


------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd082bac4c8328b180eec06d483962)