### PR TITLE
Fix orphan pet rows

### DIFF
--- a/ScriptsDB/20260514-04-remove orphan pet rows.sql
+++ b/ScriptsDB/20260514-04-remove orphan pet rows.sql
@@ -1,0 +1,6 @@
+DELETE FROM pet WHERE user_id IN (
+    SELECT p.user_id
+    FROM pet p
+    LEFT JOIN "user" u ON u.id = p.user_id
+    WHERE u.id IS NULL
+);


### PR DESCRIPTION
### Motivation

- Remove orphan rows in `pet` created by historical deletes when SQLite foreign key enforcement was disabled, performing a one-time cleanup so the data matches the existing FK constraints.

### Description

- Add `ScriptsDB/20260514-04-remove orphan pet rows.sql` containing a single SQL statement: `DELETE FROM pet WHERE user_id IN ( SELECT p.user_id FROM pet p LEFT JOIN "user" u ON u.id = p.user_id WHERE u.id IS NULL );`, using the established `LEFT JOIN` + `IN` cleanup pattern and making no schema changes or touches to other tables.

### Testing

- Verified SQLite syntax and behavior by creating a temporary DB (`PRAGMA foreign_keys = OFF;`), inserting sample `user` and `pet` rows, executing the migration via `sqlite3`, and confirming the orphan-count query `SELECT COUNT(*) FROM pet p LEFT JOIN "user" u ON u.id = p.user_id WHERE u.id IS NULL;` returned `0` while valid rows remained; also confirmed the migration file contains exactly one SQL statement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0641d408d483289549bec1c09b6911)