### PR TITLE
Show remaining jail minutes in user punishment listings

### DIFF
--- a/Codigo/modDatabase.bas
+++ b/Codigo/modDatabase.bas
@@ -633,9 +633,17 @@ End Sub
 Public Function GetUserCurrentJailMinutesDatabase(ByVal username As String) As Long
     On Error GoTo ErrorHandler
     Dim RS As ADODB.Recordset
+    Dim TargetUser As t_UserReference
 
-    ' Leemos counter_pena desde user porque representa el tiempo de carcel
-    ' pendiente real al momento de consultar el informe.
+    ' Si el usuario esta online, usamos el contador en memoria porque es el valor
+    ' mas actualizado (la DB puede quedar atrasada hasta el proximo guardado).
+    TargetUser = NameIndex(username)
+    If IsValidUserRef(TargetUser) Then
+        GetUserCurrentJailMinutesDatabase = UserList(TargetUser.ArrayIndex).Counters.Pena
+        Exit Function
+    End If
+
+    ' Para usuarios offline, usamos el valor persistido en DB.
     Set RS = Query("SELECT counter_pena FROM `user` WHERE UPPER(name) = ?;", UCase$(username))
     If RS Is Nothing Then Exit Function
     If RS.RecordCount = 0 Then Exit Function

--- a/Codigo/modDatabase.bas
+++ b/Codigo/modDatabase.bas
@@ -601,11 +601,27 @@ End Function
 Public Sub SendUserPunishmentsDatabase(ByVal UserIndex As Integer, ByVal username As String)
     On Error GoTo ErrorHandler
     Dim RS As ADODB.Recordset
+    Dim JailMinutes As Long
+    Dim Reason As String
+
+    ' Obtenemos la pena activa actual para mostrar en el informe
+    ' cuanto tiempo de carcel le queda cumplir al usuario.
+    JailMinutes = GetUserCurrentJailMinutesDatabase(username)
+
     Set RS = Query("SELECT user_id, number, reason FROM `punishment` INNER JOIN `user` ON punishment.user_id = user.id WHERE UPPER(user.name) = ?;", UCase$(username))
     If RS Is Nothing Then Exit Sub
+
     If Not RS.RecordCount = 0 Then
         While Not RS.EOF
-            Call WriteConsoleMsg(UserIndex, RS!Number & " - " & RS!Reason, e_FontTypeNames.FONTTYPE_INFO)
+            Reason = RS!Reason
+
+            ' Solo anexamos el tiempo restante cuando la pena es de carcel y
+            ' todavia hay minutos por cumplir, para no ensuciar otras sanciones.
+            If JailMinutes > 0 And InStr(1, UCase$(Reason), "CARCEL", vbTextCompare) > 0 Then
+                Reason = Reason & " | TIEMPO RESTANTE: " & JailMinutes & " minutos"
+            End If
+
+            Call WriteConsoleMsg(UserIndex, RS!Number & " - " & Reason, e_FontTypeNames.FONTTYPE_INFO)
             RS.MoveNext
         Wend
     End If
@@ -613,6 +629,22 @@ Public Sub SendUserPunishmentsDatabase(ByVal UserIndex As Integer, ByVal usernam
 ErrorHandler:
     Call LogDatabaseError("Error in SendUserPunishmentsDatabase: " & username & ". " & Err.Number & " - " & Err.Description)
 End Sub
+
+Public Function GetUserCurrentJailMinutesDatabase(ByVal username As String) As Long
+    On Error GoTo ErrorHandler
+    Dim RS As ADODB.Recordset
+
+    ' Leemos counter_pena desde user porque representa el tiempo de carcel
+    ' pendiente real al momento de consultar el informe.
+    Set RS = Query("SELECT counter_pena FROM `user` WHERE UPPER(name) = ?;", UCase$(username))
+    If RS Is Nothing Then Exit Function
+    If RS.RecordCount = 0 Then Exit Function
+
+    GetUserCurrentJailMinutesDatabase = SanitizeNullValue(RS!counter_pena, 0)
+    Exit Function
+ErrorHandler:
+    Call LogDatabaseError("Error in GetUserCurrentJailMinutesDatabase: " & username & ". " & Err.Number & " - " & Err.Description)
+End Function
 
 Public Function GetUserGuildIndexDatabase(ByVal CharId As Long) As Integer
     On Error GoTo ErrorHandler


### PR DESCRIPTION
### Motivation
- Improve punishment reports so staff can see how much jail time a user still has to serve when viewing their punishments.

### Description
- Add `GetUserCurrentJailMinutesDatabase` which queries `counter_pena` from `user` to retrieve the remaining jail minutes. 
- Update `SendUserPunishmentsDatabase` to compute `JailMinutes` and append "| TIEMPO RESTANTE: X minutos" to the punishment `Reason` when the reason contains "CARCEL" and `JailMinutes` is greater than zero. 
- Introduce local `Reason` and `JailMinutes` variables and preserve existing behavior for non-jail punishments.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff493bc1a48328ab7bbd9431b8a27a)