### PR TITLE
refactor(ciudades): renombrar NUMCIUDADES a CITY_COUNT

### DIFF
--- a/Codigo/Hogar.bas
+++ b/Codigo/Hogar.bas
@@ -27,9 +27,9 @@ Attribute VB_Name = "Hogar"
 '
 '
 Option Explicit
-' NUMCIUDADES se deriva de e_Ciudad; no actualizar manualmente.
-Public Const NUMCIUDADES          As Byte = cCiudadCount - 1
-Public Ciudades(1 To NUMCIUDADES) As t_WorldPos
+' CITY_COUNT is derived from e_Ciudad; do not update manually.
+Public Const CITY_COUNT As Byte = cCiudadCount - 1
+Public Ciudades(1 To CITY_COUNT) As t_WorldPos
 
 Public Sub goHome(ByVal UserIndex As Integer)
     On Error GoTo goHome_Err

--- a/Codigo/TCP.bas
+++ b/Codigo/TCP.bas
@@ -463,7 +463,7 @@ Function ConnectNewUser(ByVal UserIndex As Integer, _
         ' Género válido
         If UserSexo < Hombre Or UserSexo > Mujer Then Exit Function
         ' Ciudad válida
-        If Hogar <= 0 Or Hogar > NUMCIUDADES Then Exit Function
+        If Hogar <= 0 Or Hogar > CITY_COUNT Then Exit Function
         ' Cabeza válida
 #If LOGIN_STRESS_TEST = 0 Then
         If Not ValidarCabeza(UserRaza, UserSexo, head) Then Exit Function


### PR DESCRIPTION
### Motivation
- Standardize the city-count constant name to English and align it with the enum-based count derived from `e_Ciudad` without changing runtime logic.

### Description
- Define the constant exactly as `Public Const CITY_COUNT As Byte = cCiudadCount - 1` and update the city positions array to `Public Ciudades(1 To CITY_COUNT) As t_WorldPos` in `Codigo/Hogar.bas`.
- Replace usages of `NUMCIUDADES` with `CITY_COUNT`, including the new-character city bounds check in `Codigo/TCP.bas` (`If Hogar <= 0 Or Hogar > CITY_COUNT Then Exit Function`).
- No other logic or behavior was modified; the enum-derived expression `cCiudadCount - 1` is unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd0a0b2c58832884da2c7409af4b8d)