### PR TITLE
Add migration to remove orphaned spell rows

### DIFF
--- a/ScriptsDB/20260511-02-remove orphan spell rows.sql
+++ b/ScriptsDB/20260511-02-remove orphan spell rows.sql
@@ -1,6 +1,1 @@
-DELETE FROM spell
-WHERE NOT EXISTS (
-    SELECT 1
-    FROM "user" u
-    WHERE u.id = spell.user_id
-);
+DELETE FROM spell WHERE user_id IN (SELECT s.user_id FROM spell s LEFT JOIN "user" u ON u.id = s.user_id WHERE u.id IS NULL);

--- a/ScriptsDB/20260511-02-remove orphan spell rows.sql
+++ b/ScriptsDB/20260511-02-remove orphan spell rows.sql
@@ -1,0 +1,6 @@
+DELETE FROM spell
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM "user" u
+    WHERE u.id = spell.user_id
+);


### PR DESCRIPTION
### Motivation
- Orphan rows exist in `spell` that reference deleted `user` rows because SQLite foreign key enforcement was previously disabled, so a one-off cleanup is required without changing schema.

### Description
- Add `ScriptsDB/20260511-02-remove orphan spell rows.sql` which runs a single `DELETE` using `NOT EXISTS` to remove `spell` rows whose `user_id` has no matching `user.id`.
- The migration follows the existing naming convention and does not recreate tables, modify schema, add indexes, or touch unrelated tables.

### Testing
- Applied the migration against a temporary SQLite database with a sample `user` row and multiple `spell` rows (one valid and two orphans) and verified only the valid `spell` row remained after running the script.
- Verified SQLite accepts the SQL syntax and that the migration removes orphaned `spell` rows, and confirmed future orphan rows should be prevented by the existing foreign key plus `PRAGMA foreign_keys = ON`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0242ba0eec8328a60eef3b91134c9a)