### PR TITLE
Add migration to remove orphan bank_item rows

### DIFF
--- a/ScriptsDB/20260511-03-remove orphan bank item rows.sql
+++ b/ScriptsDB/20260511-03-remove orphan bank item rows.sql
@@ -1,0 +1,1 @@
+DELETE FROM bank_item WHERE user_id IN (SELECT b.user_id FROM bank_item b LEFT JOIN "user" u ON u.id = b.user_id WHERE u.id IS NULL);


### PR DESCRIPTION
### Motivation
- Remove orphan rows left in `bank_item` by historical deletes when SQLite FK enforcement was off, relying on the existing FK and `PRAGMA foreign_keys = ON` to prevent future orphans.

### Description
- Add `ScriptsDB/20260511-03-remove orphan bank item rows.sql` containing `DELETE FROM bank_item WHERE user_id IN (SELECT b.user_id FROM bank_item b LEFT JOIN "user" u ON u.id = b.user_id WHERE u.id IS NULL);` which follows the same `LEFT JOIN` + `IN` pattern used for the `spell` cleanup and does not recreate tables, change schema, modify `RunScriptInFile`, or touch unrelated tables.

### Testing
- Verified the migration SQL with `sqlite3` against a temporary database containing one valid and one orphan `bank_item` row and confirmed the orphan row was removed, the valid row was preserved, and the SQL executed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0245f660bc83288121f7886310b7ca)