### PR TITLE
Fix guild_request orphan migration

### DIFF
--- a/Codigo/modDatabase.bas
+++ b/Codigo/modDatabase.bas
@@ -48,6 +48,7 @@ Public Sub Database_Connect_Async()
         Connection_async(i).CursorLocation = adUseClient
         Connection_async(i).ConnectionString = ConnectionID
         Call Connection_async(i).Open
+        Call Connection_async(i).Execute("PRAGMA foreign_keys = ON")
     Next i
     Current_async = 1
     Set Builder = New cStringBuilder
@@ -71,6 +72,7 @@ Public Sub Database_Connect()
     Connection.ConnectionString = ConnectionID
     Set Builder = New cStringBuilder
     Call Connection.Open
+    Call Connection.Execute("PRAGMA foreign_keys = ON")
     Exit Sub
 Database_Connect_Err:
     Call LogDatabaseError("Database Error: " & Err.Number & " - " & Err.Description & " - Database_Connect")

--- a/Codigo/modDatabase.bas
+++ b/Codigo/modDatabase.bas
@@ -48,6 +48,7 @@ Public Sub Database_Connect_Async()
         Connection_async(i).CursorLocation = adUseClient
         Connection_async(i).ConnectionString = ConnectionID
         Call Connection_async(i).Open
+        ' SQLite enforces foreign keys per connection, so enable cascades immediately after opening each ADO connection.
         Call Connection_async(i).Execute("PRAGMA foreign_keys = ON")
     Next i
     Current_async = 1
@@ -72,6 +73,7 @@ Public Sub Database_Connect()
     Connection.ConnectionString = ConnectionID
     Set Builder = New cStringBuilder
     Call Connection.Open
+    ' SQLite enforces foreign keys per connection, so enable cascades immediately after opening the ADO connection.
     Call Connection.Execute("PRAGMA foreign_keys = ON")
     Exit Sub
 Database_Connect_Err:

--- a/ScriptsDB/20260511-01-fix guild request foreign keys.sql
+++ b/ScriptsDB/20260511-01-fix guild request foreign keys.sql
@@ -1,13 +1,20 @@
 DROP TABLE IF EXISTS guild_request_new;
 
 CREATE TABLE guild_request_new (
-    id INTEGER NOT NULL,
+    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
     guild_id INTEGER NOT NULL,
     user_id INTEGER NOT NULL,
     description VARCHAR(512) NOT NULL,
-    CONSTRAINT fk_guild_request_guild_id FOREIGN KEY (guild_id) REFERENCES guilds(id) ON DELETE CASCADE ON UPDATE CASCADE,
-    CONSTRAINT fk_guild_request_user_id FOREIGN KEY (user_id) REFERENCES "user"(id) ON DELETE CASCADE ON UPDATE CASCADE,
-    PRIMARY KEY (id)
+    CONSTRAINT fk_guild_request_guild_id
+        FOREIGN KEY (guild_id)
+        REFERENCES guilds(id)
+        ON DELETE CASCADE
+        ON UPDATE CASCADE,
+    CONSTRAINT fk_guild_request_user_id
+        FOREIGN KEY (user_id)
+        REFERENCES "user"(id)
+        ON DELETE CASCADE
+        ON UPDATE CASCADE
 );
 
 INSERT INTO guild_request_new (id, guild_id, user_id, description)
@@ -16,7 +23,7 @@ SELECT gr.id, gr.guild_id, gr.user_id, gr.description
     INNER JOIN "user" u ON u.id = gr.user_id
     INNER JOIN guilds g ON g.id = gr.guild_id;
 
-DROP TABLE guild_request;
+DROP TABLE IF EXISTS guild_request;
 
 ALTER TABLE guild_request_new RENAME TO guild_request;
 

--- a/ScriptsDB/20260511-01-fix guild request foreign keys.sql
+++ b/ScriptsDB/20260511-01-fix guild request foreign keys.sql
@@ -1,0 +1,25 @@
+DROP TABLE IF EXISTS guild_request_new;
+
+CREATE TABLE guild_request_new (
+    id INTEGER NOT NULL,
+    guild_id INTEGER NOT NULL,
+    user_id INTEGER NOT NULL,
+    description VARCHAR(512) NOT NULL,
+    CONSTRAINT fk_guild_request_guild_id FOREIGN KEY (guild_id) REFERENCES guilds(id) ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT fk_guild_request_user_id FOREIGN KEY (user_id) REFERENCES "user"(id) ON DELETE CASCADE ON UPDATE CASCADE,
+    PRIMARY KEY (id)
+);
+
+INSERT INTO guild_request_new (id, guild_id, user_id, description)
+SELECT gr.id, gr.guild_id, gr.user_id, gr.description
+    FROM guild_request gr
+    INNER JOIN "user" u ON u.id = gr.user_id
+    INNER JOIN guilds g ON g.id = gr.guild_id;
+
+DROP TABLE guild_request;
+
+ALTER TABLE guild_request_new RENAME TO guild_request;
+
+CREATE INDEX IF NOT EXISTS idx_fk_guild_request_user_id ON guild_request(user_id);
+
+CREATE INDEX IF NOT EXISTS idx_fk_guild_request_guild_id ON guild_request(guild_id);


### PR DESCRIPTION
### Motivation
- Remove orphan rows from `guild_request` that reference deleted `user` or `guilds` rows and ensure future enforcement with proper foreign keys.
- Enable SQLite foreign key enforcement at DB connection time so cascading deletes behave as expected.

### Description
- Add a focused migration file `ScriptsDB/20260511-01-fix guild request foreign keys.sql` that rebuilds `guild_request` by creating `guild_request_new` with the required foreign keys, copying only rows that INNER JOIN to both `"user"` and `guilds`, dropping the old table, renaming the new table, and creating indexes for `user_id` and `guild_id`.
- The migration uses `INNER JOIN` to preserve valid rows only, and it removes invalid/orphan rows by not copying them, leaving no temporary tables behind after completion.
- Enable `PRAGMA foreign_keys = ON` immediately after opening both the async connections (`Database_Connect_Async`) and the main synchronous connection (`Database_Connect`) in `Codigo/modDatabase.bas` so SQLite enforces foreign keys for the lifetime of connections.
- Files changed: `ScriptsDB/20260511-01-fix guild request foreign keys.sql` and `Codigo/modDatabase.bas`, and the change deliberately avoids modifying `RunScriptInFile` or adding any generic SQL splitter or persistent backup tables.
- Assumed the existing `guild_request` schema contains the columns `id`, `guild_id`, `user_id`, and `description` which are preserved by the migration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a020a4b870c8328b0cc44b2c2c577ef)