### PR TITLE
Fix orphan skillpoint rows

### DIFF
--- a/ScriptsDB/20260513-02-remove orphan skillpoint rows.sql
+++ b/ScriptsDB/20260513-02-remove orphan skillpoint rows.sql
@@ -1,0 +1,6 @@
+DELETE FROM skillpoint WHERE user_id IN (
+    SELECT s.user_id
+    FROM skillpoint s
+    LEFT JOIN "user" u ON u.id = s.user_id
+    WHERE u.id IS NULL
+);


### PR DESCRIPTION
### Motivation

- Remove historical orphan rows in `skillpoint` that referenced deleted users due to prior runs with SQLite foreign key enforcement disabled.
- No schema change is required because the `skillpoint` table already defines the correct foreign key with `ON DELETE CASCADE`, and `PRAGMA foreign_keys = ON` is enabled on all connections to prevent future orphans.

### Description

- Add a new migration file `ScriptsDB/20260513-02-remove orphan skillpoint rows.sql` that deletes only orphan `skillpoint` rows.
- The migration SQL uses the validated `LEFT JOIN` + `IN` pattern and is exactly:
  `DELETE FROM skillpoint WHERE user_id IN (SELECT s.user_id FROM skillpoint s LEFT JOIN "user" u ON u.id = s.user_id WHERE u.id IS NULL);`.
- The change is data-only and does not recreate or modify the `skillpoint` table, change schema, touch `RunScriptInFile`, or affect unrelated tables.
- The migration avoids `NOT EXISTS` per ADO/VB6 SQLite syntax constraints and follows the existing cleanup pattern used for other tables.

### Testing

- Executed a local SQLite verification by creating a temp DB, creating `user` and `skillpoint` tables, inserting valid and orphan rows, running the migration, and observing that only valid `skillpoint` rows remained; this test succeeded.
- Verified the migration SQL is valid SQLite syntax by running it through `sqlite3` during the test; this check succeeded.
- The migration is a one-time cleanup that removes orphan `skillpoint` rows only and relies on the existing FK plus `PRAGMA foreign_keys = ON` to prevent future orphan rows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04e9f9c43083289399e0f43a68e8fc)