### PR TITLE
Add disconnect diagnostics and propagate disconnect reason/source to network close/kick paths

### DIFF
--- a/Codigo/AntiCheat.bas
+++ b/Codigo/AntiCheat.bas
@@ -131,7 +131,8 @@ Public Sub KickUnregisteredPlayers()
         If Result > 0 And IsValidUserRef(UserRef) Then
             If Not IsUserAdmin(UserRef.ArrayIndex) Then
                 With UserList(UserRef.ArrayIndex)
-                    Call modNetwork.Kick(.ConnectionDetails.ConnID, "Anticheat detection timeout for Username: " & .name)
+                    Call LogDisconnectEvent("AntiCheat.KickUnregisteredPlayers", "Kick", UserRef.ArrayIndex, .ConnectionDetails.ConnID, "anticheat_register_timeout user=" & .name)
+                    Call modNetwork.Kick(.ConnectionDetails.ConnID, "Anticheat detection timeout for Username: " & .name, "AntiCheat.KickUnregisteredPlayers")
                 End With
             End If
         End If
@@ -210,7 +211,8 @@ Public Sub ClientActionRequired(ByRef UserRef As t_UserReference, ByVal Action A
         ReasonStr = GetStringFromPtr(ReasonString.Ptr, ReasonString.Len)
     End If
     If Action = eEOS_ACCCA_RemovePlayer And IsValidUserRef(UserRef) Then
-        Call modNetwork.Kick(UserList(UserRef.ArrayIndex).ConnectionDetails.ConnID, ReasonStr)
+        Call LogDisconnectEvent("AntiCheat.ClientActionRequired", "Kick", UserRef.ArrayIndex, UserList(UserRef.ArrayIndex).ConnectionDetails.ConnID, ReasonStr)
+        Call modNetwork.Kick(UserList(UserRef.ArrayIndex).ConnectionDetails.ConnID, ReasonStr, "AntiCheat.ClientActionRequired")
     End If
     Exit Sub
 ClientActionRequired_Err:

--- a/Codigo/DisconnectDiagnostics.bas
+++ b/Codigo/DisconnectDiagnostics.bas
@@ -1,0 +1,55 @@
+Attribute VB_Name = "DisconnectDiagnostics"
+' Argentum 20 Game Server
+'
+' Lightweight disconnect diagnostics gated by the debug_disconnects feature flag.
+
+Option Explicit
+
+Public Sub LogDisconnectEvent( _
+    ByVal Source As String, _
+    ByVal Action As String, _
+    ByVal UserIndex As Integer, _
+    ByVal ConnID As Long, _
+    Optional ByVal Reason As String = vbNullString, _
+    Optional ByVal PacketId As Long = -1)
+
+    On Error Resume Next
+
+    If Not IsFeatureEnabled("debug_disconnects") Then Exit Sub
+
+    Dim message As String
+    message = "disconnect_diag" & _
+            " source=" & Source & _
+            " action=" & Action & _
+            " userIndex=" & CStr(UserIndex) & _
+            " connID=" & CStr(ConnID)
+
+    If Reason <> vbNullString Then
+        message = message & " reason=" & Replace(Reason, vbCrLf, " ")
+    End If
+
+    If PacketId >= 0 Then
+        message = message & " packetId=" & CStr(PacketId)
+    End If
+
+    If UserIndex > 0 Then
+        With UserList(UserIndex)
+            message = message & _
+                    " username=" & .name & _
+                    " userId=" & CStr(.Id) & _
+                    " accountId=" & CStr(.AccountID) & _
+                    " ip=" & .ConnectionDetails.IP & _
+                    " userLogged=" & CStr(.flags.UserLogged) & _
+                    " connIDValida=" & CStr(.ConnectionDetails.ConnIDValida) & _
+                    " map=" & CStr(.pos.Map) & _
+                    " x=" & CStr(.pos.x) & _
+                    " y=" & CStr(.pos.y) & _
+                    " idleCount=" & CStr(.Counters.IdleCount) & _
+                    " saliendo=" & CStr(.Counters.Saliendo) & _
+                    " salir=" & CStr(.Counters.Salir)
+        End With
+    End If
+
+    Call LogInfoServidor(message)
+    Call AddLogToCircularBuffer(message)
+End Sub

--- a/Codigo/Protocol.bas
+++ b/Codigo/Protocol.bas
@@ -186,6 +186,8 @@ Public Function HandleIncomingData(ByVal ConnectionID As Long, ByVal Message As 
         End If
         Mapping(ConnectionID).PacketCount = Mapping(ConnectionID).PacketCount + 1
         If Mapping(ConnectionID).PacketCount > 100 Then
+            Dim PacketCountAtOverflow As Long
+            PacketCountAtOverflow = Mapping(ConnectionID).PacketCount
             'Lo kickeo
             If UserIndex > 0 Then
                 If Not IsMissing(optional_user_index) Then ' userindex may be invalid here
@@ -194,7 +196,8 @@ Public Function HandleIncomingData(ByVal ConnectionID As Long, ByVal Message As 
                 End If
                 Mapping(ConnectionID).PacketCount = 0
                 If IsFeatureEnabled("kick_packet_overflow") Then
-                    Call KickConnection(ConnectionID)
+                    Call LogDisconnectEvent("Protocol.HandleIncomingData", "KickConnection", UserIndex, ConnectionID, "packet_overflow count=" & CStr(PacketCountAtOverflow) & " packet=" & CStr(PacketId), PacketId)
+                    Call KickConnection(ConnectionID, "packet_overflow count=" & CStr(PacketCountAtOverflow) & " packet=" & CStr(PacketId), "Protocol.HandleIncomingData")
                 End If
             Else
                 If Not IsMissing(optional_user_index) Then ' userindex may be invalid here
@@ -203,7 +206,8 @@ Public Function HandleIncomingData(ByVal ConnectionID As Long, ByVal Message As 
                 End If
                 Mapping(ConnectionID).PacketCount = 0
                 If IsFeatureEnabled("kick_packet_overflow") Then
-                    Call KickConnection(ConnectionID)
+                    Call LogDisconnectEvent("Protocol.HandleIncomingData", "KickConnection", 0, ConnectionID, "packet_overflow count=" & CStr(PacketCountAtOverflow) & " packet=" & CStr(PacketId), PacketId)
+                    Call KickConnection(ConnectionID, "packet_overflow count=" & CStr(PacketCountAtOverflow) & " packet=" & CStr(PacketId), "Protocol.HandleIncomingData")
                 End If
             End If
             Exit Function
@@ -215,7 +219,8 @@ Public Function HandleIncomingData(ByVal ConnectionID As Long, ByVal Message As 
             Call SendData(SendTarget.ToGM, UserIndex, PrepareMessageConsoleMsg("Control Paquetes---> El usuario " & GetUserGMName(UserIndex) & " | IP: " & UserList( _
                     UserIndex).ConnectionDetails.IP & " ESTÁ ENVIANDO PAQUETES INVÁLIDOS", e_FontTypeNames.FONTTYPE_GUILD))
         End If
-        Call KickConnection(ConnectionID)
+        Call LogDisconnectEvent("Protocol.HandleIncomingData", "KickConnection", UserIndex, ConnectionID, "invalid_packet packet=" & CStr(PacketId), PacketId)
+        Call KickConnection(ConnectionID, "invalid_packet packet=" & CStr(PacketId), "Protocol.HandleIncomingData")
         Exit Function
     End If
     #If PYMMO = 1 Then
@@ -226,7 +231,8 @@ Public Function HandleIncomingData(ByVal ConnectionID As Long, ByVal Message As 
             If Not IsMissing(optional_user_index) Then ' userindex may be invalid here
                 'Is the user actually logged?
                 If Not UserList(UserIndex).flags.UserLogged Then
-                    Call CloseSocket(UserIndex)
+                    Call LogDisconnectEvent("Protocol.HandleIncomingData", "CloseSocket", UserIndex, ConnectionID, "packet_requires_logged_user_but_user_not_logged packet=" & CStr(PacketId), PacketId)
+                    Call CloseSocket(UserIndex, "packet_requires_logged_user_but_user_not_logged packet=" & CStr(PacketId), "Protocol.HandleIncomingData")
                     Exit Function
                     'He is logged. Reset idle counter if id is valid.
                 ElseIf PacketId <= ClientPacketID.[PacketCount] Then
@@ -234,7 +240,8 @@ Public Function HandleIncomingData(ByVal ConnectionID As Long, ByVal Message As 
                 End If
             Else
                 'If UserIndex is missing then kick out
-                Call KickConnection(ConnectionID)
+                Call LogDisconnectEvent("Protocol.HandleIncomingData", "KickConnection", 0, ConnectionID, "packet_requires_logged_user_but_user_not_logged packet=" & CStr(PacketId), PacketId)
+                Call KickConnection(ConnectionID, "packet_requires_logged_user_but_user_not_logged packet=" & CStr(PacketId), "Protocol.HandleIncomingData")
                 Exit Function ' Don't process incoming data
             End If
         Else
@@ -242,7 +249,8 @@ Public Function HandleIncomingData(ByVal ConnectionID As Long, ByVal Message As 
             Debug.Assert IsMissing(optional_user_index)
             If Not IsMissing(optional_user_index) Then
                 'If UserIndex is not missing then kick out
-                Call KickConnection(ConnectionID)
+                Call LogDisconnectEvent("Protocol.HandleIncomingData", "KickConnection", UserIndex, ConnectionID, "unexpected_login_packet_with_user packet=" & CStr(PacketId), PacketId)
+                Call KickConnection(ConnectionID, "unexpected_login_packet_with_user packet=" & CStr(PacketId), "Protocol.HandleIncomingData")
                 Exit Function ' Don't process incoming data
             End If
         End If
@@ -251,13 +259,15 @@ Public Function HandleIncomingData(ByVal ConnectionID As Long, ByVal Message As 
         If Not (PacketId = ClientPacketID.eCreateAccount Or PacketId = ClientPacketID.eLoginAccount) Then
             'Is the account actually logged?
             If UserList(UserIndex).AccountID = 0 Then
-                Call CloseSocket(UserIndex)
+                Call LogDisconnectEvent("Protocol.HandleIncomingData", "CloseSocket", UserIndex, ConnectionID, "packet_requires_logged_account_but_account_not_logged packet=" & CStr(PacketId), PacketId)
+                Call CloseSocket(UserIndex, "packet_requires_logged_account_but_account_not_logged packet=" & CStr(PacketId), "Protocol.HandleIncomingData")
                 Exit Function
             End If
             If Not (PacketId = ClientPacketID.eLoginExistingChar Or PacketId = ClientPacketID.eLoginNewChar) Then
                 'Is the user actually logged?
                 If Not UserList(UserIndex).flags.UserLogged Then
-                    Call CloseSocket(UserIndex)
+                    Call LogDisconnectEvent("Protocol.HandleIncomingData", "CloseSocket", UserIndex, ConnectionID, "packet_requires_logged_user_but_user_not_logged packet=" & CStr(PacketId), PacketId)
+                    Call CloseSocket(UserIndex, "packet_requires_logged_user_but_user_not_logged packet=" & CStr(PacketId), "Protocol.HandleIncomingData")
                     Exit Function
                     'He is logged. Reset idle counter if id is valid.
                 ElseIf PacketId <= ClientPacketID.[PacketCount] Then
@@ -890,7 +900,8 @@ Public Function HandleIncomingData(ByVal ConnectionID As Long, ByVal Message As 
             If Not IsMissing(optional_user_index) Then
                 Call SendData(SendTarget.ToGM, UserIndex, PrepareMessageConsoleMsg("[Error] Paquete desconocido: " & PacketId, e_FontTypeNames.FONTTYPE_GUILD))
             End If
-            Call KickConnection(ConnectionID)
+            Call LogDisconnectEvent("Protocol.HandleIncomingData", "KickConnection", UserIndex, ConnectionID, "unhandled_packet packet=" & CStr(PacketId), PacketId)
+            Call KickConnection(ConnectionID, "unhandled_packet packet=" & CStr(PacketId), "Protocol.HandleIncomingData")
             HandleIncomingData = False
             Exit Function
     End Select
@@ -904,7 +915,8 @@ Public Function HandleIncomingData(ByVal ConnectionID As Long, ByVal Message As 
         If Not IsMissing(optional_user_index) Then
             Call SendData(SendTarget.ToGM, UserIndex, PrepareMessageConsoleMsg("[Warning] " & errMsg, e_FontTypeNames.FONTTYPE_GUILD))
         End If
-        Call KickConnection(ConnectionID)
+        Call LogDisconnectEvent("Protocol.HandleIncomingData", "KickConnection", UserIndex, ConnectionID, "extra_bytes packet=" & CStr(PacketId) & " extra=" & CStr(reader.GetAvailable()), PacketId)
+        Call KickConnection(ConnectionID, "extra_bytes packet=" & CStr(PacketId) & " extra=" & CStr(reader.GetAvailable()), "Protocol.HandleIncomingData")
         HandleIncomingData = False
         Exit Function
     End If

--- a/Codigo/TCP.bas
+++ b/Codigo/TCP.bas
@@ -553,8 +553,9 @@ ConnectNewUser_Err:
     Call TraceError(Err.Number, Err.Description, "TCP.ConnectNewUser", Erl)
 End Function
 
-Sub CloseSocket(ByVal UserIndex As Integer)
+Sub CloseSocket(ByVal UserIndex As Integer, Optional ByVal Reason As String = vbNullString, Optional ByVal Source As String = "TCP.CloseSocket")
     On Error GoTo ErrHandler
+    Call LogDisconnectEvent(Source, "CloseSocket", UserIndex, UserList(UserIndex).ConnectionDetails.ConnID, Reason)
     If UserIndex = LastUser Then
         Do Until UserList(LastUser).flags.UserLogged
             LastUser = LastUser - 1
@@ -562,7 +563,7 @@ Sub CloseSocket(ByVal UserIndex As Integer)
         Loop
     End If
     With UserList(UserIndex)
-        If .ConnectionDetails.ConnIDValida Then Call CloseSocketSL(UserIndex)
+        If .ConnectionDetails.ConnIDValida Then Call CloseSocketSL(UserIndex, Reason, Source)
         'mato los comercios seguros
         If IsValidUserRef(.ComUsu.DestUsu) Then
             If UserList(.ComUsu.DestUsu.ArrayIndex).flags.UserLogged Then
@@ -587,10 +588,11 @@ ErrHandler:
     Call TraceError(Err.Number, Err.Description, "TCP.CloseSocket", Erl)
 End Sub
 
-Sub CloseSocketSL(ByVal UserIndex As Integer)
+Sub CloseSocketSL(ByVal UserIndex As Integer, Optional ByVal Reason As String = vbNullString, Optional ByVal Source As String = "TCP.CloseSocketSL")
     On Error GoTo CloseSocketSL_Err
     If UserList(UserIndex).ConnectionDetails.ConnIDValida Then
-        Call modNetwork.Kick(UserList(UserIndex).ConnectionDetails.ConnID)
+        Call LogDisconnectEvent(Source, "CloseSocketSL", UserIndex, UserList(UserIndex).ConnectionDetails.ConnID, Reason)
+        Call modNetwork.Kick(UserList(UserIndex).ConnectionDetails.ConnID, Reason, Source)
         UserList(UserIndex).ConnectionDetails.ConnIDValida = False
     End If
     Exit Sub

--- a/Codigo/modNetwork.bas
+++ b/Codigo/modNetwork.bas
@@ -97,7 +97,7 @@ Public Sub Flush(ByVal UserIndex As Long)
     Call Server.Flush(UserList(UserIndex).ConnectionDetails.ConnID)
 End Sub
 
-Public Sub Kick(ByVal Connection As Long, Optional ByVal Message As String = vbNullString)
+Public Sub Kick(ByVal Connection As Long, Optional ByVal Message As String = vbNullString, Optional ByVal Source As String = "modNetwork.Kick")
     On Error GoTo Kick_ErrHandler:
     If IsFeatureEnabled("debug_connections") Then
         If (Message <> vbNullString) Then
@@ -108,6 +108,11 @@ Public Sub Kick(ByVal Connection As Long, Optional ByVal Message As String = vbN
     End If
     Dim UserRef As t_UserReference
     UserRef = Mapping(Connection).UserRef
+    If IsValidUserRef(UserRef) And UserList(UserRef.ArrayIndex).flags.UserLogged Then
+        Call LogDisconnectEvent(Source, "Kick", UserRef.ArrayIndex, Connection, Message)
+    Else
+        Call LogDisconnectEvent(Source, "Kick", 0, Connection, Message)
+    End If
     If (Message <> vbNullString) Then
         If UserRef.ArrayIndex > 0 Then
             Call Protocol_Writes.WriteErrorMsg(UserRef.ArrayIndex, Message)
@@ -142,7 +147,7 @@ Public Sub close_not_logged_sockets_if_timeout()
                 If IsValidUserRef(.UserRef) Then
                     LogError ("trying to kick an assigned connection: " & ConnectionID & " assigned to: " & .UserRef.ArrayIndex)
                 Else
-                    Call KickConnection(ConnectionID)
+                    Call KickConnection(ConnectionID, "pending_connection_timeout", "modNetwork.close_not_logged_sockets_if_timeout")
                 End If
             End If
         End With
@@ -182,11 +187,11 @@ Private Sub OnServerConnect(ByVal Connection As Long, ByVal Address As String)
         Call PendingConnections.Add(Connection, Connection)
         Call modSendData.SendToConnection(Connection, PrepareConnected())
     Else
-        Call Kick(Connection, "El server se encuentra lleno en este momento. Disculpe las molestias ocasionadas.")
+        Call Kick(Connection, "El server se encuentra lleno en este momento. Disculpe las molestias ocasionadas.", "modNetwork.OnServerConnect")
     End If
     Exit Sub
 OnServerConnect_Err:
-    Call Kick(Connection)
+    Call Kick(Connection, "server_connect_error err=" & CStr(Err.Number) & " desc=" & Err.Description, "modNetwork.OnServerConnect")
     Call TraceError(Err.Number, Err.Description, "modNetwork.OnServerConnect", Erl)
 End Sub
 
@@ -194,6 +199,11 @@ Private Sub OnServerClose(ByVal Connection As Long)
     On Error GoTo OnServerClose_Err:
     Dim UserRef As t_UserReference
     UserRef = Mapping(Connection).UserRef
+    If IsValidUserRef(UserRef) Then
+        Call LogDisconnectEvent("modNetwork.OnServerClose", "remote_or_library_close", UserRef.ArrayIndex, Connection, "server_close_callback")
+    Else
+        Call LogDisconnectEvent("modNetwork.OnServerClose", "remote_or_library_close", 0, Connection, "server_close_callback")
+    End If
     If IsFeatureEnabled("debug_connections") Then
         If UserRef.ArrayIndex > 0 Then
             Call AddLogToCircularBuffer("OnServerClose disconnected user index: " & UserRef.ArrayIndex & " With connection id: " & Connection & " with name: " & UserList( _
@@ -204,10 +214,10 @@ Private Sub OnServerClose(ByVal Connection As Long)
     End If
     If IsValidUserRef(UserRef) Then
         If UserList(UserRef.ArrayIndex).flags.UserLogged Then
-            Call CloseSocketSL(UserRef.ArrayIndex)
+            Call CloseSocketSL(UserRef.ArrayIndex, "server_close_callback", "modNetwork.OnServerClose")
             Call Cerrar_Usuario(UserRef.ArrayIndex)
         Else
-            Call CloseSocket(UserRef.ArrayIndex)
+            Call CloseSocket(UserRef.ArrayIndex, "server_close_callback", "modNetwork.OnServerClose")
         End If
         UserList(UserRef.ArrayIndex).ConnectionDetails.ConnIDValida = False
         UserList(UserRef.ArrayIndex).ConnectionDetails.ConnID = 0
@@ -225,7 +235,7 @@ Private Sub OnServerSend(ByVal Connection As Long, ByVal Message As Network.read
     On Error GoTo OnServerSend_Err:
     Exit Sub
 OnServerSend_Err:
-    Call Kick(Connection)
+    Call Kick(Connection, "send_error err=" & CStr(Err.Number) & " desc=" & Err.Description, "modNetwork.OnServerSend")
     Call TraceError(Err.Number, Err.Description, "modNetwork.OnServerSend", Erl)
 End Sub
 
@@ -245,7 +255,7 @@ Private Sub OnServerRecv(ByVal Connection As Long, ByVal Message As Network.read
     End If
     Exit Sub
 OnServerRecv_Err:
-    Call Kick(Connection)
+    Call Kick(Connection, "recv_error err=" & CStr(Err.Number) & " desc=" & Err.Description, "modNetwork.OnServerRecv")
     Call TraceError(Err.Number, Err.Description, "modNetwork.OnServerRecv", Erl)
 End Sub
 
@@ -262,8 +272,15 @@ ForcedClose_Err:
     Call TraceError(Err.Number, Err.Description, "modNetwork.ForcedClose", Erl)
 End Sub
 
-Public Sub KickConnection(Connection As Long)
+Public Sub KickConnection(ByVal Connection As Long, Optional ByVal Reason As String = vbNullString, Optional ByVal Source As String = "modNetwork.KickConnection")
     On Error GoTo ForcedClose_Err:
+    Dim UserRef As t_UserReference
+    UserRef = Mapping(Connection).UserRef
+    If IsValidUserRef(UserRef) Then
+        Call LogDisconnectEvent(Source, "KickConnection", UserRef.ArrayIndex, Connection, Reason)
+    Else
+        Call LogDisconnectEvent(Source, "KickConnection", 0, Connection, Reason)
+    End If
     Call Server.Flush(Connection)
     Call Server.Kick(Connection, True)
     Call ClearConnection(Connection)
@@ -299,6 +316,7 @@ Public Sub CheckDisconnectedUsers()
                             End If
                             Call FinComerciarUsu(iUserIndex)
                         End If
+                        Call LogDisconnectEvent("modNetwork.CheckDisconnectedUsers", "Cerrar_Usuario", iUserIndex, .ConnectionDetails.ConnID, "disconnect_timeout")
                         Call Cerrar_Usuario(iUserIndex, True)
                     End If
                 End If
@@ -325,7 +343,7 @@ Public Function MapConnectionToUser(ByVal ConnectionID As Long) As Integer
         If IsFeatureEnabled("debug_connections") Then
             Call LogError("Failed to find slot for new user, connection: " & Connection & " LastUser: " & LastUser)
         End If
-        Call Kick(ConnectionID, "El server se encuentra lleno en este momento. Disculpe las molestias ocasionadas.")
+        Call Kick(ConnectionID, "El server se encuentra lleno en este momento. Disculpe las molestias ocasionadas.", "modNetwork.MapConnectionToUser")
         Exit Function
     End If
     If UserList(FreeUser).InUse Then
@@ -370,7 +388,7 @@ On Error GoTo CheckDisconnectedUsers_Err:
             If IsFeatureEnabled("debug_connections") Then
                 Call LogError("Failed to find slot for new user, connection: " & Connection & " LastUser: " & LastUser)
             End If
-            KickConnection (ConnectionID)
+            Call KickConnection(ConnectionID, "no_free_user_slot", "modNetwork.MapConnectionToUser")
             Exit Function
         End If
         
@@ -495,7 +513,7 @@ On Error GoTo create_player_err
         With Mapping.Item(lPlayerID)
           Call TraceError(Err.Number, Err.Description, "OnServerConnect Mapping(lPlayerID) > 0, connection: " & lPlayerID & " value: " & Mapping.Item(lPlayerID), Erl)
         End With
-        Call KickConnection(lPlayerID)
+        Call KickConnection(lPlayerID, "directplay_duplicate_mapping", "modNetwork.CreatePlayer")
         Exit Sub
     End If
        
@@ -508,7 +526,7 @@ create_player_err:
     If Err.Number <> 0 Then
         Call HandleDPlayError(Err.Number, Err.Description, "modnetwork.CreatePlayer", Erl)
     End If
-    Call KickConnection(lPlayerID)
+    Call KickConnection(lPlayerID, "directplay_create_player_error", "modNetwork.CreatePlayer")
 
 End Sub
 
@@ -519,11 +537,13 @@ On Error GoTo OnServerClose_Err:
     If Mapping.Exists(lPlayerID) Then
         Dim user_index As Integer
         user_index = Mapping.Item(lPlayerID)
+        Call LogDisconnectEvent("modNetwork.DestroyPlayer", "remote_or_library_close", user_index, lPlayerID, "server_close_callback")
         With UserList(user_index)
             ' With UPD there is no way to send a msg after DirectPlay8Event.DestroyPlayer has been called so
             ' we set ConnIDValida to false to prevent sending msg and getting errors
             .ConnectionDetails.ConnIDValida = False
             If .flags.UserLogged Then
+                Call LogDisconnectEvent("modNetwork.DestroyPlayer", "Cerrar_Usuario", user_index, lPlayerID, "server_close_callback")
                 Call Cerrar_Usuario(user_index)
             End If
         End With
@@ -587,8 +607,12 @@ Public Sub Flush(ByVal user_index As Long)
     'Nothing
 End Sub
 
-Public Sub KickConnection(ByVal Connection As Long)
+Public Sub KickConnection(ByVal Connection As Long, Optional ByVal Reason As String = vbNullString, Optional ByVal Source As String = "modNetwork.KickConnection")
 On Error GoTo KickConnection_err:
+    Dim user_index As Integer
+    user_index = 0
+    If Mapping.Exists(Connection) Then user_index = Mapping.Item(Connection)
+    Call LogDisconnectEvent(Source, "KickConnection", user_index, Connection, Reason)
     Err.Clear
     Call dps.DestroyClient(Connection, 0, 0, 0)
     Exit Sub
@@ -598,7 +622,7 @@ KickConnection_err:
     End If
 End Sub
 
-Public Sub Kick(ByVal Connection As Long, Optional ByVal Message As String = vbNullString)
+Public Sub Kick(ByVal Connection As Long, Optional ByVal Message As String = vbNullString, Optional ByVal Source As String = "modNetwork.Kick")
 On Error GoTo Kick_ErrHandler:
     If IsFeatureEnabled("debug_connections") Then
         If (Message <> vbNullString) Then
@@ -607,18 +631,23 @@ On Error GoTo Kick_ErrHandler:
             Call AddLogToCircularBuffer("Kick connection: " & Connection)
         End If
     End If
+    Dim user_index As Integer
+    user_index = 0
+    If Mapping.Exists(Connection) Then user_index = Mapping.Item(Connection)
+    If user_index > 0 And UserList(user_index).flags.UserLogged Then
+        Call LogDisconnectEvent(Source, "Kick", user_index, Connection, Message)
+    Else
+        Call LogDisconnectEvent(Source, "Kick", 0, Connection, Message)
+    End If
     If (Message <> vbNullString) Then
-        Dim user_index As Integer
-        
         If Mapping.Exists(Connection) Then
-            user_index = Mapping.Item(Connection)
             Call Protocol_Writes.WriteErrorMsg(user_index, Message)
             If UserList(user_index).flags.UserLogged Then
                 Call Cerrar_Usuario(user_index)
             End If
         End If
     End If
-    KickConnection Connection
+    KickConnection Connection, Message, Source
     Exit Sub
     
 Kick_ErrHandler:

--- a/Server.VBP
+++ b/Server.VBP
@@ -83,6 +83,7 @@ Module=basCryptoSys; Codigo\basCryptoSys.bas
 Module=ModShopAO20; Codigo\ModShopAO20.bas
 Module=UnitTesting; Codigo\UnitTesting.bas
 Module=Logging; Codigo\Logging.bas
+Module=DisconnectDiagnostics; Codigo\DisconnectDiagnostics.bas
 Class=Instruments; Codigo\Instrumentation.cls
 Module=modTime; Codigo\modTime.bas
 Module=UnitClient; Codigo\Tests\UnitClient.bas


### PR DESCRIPTION
### Motivation

- Add lightweight disconnect diagnostics and richer logging for network disconnects to aid debugging of unexpected client disconnects and packet-driven kicks. 
- Ensure disconnect-related functions propagate a human-readable `Reason` and `Source` to central logging so operators can correlate kicks/closures with code paths and packet IDs.

### Description

- Add new module `DisconnectDiagnostics.bas` with `LogDisconnectEvent` to emit gated diagnostics messages when the `debug_disconnects` feature flag is enabled. 
- Thread `Reason` and `Source` parameters through network shutdown APIs by adding optional `Reason` and `Source` arguments to `Kick`, `KickConnection`, `CloseSocket`, and `CloseSocketSL` and updating callers to pass context. 
- Instrument many disconnect and protocol-handling sites (including `Protocol.HandleIncomingData`, anti-cheat callbacks, and `modNetwork` connection lifecycle handlers) to call `LogDisconnectEvent` with contextual fields like `packetId` and user/connection info. 
- Register the new module in `Server.VBP` so it is compiled with the project. 

### Testing

- Performed a project build of the solution and the build completed successfully. 
- Executed the repository's automated unit test suite (`Unit_*` modules) and the tests completed successfully. 
- Ran the automated network-related tests included in the suite and they passed, confirming no regressions in disconnect semantics.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29de80ed9c8328a1c3df7630304c93)