### PR TITLE
refactor: rename e_Ciudad -> e_City and Ciudades -> Cities

### DIFF
--- a/Codigo/Declares.bas
+++ b/Codigo/Declares.bas
@@ -336,7 +336,7 @@ Public Enum e_Class
     Bandit      'Bandido
 End Enum
 
-Public Enum e_Ciudad
+Public Enum e_City
     cUllathorpe = 1
     cNix
     cBanderbill
@@ -2959,8 +2959,8 @@ Public Type t_User
     raza As e_Raza
     genero As e_Genero
     Email As String
-    Hogar As e_Ciudad
-    PosibleHogar As e_Ciudad
+    Hogar As e_City
+    PosibleHogar As e_City
     MENSAJEINFORMACION As String
     invent As t_Inventario
     Invent_bk As t_Inventario

--- a/Codigo/FileIO.bas
+++ b/Codigo/FileIO.bas
@@ -1914,8 +1914,8 @@ LoadPacketRatePolicy_Err:
     Call TraceError(Err.Number, Err.Description, "ES.LoadPacketRatePolicy", Erl)
 End Sub
 
-' Centralizes city INI parsing and keeps Ciudades() synchronized for legacy callers.
-Private Sub LoadCityData(ByRef Lector As clsIniManager, ByVal CityId As e_Ciudad, ByVal SectionName As String)
+' Centralizes city INI parsing and keeps Cities() synchronized for legacy callers.
+Private Sub LoadCityData(ByRef Lector As clsIniManager, ByVal CityId As e_City, ByVal SectionName As String)
     Dim ErrorMessage As String
 
     With CityData(CityId)
@@ -1948,9 +1948,9 @@ Private Sub LoadCityData(ByRef Lector As clsIniManager, ByVal CityId As e_Ciudad
         End If
     End With
 
-    Ciudades(CityId).Map = CityData(CityId).Map
-    Ciudades(CityId).X = CityData(CityId).X
-    Ciudades(CityId).Y = CityData(CityId).Y
+    Cities(CityId).Map = CityData(CityId).Map
+    Cities(CityId).X = CityData(CityId).X
+    Cities(CityId).Y = CityData(CityId).Y
 End Sub
 
 Private Sub ValidateCities()
@@ -1961,7 +1961,7 @@ Private Sub ValidateCities()
     ' surfaced in the IDE via Debug.Assert instead of causing silent gameplay
     ' failures when new cities are added. Validation is intentionally non-fatal
     ' so startup/CI can continue and report all invalid city entries.
-    ' CITY_COUNT is derived from e_Ciudad, so every enum city must have a
+    ' CITY_COUNT is derived from e_City, so every enum city must have a
     ' synchronized CityData entry loaded with valid Map/X/Y coordinates.
     For CityIndex = 1 To CITY_COUNT
         If Not IsValidCity(CityIndex) Then
@@ -1985,16 +1985,16 @@ Sub CargarCiudades()
     Set Lector = New clsIniManager
     Call Lector.Initialize(DatPath & "Ciudades.dat")
     Dim MapasCiudades As String
-    Call LoadCityData(Lector, e_Ciudad.cUllathorpe, "Ullathorpe")
-    Call LoadCityData(Lector, e_Ciudad.cNix, "NIX")
-    Call LoadCityData(Lector, e_Ciudad.cBanderbill, "Banderbill")
-    Call LoadCityData(Lector, e_Ciudad.cLindos, "Lindos")
-    Call LoadCityData(Lector, e_Ciudad.cArghal, "Arghal")
-    Call LoadCityData(Lector, e_Ciudad.cArkhein, "Arkhein")
-    Call LoadCityData(Lector, e_Ciudad.cForgat, "Forgat")
-    Call LoadCityData(Lector, e_Ciudad.cEldoria, "Eldoria")
-    Call LoadCityData(Lector, e_Ciudad.cPenthar, "Penthar")
-    Call LoadCityData(Lector, e_Ciudad.cMorgrim, "Morgrim")
+    Call LoadCityData(Lector, e_City.cUllathorpe, "Ullathorpe")
+    Call LoadCityData(Lector, e_City.cNix, "NIX")
+    Call LoadCityData(Lector, e_City.cBanderbill, "Banderbill")
+    Call LoadCityData(Lector, e_City.cLindos, "Lindos")
+    Call LoadCityData(Lector, e_City.cArghal, "Arghal")
+    Call LoadCityData(Lector, e_City.cArkhein, "Arkhein")
+    Call LoadCityData(Lector, e_City.cForgat, "Forgat")
+    Call LoadCityData(Lector, e_City.cEldoria, "Eldoria")
+    Call LoadCityData(Lector, e_City.cPenthar, "Penthar")
+    Call LoadCityData(Lector, e_City.cMorgrim, "Morgrim")
 
     MapasCiudades = Lector.GetValue("NIX", "Mapas") & "," _
         & Lector.GetValue("Ullathorpe", "Mapas") & "," _

--- a/Codigo/Hogar.bas
+++ b/Codigo/Hogar.bas
@@ -27,17 +27,17 @@ Attribute VB_Name = "Hogar"
 '
 '
 Option Explicit
-' CITY_COUNT is derived from e_Ciudad; do not update manually.
+' CITY_COUNT is derived from e_City; do not update manually.
 Public Const CITY_COUNT As Byte = cCiudadCount - 1
 ' CityData() is the canonical city configuration store.
-' Ciudades() is the compatibility projection for indexed Map/X/Y lookups.
+' Cities() is the compatibility projection for indexed Map/X/Y lookups.
 ' CityNames() is populated from LoadCityData for diagnostics/display.
 ' Per-city globals were intentionally removed to simplify adding new cities.
 Public CityData(1 To CITY_COUNT) As t_CityData
 Public CityNames(1 To CITY_COUNT) As String
-Public Ciudades(1 To CITY_COUNT) As t_WorldPos
+Public Cities(1 To CITY_COUNT) As t_WorldPos
 
-Public Function IsValidCity(ByVal CityId As e_Ciudad) As Boolean
+Public Function IsValidCity(ByVal CityId As e_City) As Boolean
     If CityId < 1 Or CityId > CITY_COUNT Then Exit Function
 
     With CityData(CityId)
@@ -118,15 +118,15 @@ Public Sub HomeArrival(ByVal UserIndex As Integer)
             'Le sacamos el navegando, pero no le mostramos a los demas porque va a ser sumoneado hasta ulla.
         End If
         If IsValidCity(.Hogar) Then
-            ' Ciudades() centralizes home Map/X/Y lookup.
-            tX = Ciudades(.Hogar).x
-            tY = Ciudades(.Hogar).y
-            tMap = Ciudades(.Hogar).Map
+            ' Cities() centralizes home Map/X/Y lookup.
+            tX = Cities(.Hogar).x
+            tY = Cities(.Hogar).y
+            tMap = Cities(.Hogar).Map
         Else
             Call LogError("Invalid home city. UserIndex=" & UserIndex & " Hogar=" & .Hogar)
-            tX = Ciudades(e_Ciudad.cUllathorpe).x
-            tY = Ciudades(e_Ciudad.cUllathorpe).y
-            tMap = Ciudades(e_Ciudad.cUllathorpe).Map
+            tX = Cities(e_City.cUllathorpe).x
+            tY = Cities(e_City.cUllathorpe).y
+            tMap = Cities(e_City.cUllathorpe).Map
         End If
         Call FindLegalPos(UserIndex, tMap, CByte(tX), CByte(tY))
         Call WarpUserChar(UserIndex, tMap, tX, tY, True)

--- a/Codigo/InvUsuario.bas
+++ b/Codigo/InvUsuario.bas
@@ -2171,11 +2171,11 @@ Sub UseInvItem(ByVal UserIndex As Integer, ByVal Slot As Byte, ByVal ByClick As 
                         Dim DeDonde As t_WorldPos
                         Call QuitarUserInvItem(UserIndex, Slot, 1)
                         If IsValidCity(.Hogar) Then
-                            ' Ciudades() centralizes city Map/X/Y lookup; avoid duplicated enum mappings.
-                            DeDonde = Ciudades(.Hogar)
+                            ' Cities() centralizes city Map/X/Y lookup; avoid duplicated enum mappings.
+                            DeDonde = Cities(.Hogar)
                         Else
                             Call LogError("Invalid home city. UserIndex=" & UserIndex & " Hogar=" & .Hogar)
-                            DeDonde = Ciudades(e_Ciudad.cUllathorpe)
+                            DeDonde = Cities(e_City.cUllathorpe)
                         End If
                         Map = DeDonde.Map
                         x = DeDonde.x

--- a/Codigo/Modulo_UsUaRiOs.bas
+++ b/Codigo/Modulo_UsUaRiOs.bas
@@ -501,24 +501,24 @@ Dim tStr                        As String
         .Counters.TiempoDeInmunidad = IntervaloPuedeSerAtacado
         .Counters.TiempoDeInmunidadParalisisNoMagicas = 0
 
-        Dim HomeCityId As e_Ciudad
+        Dim HomeCityId As e_City
         HomeCityId = .Hogar
         If Not IsValidCity(HomeCityId) Then
             Call LogError("Invalid home city. UserIndex=" & UserIndex & " Hogar=" & .Hogar)
-            HomeCityId = e_Ciudad.cUllathorpe
+            HomeCityId = e_City.cUllathorpe
         End If
   
         If Not MapaValido(.pos.Map) Then
             Call WriteErrorMsg(UserIndex, "Your character was found on an illegal map, it has been teleported to the corresponding home")
-            .pos.Map = Ciudades(HomeCityId).Map
-            .pos.x = Ciudades(HomeCityId).x
-            .pos.y = Ciudades(HomeCityId).y
+            .pos.Map = Cities(HomeCityId).Map
+            .pos.x = Cities(HomeCityId).x
+            .pos.y = Cities(HomeCityId).y
         End If
         If MapInfo(.pos.Map).MapResource = 0 Then
             Call WriteErrorMsg(UserIndex, "Your character was found on an illegal map, it has been teleported to the corresponding home")
-            .pos.Map = Ciudades(HomeCityId).Map
-            .pos.x = Ciudades(HomeCityId).x
-            .pos.y = Ciudades(HomeCityId).y
+            .pos.Map = Cities(HomeCityId).Map
+            .pos.x = Cities(HomeCityId).x
+            .pos.y = Cities(HomeCityId).y
         End If
         If MapData(.pos.Map, .pos.x, .pos.y).UserIndex <> 0 Or MapData(.pos.Map, .pos.x, .pos.y).NpcIndex <> 0 Then
             Dim FoundPlace As Boolean
@@ -645,7 +645,7 @@ Dim tStr                        As String
                     Then
                 Call WarpToLegalPos(UserIndex, .flags.ReturnPos.Map, .flags.ReturnPos.x, .flags.ReturnPos.y, True)
             Else ' Lo mando a su hogar
-                Call WarpToLegalPos(UserIndex, Ciudades(HomeCityId).Map, Ciudades(HomeCityId).x, Ciudades(HomeCityId).y, True)
+                Call WarpToLegalPos(UserIndex, Cities(HomeCityId).Map, Cities(HomeCityId).x, Cities(HomeCityId).y, True)
             End If
         End If
         .flags.UserLogged = True
@@ -1510,7 +1510,7 @@ If IsValidCity(UserList(UserIndex).Hogar) Then
     char_home = CityNames(UserList(UserIndex).Hogar)
 Else
     Call LogError("Invalid home city. UserIndex=" & UserIndex & " Hogar=" & UserList(UserIndex).Hogar)
-    char_home = CityNames(e_Ciudad.cUllathorpe)
+    char_home = CityNames(e_City.cUllathorpe)
 End If
     Call WriteLocaleMsg(sendIndex, MSG_CHARACTER_HOME, e_FontTypeNames.FONTTYPE_INFO, char_home)
 

--- a/Codigo/Protocol.bas
+++ b/Codigo/Protocol.bas
@@ -1259,7 +1259,7 @@ Private Sub HandleLoginNewChar(ByVal ConnectionID As Long)
     Dim encrypted_username      As String
     Dim race                    As e_Raza
     Dim gender                  As e_Genero
-    Dim Hogar                   As e_Ciudad
+    Dim Hogar                   As e_City
     Dim Class                   As e_Class
     Dim head                    As Integer
 
@@ -1413,7 +1413,7 @@ Private Sub HandleLoginNewChar(ByVal UserIndex As Integer)
         Dim name As String
         Dim race     As e_Raza
         Dim gender   As e_Genero
-        Dim Hogar    As e_Ciudad
+        Dim Hogar    As e_City
         Dim Class As e_Class
         Dim head        As Integer
 
@@ -6689,7 +6689,7 @@ Private Sub HandleResponderPregunta(ByVal UserIndex As Integer)
                         DeDonde = CityNames(UserList(UserIndex).Hogar)
                     Else
                         Call LogError("Invalid home city. UserIndex=" & UserIndex & " Hogar=" & UserList(UserIndex).Hogar)
-                        DeDonde = CityNames(e_Ciudad.cUllathorpe)
+                        DeDonde = CityNames(e_City.cUllathorpe)
                     End If
                     If IsValidNpcRef(UserList(UserIndex).flags.TargetNPC) Then
                         Call WriteLocaleChatOverHead(UserIndex, 1421, GetUserDisplayName(UserIndex) & "¬" & DeDonde, NpcList(UserList( _
@@ -6778,7 +6778,7 @@ Private Sub HandleResponderPregunta(ByVal UserIndex As Integer)
                         DeDonde = CityNames(UserList(UserIndex).PosibleHogar)
                     Else
                         Call LogError("Invalid possible home city. UserIndex=" & UserIndex & " PosibleHogar=" & UserList(UserIndex).PosibleHogar)
-                        DeDonde = CityNames(e_Ciudad.cUllathorpe)
+                        DeDonde = CityNames(e_City.cUllathorpe)
                     End If
                     If IsValidNpcRef(UserList(UserIndex).flags.TargetNPC) Then
                         Call WriteLocaleChatOverHead(UserIndex, 1423, GetUserDisplayName(UserIndex) & "¬" & DeDonde, NpcList(UserList( _
@@ -6995,7 +6995,7 @@ Private Sub HandleCompletarViaje(ByVal UserIndex As Integer)
                 DeDonde = CityData(Destino)
             Else
                 Call LogError("Invalid travel destination city. UserIndex=" & UserIndex & " Destino=" & Destino)
-                DeDonde = CityData(e_Ciudad.cUllathorpe)
+                DeDonde = CityData(e_City.cUllathorpe)
             End If
             If DeDonde.NecesitaNave > 0 Then
                 If UserList(UserIndex).Stats.UserSkills(e_Skill.Navegacion) < 80 Then
@@ -7481,14 +7481,14 @@ Private Sub HandleHome(ByVal UserIndex As Integer)
             Exit Sub
         End If
         If .flags.Traveling = 0 Then
-            Dim HomeCityId As e_Ciudad
+            Dim HomeCityId As e_City
             HomeCityId = .Hogar
             If Not IsValidCity(HomeCityId) Then
                 Call LogError("Invalid home city. UserIndex=" & UserIndex & " Hogar=" & .Hogar)
-                HomeCityId = e_Ciudad.cUllathorpe
+                HomeCityId = e_City.cUllathorpe
             End If
 
-            If .pos.Map <> Ciudades(HomeCityId).Map Then
+            If .pos.Map <> Cities(HomeCityId).Map Then
                 
                 ' Costo en oro
                 Dim homeCostGLD As Long

--- a/Codigo/Protocol_GmCommands.bas
+++ b/Codigo/Protocol_GmCommands.bas
@@ -1257,17 +1257,17 @@ Public Sub HandleEditChar(ByVal UserIndex As Integer)
                 Arg1 = UCase$(Arg1)
                 Select Case Arg1
                     Case "NIX"
-                        UserList(tUser.ArrayIndex).Hogar = e_Ciudad.cNix
+                        UserList(tUser.ArrayIndex).Hogar = e_City.cNix
                     Case "ULLA", "ULLATHORPE"
-                        UserList(tUser.ArrayIndex).Hogar = e_Ciudad.cUllathorpe
+                        UserList(tUser.ArrayIndex).Hogar = e_City.cUllathorpe
                     Case "BANDER", "BANDERBILL"
-                        UserList(tUser.ArrayIndex).Hogar = e_Ciudad.cBanderbill
+                        UserList(tUser.ArrayIndex).Hogar = e_City.cBanderbill
                     Case "LINDOS"
-                        UserList(tUser.ArrayIndex).Hogar = e_Ciudad.cLindos
+                        UserList(tUser.ArrayIndex).Hogar = e_City.cLindos
                     Case "ARGHAL"
-                        UserList(tUser.ArrayIndex).Hogar = e_Ciudad.cArghal
+                        UserList(tUser.ArrayIndex).Hogar = e_City.cArghal
                     Case "ARKHEIN"
-                        UserList(tUser.ArrayIndex).Hogar = e_Ciudad.cArkhein
+                        UserList(tUser.ArrayIndex).Hogar = e_City.cArkhein
                 End Select
             Case e_EditOptions.eo_Alias
                 If Not IsUserAdmin(UserIndex) Then Exit Sub

--- a/Codigo/TCP.bas
+++ b/Codigo/TCP.bas
@@ -430,7 +430,7 @@ Function ConnectNewUser(ByVal UserIndex As Integer, _
                         ByVal UserSexo As e_Genero, _
                         ByVal UserClase As e_Class, _
                         ByVal head As Integer, _
-                        ByVal Hogar As e_Ciudad) As Boolean
+                        ByVal Hogar As e_City) As Boolean
     On Error GoTo ConnectNewUser_Err
     With UserList(UserIndex)
         Dim LoopC As Long
@@ -529,15 +529,15 @@ Function ConnectNewUser(ByVal UserIndex As Integer, _
         .ChatCombate = 1
         .ChatGlobal = 1
         If IsValidCity(.Hogar) Then
-            ' Ciudades() centralizes city Map/X/Y lookup; avoid duplicated enum mappings.
-            .pos.Map = Ciudades(.Hogar).Map
-            .pos.x = Ciudades(.Hogar).x
-            .pos.y = Ciudades(.Hogar).y
+            ' Cities() centralizes city Map/X/Y lookup; avoid duplicated enum mappings.
+            .pos.Map = Cities(.Hogar).Map
+            .pos.x = Cities(.Hogar).x
+            .pos.y = Cities(.Hogar).y
         Else
             Call LogError("Invalid home city while creating user. UserIndex=" & UserIndex & " Hogar=" & .Hogar)
-            .pos.Map = Ciudades(e_Ciudad.cUllathorpe).Map
-            .pos.x = Ciudades(e_Ciudad.cUllathorpe).x
-            .pos.y = Ciudades(e_Ciudad.cUllathorpe).y
+            .pos.Map = Cities(e_City.cUllathorpe).Map
+            .pos.x = Cities(e_City.cUllathorpe).x
+            .pos.y = Cities(e_City.cUllathorpe).y
         End If
         UltimoChar = UCase$(name)
         Call SaveNewUser(UserIndex)

--- a/Codigo/WorldActions.bas
+++ b/Codigo/WorldActions.bas
@@ -330,12 +330,12 @@ Private Sub HandleGovernorNpcInteraction(ByVal UserIndex As Integer, ByVal NpcIn
         Exit Sub
     End If
 
-    If (UserList(UserIndex).Faccion.Status = 0 Or UserList(UserIndex).Faccion.Status = 2) And Gobernador.GobernadorDe = e_Ciudad.cBanderbill Then
+    If (UserList(UserIndex).Faccion.Status = 0 Or UserList(UserIndex).Faccion.Status = 2) And Gobernador.GobernadorDe = e_City.cBanderbill Then
         Call WriteLocaleChatOverHead(UserIndex, "1350", "", Gobernador.Char.charindex, vbWhite) ' Msg1350=Aquí no aceptamos criminales.
         Exit Sub
     End If
 
-    If (UserList(UserIndex).Faccion.Status = 3 Or UserList(UserIndex).Faccion.Status = 1) And Gobernador.GobernadorDe = e_Ciudad.cArkhein Then
+    If (UserList(UserIndex).Faccion.Status = 3 Or UserList(UserIndex).Faccion.Status = 1) And Gobernador.GobernadorDe = e_City.cArkhein Then
         Call WriteLocaleChatOverHead(UserIndex, "1351", "", Gobernador.Char.charindex, vbWhite) ' Msg1351=¡¡Sal de aquí ciudadano asqueroso!!
         Exit Sub
     End If
@@ -346,7 +346,7 @@ Private Sub HandleGovernorNpcInteraction(ByVal UserIndex As Integer, ByVal NpcIn
     Else
         Call LogError("Invalid possible home city from governor. UserIndex=" & UserIndex & " PosibleHogar=" & UserList(UserIndex).PosibleHogar)
     End If
-    If LenB(DeDonde) = 0 Then DeDonde = CityNames(e_Ciudad.cUllathorpe)
+    If LenB(DeDonde) = 0 Then DeDonde = CityNames(e_City.cUllathorpe)
     If LenB(DeDonde) = 0 Then DeDonde = "Ullathorpe"
     UserList(UserIndex).flags.pregunta = 3
     Call WritePreguntaBox(UserIndex, 1592, DeDonde)


### PR DESCRIPTION
### Motivation
- Standardize remaining Spanish city identifiers to English to match the refactored city system while preserving behavior and enum numeric values.
- Keep `CityData` and `CityNames` as the canonical configuration sources while providing a backwards-compatible projection for indexed Map/X/Y lookups.

### Description
- Rename the enum type `e_Ciudad` to `e_City` and update all type references and variable declarations to use `e_City` without changing enum members or numeric ordering.
- Rename the legacy compatibility projection array `Ciudades` to `Cities` and update all array declarations, reads/writes and comments to use `Cities` while keeping `CityData`/`CityNames` intact.
- Update function signatures, local variables, select/case mappings, and call sites across `Codigo/*` modules (notably `Declares.bas`, `FileIO.bas`, `Hogar.bas`, `InvUsuario.bas`, `Modulo_UsUaRiOs.bas`, `Protocol.bas`, `Protocol_GmCommands.bas`, `TCP.bas`, and `WorldActions.bas`) to the new identifiers.
- Add/clarify a short comment next to the arrays/types that `CityData` is the canonical configuration store and `Cities` is the compatibility Map/X/Y projection, and preserve INI section names and runtime loading of `Ciudades.dat` to avoid behavior changes.

### Testing
- Ran `git diff --check` to validate there are no obvious whitespace/index errors and it passed.
- Ran repository-wide grep checks to confirm there are no remaining `e_Ciudad` or `Ciudades(...)` references in code (excluding the preserved `Ciudades.dat` filename), which succeeded.
- VB6 compile/unit-test execution was not run because `vb6.exe` is not available in this environment, so runtime compilation tests were not performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00fd49d4f483289bdda7d314116369)