### PR TITLE
Preserve punishment records in DB and show dynamic remaining jail time when listing punishments

### DIFF
--- a/Codigo/Protocol_GmCommands.bas
+++ b/Codigo/Protocol_GmCommands.bas
@@ -899,10 +899,13 @@ Public Sub HandleJail(ByVal UserIndex As Integer)
                         If (InStrB(username, "/") <> 0) Then
                             username = Replace(username, "/", "")
                         End If
+                        Call Encarcelar(tUser.ArrayIndex, jailTime, .name)
                         If PersonajeExiste(username) Then
+                            ' Se conserva el formato historico de la pena en DB.
+                            ' El tiempo restante se calcula y agrega solo al mostrar /penas,
+                            ' para evitar persistir un valor que cambia minuto a minuto.
                             Call SavePenaDatabase(username, .name & ": CARCEL " & jailTime & "m, MOTIVO: " & Reason & " " & Date & " " & Time)
                         End If
-                        Call Encarcelar(tUser.ArrayIndex, jailTime, .name)
                         Call LogGM(GetUserRealName(UserIndex), " encarceló a " & username)
                     End If
                 End If

--- a/Codigo/modDatabase.bas
+++ b/Codigo/modDatabase.bas
@@ -604,8 +604,23 @@ Public Sub SendUserPunishmentsDatabase(ByVal UserIndex As Integer, ByVal usernam
     Set RS = Query("SELECT user_id, number, reason FROM `punishment` INNER JOIN `user` ON punishment.user_id = user.id WHERE UPPER(user.name) = ?;", UCase$(username))
     If RS Is Nothing Then Exit Sub
     If Not RS.RecordCount = 0 Then
+        ' Buscamos al usuario en memoria para poder calcular y mostrar el tiempo
+        ' restante real de carcel sin modificar lo guardado en la base de datos.
+        Dim tUser As t_UserReference
+        tUser = NameIndex(username)
         While Not RS.EOF
-            Call WriteConsoleMsg(UserIndex, RS!Number & " - " & RS!Reason, e_FontTypeNames.FONTTYPE_INFO)
+            Dim punishmentLine As String
+            ' Se muestra primero exactamente el texto historico persistido en DB.
+            punishmentLine = RS!Number & " - " & RS!Reason
+            If IsValidUserRef(tUser) Then
+                ' Solo agregamos el sufijo dinamico si:
+                ' 1) el usuario esta online, 2) sigue cumpliendo pena, y
+                ' 3) la entrada corresponde a una carcel.
+                If UserList(tUser.ArrayIndex).Counters.Pena > 0 And InStr(1, UCase$(punishmentLine), "CARCEL", vbTextCompare) > 0 Then
+                    punishmentLine = punishmentLine & ": RESTAN CUMPLIR: " & UserList(tUser.ArrayIndex).Counters.Pena & "m"
+                End If
+            End If
+            Call WriteConsoleMsg(UserIndex, punishmentLine, e_FontTypeNames.FONTTYPE_INFO)
             RS.MoveNext
         Wend
     End If


### PR DESCRIPTION
### Motivation
- Prevent persisting a changing remaining-jail-time value in the punishment DB and retain the original historical sentence text. 
- Provide a dynamic remaining-time suffix when an online punished user is queried with `/penas` without modifying the stored record.
- Fix the jail flow to avoid duplicate/ordering issues when applying jail and saving the punishment entry.

### Description
- In `HandleJail` moved the call to `Encarcelar(tUser.ArrayIndex, jailTime, .name)` before saving the punishment and removed the duplicate call, and only save the DB entry if `PersonajeExiste(username)`; the saved string preserves the historical format with `.name & ": CARCEL " & jailTime & "m, MOTIVO: " & Reason & " " & Date & " " & Time`.
- In `SendUserPunishmentsDatabase` added an in-memory lookup `tUser = NameIndex(username)` and build `punishmentLine` from the persisted `RS!Reason`; if the user is online and currently serving a jail (`UserList(...).Counters.Pena > 0`) and the persisted line contains `"CARCEL"` then append the dynamic suffix `": RESTAN CUMPLIR: <minutes>m"` before displaying.
- Added explanatory comments and local variables to clarify that the DB keeps the historical text and the remaining time is computed only for display.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a009754532c8328b9b7af218366651f)