### PR TITLE
Fix orphan inventory_item rows

### DIFF
--- a/ScriptsDB/20260514-03-remove orphan inventory item rows.sql
+++ b/ScriptsDB/20260514-03-remove orphan inventory item rows.sql
@@ -1,0 +1,6 @@
+DELETE FROM inventory_item WHERE user_id IN (
+    SELECT i.user_id
+    FROM inventory_item i
+    LEFT JOIN "user" u ON u.id = i.user_id
+    WHERE u.id IS NULL
+);


### PR DESCRIPTION
### Motivation

- Historical deletes while SQLite foreign key enforcement was disabled produced orphan rows in `inventory_item` that must be removed as a one-time cleanup.
- The `inventory_item` table already contains the correct FK (`CONSTRAINT fk_inventory_user ... ON DELETE CASCADE`), so no schema change or table recreation is required and future orphans should be prevented by `PRAGMA foreign_keys = ON` on all connections.

### Description

- Add a new migration file `ScriptsDB/20260514-03-remove orphan inventory item rows.sql` that contains exactly one SQL statement which deletes orphan `inventory_item` rows only.
- The migration uses the validated `LEFT JOIN` + `IN` cleanup pattern (avoiding `NOT EXISTS`) to remove rows whose `user_id` has no matching row in `"user"`.
- This change does not modify any schema, does not recreate the table, and does not touch unrelated tables or `RunScriptInFile` behavior.

### Testing

- Verified SQLite syntax and behavior by loading the migration into a `sqlite3 :memory:` DB with sample data and applying the file via `.read`, which executed without error.
- Executed the verification query `SELECT COUNT(*) FROM inventory_item i LEFT JOIN "user" u ON u.id = i.user_id WHERE u.id IS NULL;` after applying the migration and confirmed the result is `0`.
- Confirmed the migration file contains exactly one `DELETE` statement and follows the same pattern as existing orphan-cleanup migrations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06405da6548328a840089d4891c13a)