### PR TITLE
Remove obsolete remote-close branch (SGRACEFULLY) from HandleFeatureToggle

### DIFF
--- a/Codigo/Protocol_GmCommands.bas
+++ b/Codigo/Protocol_GmCommands.bas
@@ -3998,16 +3998,8 @@ Public Sub HandleFeatureToggle(ByVal UserIndex As Integer)
         Exit Sub
     End If
     If (UserList(UserIndex).flags.Privilegios And (e_PlayerType.Admin)) Then
-        If name = "SGRACEFULLY" Then
-            Call SendData(SendTarget.ToAll, 0, PrepareMessageLocaleMsg(MSG_SERVIDOR_CERRANDO_AHORA, vbNullString, e_FontTypeNames.FONTTYPE_PROMEDIO_MENOR)) 'Msg1740=Servidor » cerrando ahora.
-            Call GuardarUsuarios
-            Call EcharPjsNoPrivilegiados
-            frmMain.GuardarYCerrar = True
-            Unload frmMain
-        Else
-            Call SetFeatureToggle(name, value > 0)
-            Call WriteLocaleMsg(UserIndex, MSG_VARIABLE_CONFIGURADA_CORRECTAMENTE, e_FontTypeNames.FONTTYPE_INFO) 'Msg1006= variable configurada correctamente.
-        End If
+        Call SetFeatureToggle(name, value > 0)
+        Call WriteLocaleMsg(UserIndex, MSG_VARIABLE_CONFIGURADA_CORRECTAMENTE, e_FontTypeNames.FONTTYPE_INFO) 'Msg1006= variable configurada correctamente.
     Else
         Call WriteLocaleMsg(UserIndex, MSG_NO_TIENES_PERMISOS_REALIZAR_ACCION, e_FontTypeNames.FONTTYPE_INFO) 'Msg1007= no tienes permisos para realizar esta accion.
     End If


### PR DESCRIPTION
### Motivation
- Remove a dead special-case that triggered a remote server shutdown via the feature-toggle name `SGRACEFULLY` because the REMOTE_CLOSE path is permanently disabled while keeping current admin feature-toggle behavior intact.

### Description
- Modified `Codigo/Protocol_GmCommands.bas` to delete the `If name = "SGRACEFULLY" Then` branch (which invoked `SendData(...MSG_SERVIDOR_CERRANDO_AHORA)`, `GuardarUsuarios`, `EcharPjsNoPrivilegiados`, `frmMain.GuardarYCerrar = True`, and `Unload frmMain`) and preserve the normal admin path that calls `SetFeatureToggle(name, value > 0)` and returns the existing success message.

### Testing
- Ran repository searches for `REMOTE_CLOSE`, `SGRACEFULLY`, and related tokens and confirmed the removed remote-close branch is no longer present, executed `git diff --check` which reported no problems, and committed the change; a full VB6/MSBuild compile could not be performed in this environment because the VB6 toolchain is not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dead9e9e48328b9687b1bd5ecc053)