### PR TITLE
Fix orphan bank_item rows

### DIFF
--- a/ScriptsDB/20260511-03-remove orphan bank item rows.sql
+++ b/ScriptsDB/20260511-03-remove orphan bank item rows.sql
@@ -1,0 +1,6 @@
+DELETE FROM bank_item WHERE user_id IN (
+    SELECT b.user_id
+    FROM bank_item b
+    LEFT JOIN "user" u ON u.id = b.user_id
+    WHERE u.id IS NULL
+);


### PR DESCRIPTION
### Motivation

- Historical deletes left orphan rows in `bank_item` because SQLite foreign-key enforcement had been disabled, while the table already contains a correct `FOREIGN KEY(user_id) REFERENCES "user"(id) ON DELETE CASCADE` so no schema change is needed.

### Description

- Add migration `ScriptsDB/20260511-03-remove orphan bank item rows.sql` that runs a `DELETE FROM bank_item` using a `LEFT JOIN` + `IN` subquery (avoiding `NOT EXISTS`) to remove only orphan `bank_item` rows, without recreating the table or modifying schema or other tables.

### Testing

- Executed an in-memory SQLite test using `sqlite3` that created the `user` and `bank_item` tables, inserted a valid and an orphan row, ran the migration, and confirmed the orphan row was deleted while the valid row remained and the SQL syntax executed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0247b3e7348328ad038e317bc61212)