### PR TITLE
Add disconnect diagnostics logging

### DIFF
--- a/Codigo/AntiCheat.bas
+++ b/Codigo/AntiCheat.bas
@@ -131,8 +131,7 @@ Public Sub KickUnregisteredPlayers()
         If Result > 0 And IsValidUserRef(UserRef) Then
             If Not IsUserAdmin(UserRef.ArrayIndex) Then
                 With UserList(UserRef.ArrayIndex)
-                    Call LogDisconnectEvent("AntiCheat.KickUnregisteredPlayers", "Kick", UserRef.ArrayIndex, .ConnectionDetails.ConnID, "anticheat_register_timeout user=" & .name)
-                    Call modNetwork.Kick(.ConnectionDetails.ConnID, "Anticheat detection timeout for Username: " & .name, "AntiCheat.KickUnregisteredPlayers")
+                    Call modNetwork.Kick(.ConnectionDetails.ConnID, "anticheat_register_timeout", "AntiCheat.KickUnregisteredPlayers", -1, vbNullString, -1, "user=" & .name)
                 End With
             End If
         End If
@@ -211,7 +210,6 @@ Public Sub ClientActionRequired(ByRef UserRef As t_UserReference, ByVal Action A
         ReasonStr = GetStringFromPtr(ReasonString.Ptr, ReasonString.Len)
     End If
     If Action = eEOS_ACCCA_RemovePlayer And IsValidUserRef(UserRef) Then
-        Call LogDisconnectEvent("AntiCheat.ClientActionRequired", "Kick", UserRef.ArrayIndex, UserList(UserRef.ArrayIndex).ConnectionDetails.ConnID, ReasonStr)
         Call modNetwork.Kick(UserList(UserRef.ArrayIndex).ConnectionDetails.ConnID, ReasonStr, "AntiCheat.ClientActionRequired")
     End If
     Exit Sub

--- a/Codigo/DisconnectDiagnostics.bas
+++ b/Codigo/DisconnectDiagnostics.bas
@@ -1,9 +1,67 @@
 Attribute VB_Name = "DisconnectDiagnostics"
 ' Argentum 20 Game Server
 '
-' Lightweight disconnect diagnostics gated by the debug_disconnects feature flag.
+' Lightweight disconnect diagnostics gated by PYMMO and debug_disconnects.
 
 Option Explicit
+
+Public Sub LogDisconnectDiag( _
+    ByVal Source As String, _
+    ByVal Action As String, _
+    ByVal UserIndex As Integer, _
+    ByVal ConnID As Long, _
+    ByVal Reason As String, _
+    Optional ByVal PacketId As Long = -1, _
+    Optional ByVal PacketName As String = vbNullString, _
+    Optional ByVal PacketCount As Long = -1, _
+    Optional ByVal Extra As String = vbNullString)
+
+    On Error Resume Next
+
+    #If PYMMO = 0 Then
+        Exit Sub
+    #End If
+
+    If Not IsFeatureEnabled("debug_disconnects") Then Exit Sub
+
+    If PacketName = vbNullString And PacketId >= 0 Then
+        PacketName = GetClientPacketName(PacketId)
+    End If
+
+    Dim message As String
+    message = "disconnect_diag" & _
+            " source=" & CleanDisconnectDiagValue(Source) & _
+            " action=" & CleanDisconnectDiagValue(Action) & _
+            " reason=" & CleanDisconnectDiagValue(Reason) & _
+            " userIndex=" & CStr(UserIndex) & _
+            " connID=" & CStr(ConnID)
+
+    If PacketId >= 0 Then message = message & " packetId=" & CStr(PacketId)
+    If PacketName <> vbNullString Then message = message & " packetName=" & CleanDisconnectDiagValue(PacketName)
+    If PacketCount >= 0 Then message = message & " packetCount=" & CStr(PacketCount)
+
+    If UserIndex > 0 Then
+        With UserList(UserIndex)
+            message = message & _
+                    " name=" & CleanDisconnectDiagValue(.name) & _
+                    " userId=" & CStr(.Id) & _
+                    " accountId=" & CStr(.AccountID) & _
+                    " ip=" & CleanDisconnectDiagValue(.ConnectionDetails.IP) & _
+                    " logged=" & CStr(.flags.UserLogged) & _
+                    " connValid=" & CStr(.ConnectionDetails.ConnIDValida) & _
+                    " map=" & CStr(.pos.Map) & _
+                    " x=" & CStr(.pos.x) & _
+                    " y=" & CStr(.pos.y) & _
+                    " idle=" & CStr(.Counters.IdleCount) & _
+                    " saliendo=" & CStr(.Counters.Saliendo)
+        End With
+    End If
+
+    If Extra <> vbNullString Then message = message & " extra=" & CleanDisconnectDiagValue(Extra)
+
+    Call LogInfoServidor(message)
+    Call AddLogToCircularBuffer(message)
+End Sub
 
 Public Sub LogDisconnectEvent( _
     ByVal Source As String, _
@@ -13,43 +71,24 @@ Public Sub LogDisconnectEvent( _
     Optional ByVal Reason As String = vbNullString, _
     Optional ByVal PacketId As Long = -1)
 
+    Call LogDisconnectDiag(Source, Action, UserIndex, ConnID, Reason, PacketId)
+End Sub
+
+Public Function GetClientPacketName(ByVal PacketId As Long) As String
     On Error Resume Next
 
-    If Not IsFeatureEnabled("debug_disconnects") Then Exit Sub
-
-    Dim message As String
-    message = "disconnect_diag" & _
-            " source=" & Source & _
-            " action=" & Action & _
-            " userIndex=" & CStr(UserIndex) & _
-            " connID=" & CStr(ConnID)
-
-    If Reason <> vbNullString Then
-        message = message & " reason=" & Replace(Reason, vbCrLf, " ")
+    If PacketId < ClientPacketID.eMinPacket Or PacketId >= ClientPacketID.PacketCount Then
+        GetClientPacketName = "Invalid"
+    Else
+        GetClientPacketName = PacketID_to_string(PacketId)
+        If GetClientPacketName = vbNullString Then GetClientPacketName = "Unknown"
     End If
+End Function
 
-    If PacketId >= 0 Then
-        message = message & " packetId=" & CStr(PacketId)
-    End If
+Private Function CleanDisconnectDiagValue(ByVal Value As String) As String
+    On Error Resume Next
 
-    If UserIndex > 0 Then
-        With UserList(UserIndex)
-            message = message & _
-                    " username=" & .name & _
-                    " userId=" & CStr(.Id) & _
-                    " accountId=" & CStr(.AccountID) & _
-                    " ip=" & .ConnectionDetails.IP & _
-                    " userLogged=" & CStr(.flags.UserLogged) & _
-                    " connIDValida=" & CStr(.ConnectionDetails.ConnIDValida) & _
-                    " map=" & CStr(.pos.Map) & _
-                    " x=" & CStr(.pos.x) & _
-                    " y=" & CStr(.pos.y) & _
-                    " idleCount=" & CStr(.Counters.IdleCount) & _
-                    " saliendo=" & CStr(.Counters.Saliendo) & _
-                    " salir=" & CStr(.Counters.Salir)
-        End With
-    End If
-
-    Call LogInfoServidor(message)
-    Call AddLogToCircularBuffer(message)
-End Sub
+    CleanDisconnectDiagValue = Replace(Value, vbCr, " ")
+    CleanDisconnectDiagValue = Replace(CleanDisconnectDiagValue, vbLf, " ")
+    CleanDisconnectDiagValue = Replace(CleanDisconnectDiagValue, vbTab, " ")
+End Function

--- a/Codigo/Protocol.bas
+++ b/Codigo/Protocol.bas
@@ -175,6 +175,8 @@ Public Function HandleIncomingData(ByVal ConnectionID As Long, ByVal Message As 
     #End If
     Dim PacketId As Long
     PacketId = reader.ReadInt16
+    Dim PacketName As String
+    PacketName = GetClientPacketName(PacketId)
     Dim actual_time       As Long
     Dim performance_timer As Long
     actual_time = GetTickCountRaw()
@@ -196,8 +198,7 @@ Public Function HandleIncomingData(ByVal ConnectionID As Long, ByVal Message As 
                 End If
                 Mapping(ConnectionID).PacketCount = 0
                 If IsFeatureEnabled("kick_packet_overflow") Then
-                    Call LogDisconnectEvent("Protocol.HandleIncomingData", "KickConnection", UserIndex, ConnectionID, "packet_overflow count=" & CStr(PacketCountAtOverflow) & " packet=" & CStr(PacketId), PacketId)
-                    Call KickConnection(ConnectionID, "packet_overflow count=" & CStr(PacketCountAtOverflow) & " packet=" & CStr(PacketId), "Protocol.HandleIncomingData")
+                    Call KickConnection(ConnectionID, "packet_overflow", "Protocol.HandleIncomingData", PacketId, PacketName, PacketCountAtOverflow)
                 End If
             Else
                 If Not IsMissing(optional_user_index) Then ' userindex may be invalid here
@@ -206,8 +207,7 @@ Public Function HandleIncomingData(ByVal ConnectionID As Long, ByVal Message As 
                 End If
                 Mapping(ConnectionID).PacketCount = 0
                 If IsFeatureEnabled("kick_packet_overflow") Then
-                    Call LogDisconnectEvent("Protocol.HandleIncomingData", "KickConnection", 0, ConnectionID, "packet_overflow count=" & CStr(PacketCountAtOverflow) & " packet=" & CStr(PacketId), PacketId)
-                    Call KickConnection(ConnectionID, "packet_overflow count=" & CStr(PacketCountAtOverflow) & " packet=" & CStr(PacketId), "Protocol.HandleIncomingData")
+                    Call KickConnection(ConnectionID, "packet_overflow", "Protocol.HandleIncomingData", PacketId, PacketName, PacketCountAtOverflow)
                 End If
             End If
             Exit Function
@@ -219,8 +219,7 @@ Public Function HandleIncomingData(ByVal ConnectionID As Long, ByVal Message As 
             Call SendData(SendTarget.ToGM, UserIndex, PrepareMessageConsoleMsg("Control Paquetes---> El usuario " & GetUserGMName(UserIndex) & " | IP: " & UserList( _
                     UserIndex).ConnectionDetails.IP & " ESTÁ ENVIANDO PAQUETES INVÁLIDOS", e_FontTypeNames.FONTTYPE_GUILD))
         End If
-        Call LogDisconnectEvent("Protocol.HandleIncomingData", "KickConnection", UserIndex, ConnectionID, "invalid_packet packet=" & CStr(PacketId), PacketId)
-        Call KickConnection(ConnectionID, "invalid_packet packet=" & CStr(PacketId), "Protocol.HandleIncomingData")
+        Call KickConnection(ConnectionID, "invalid_packet", "Protocol.HandleIncomingData", PacketId, PacketName, Mapping(ConnectionID).PacketCount)
         Exit Function
     End If
     #If PYMMO = 1 Then
@@ -231,8 +230,7 @@ Public Function HandleIncomingData(ByVal ConnectionID As Long, ByVal Message As 
             If Not IsMissing(optional_user_index) Then ' userindex may be invalid here
                 'Is the user actually logged?
                 If Not UserList(UserIndex).flags.UserLogged Then
-                    Call LogDisconnectEvent("Protocol.HandleIncomingData", "CloseSocket", UserIndex, ConnectionID, "packet_requires_logged_user_but_user_not_logged packet=" & CStr(PacketId), PacketId)
-                    Call CloseSocket(UserIndex, "packet_requires_logged_user_but_user_not_logged packet=" & CStr(PacketId), "Protocol.HandleIncomingData")
+                    Call CloseSocket(UserIndex, "packet_requires_logged_user_but_user_not_logged", "Protocol.HandleIncomingData", PacketId, PacketName, Mapping(ConnectionID).PacketCount)
                     Exit Function
                     'He is logged. Reset idle counter if id is valid.
                 ElseIf PacketId <= ClientPacketID.[PacketCount] Then
@@ -240,8 +238,7 @@ Public Function HandleIncomingData(ByVal ConnectionID As Long, ByVal Message As 
                 End If
             Else
                 'If UserIndex is missing then kick out
-                Call LogDisconnectEvent("Protocol.HandleIncomingData", "KickConnection", 0, ConnectionID, "packet_requires_logged_user_but_user_not_logged packet=" & CStr(PacketId), PacketId)
-                Call KickConnection(ConnectionID, "packet_requires_logged_user_but_user_not_logged packet=" & CStr(PacketId), "Protocol.HandleIncomingData")
+                Call KickConnection(ConnectionID, "packet_requires_logged_user_but_user_not_logged", "Protocol.HandleIncomingData", PacketId, PacketName, Mapping(ConnectionID).PacketCount)
                 Exit Function ' Don't process incoming data
             End If
         Else
@@ -249,8 +246,7 @@ Public Function HandleIncomingData(ByVal ConnectionID As Long, ByVal Message As 
             Debug.Assert IsMissing(optional_user_index)
             If Not IsMissing(optional_user_index) Then
                 'If UserIndex is not missing then kick out
-                Call LogDisconnectEvent("Protocol.HandleIncomingData", "KickConnection", UserIndex, ConnectionID, "unexpected_login_packet_with_user packet=" & CStr(PacketId), PacketId)
-                Call KickConnection(ConnectionID, "unexpected_login_packet_with_user packet=" & CStr(PacketId), "Protocol.HandleIncomingData")
+                Call KickConnection(ConnectionID, "unexpected_login_packet_with_user", "Protocol.HandleIncomingData", PacketId, PacketName, Mapping(ConnectionID).PacketCount)
                 Exit Function ' Don't process incoming data
             End If
         End If
@@ -259,15 +255,13 @@ Public Function HandleIncomingData(ByVal ConnectionID As Long, ByVal Message As 
         If Not (PacketId = ClientPacketID.eCreateAccount Or PacketId = ClientPacketID.eLoginAccount) Then
             'Is the account actually logged?
             If UserList(UserIndex).AccountID = 0 Then
-                Call LogDisconnectEvent("Protocol.HandleIncomingData", "CloseSocket", UserIndex, ConnectionID, "packet_requires_logged_account_but_account_not_logged packet=" & CStr(PacketId), PacketId)
-                Call CloseSocket(UserIndex, "packet_requires_logged_account_but_account_not_logged packet=" & CStr(PacketId), "Protocol.HandleIncomingData")
+                Call CloseSocket(UserIndex, "packet_requires_logged_account_but_account_not_logged", "Protocol.HandleIncomingData", PacketId, PacketName, Mapping(ConnectionID).PacketCount)
                 Exit Function
             End If
             If Not (PacketId = ClientPacketID.eLoginExistingChar Or PacketId = ClientPacketID.eLoginNewChar) Then
                 'Is the user actually logged?
                 If Not UserList(UserIndex).flags.UserLogged Then
-                    Call LogDisconnectEvent("Protocol.HandleIncomingData", "CloseSocket", UserIndex, ConnectionID, "packet_requires_logged_user_but_user_not_logged packet=" & CStr(PacketId), PacketId)
-                    Call CloseSocket(UserIndex, "packet_requires_logged_user_but_user_not_logged packet=" & CStr(PacketId), "Protocol.HandleIncomingData")
+                    Call CloseSocket(UserIndex, "packet_requires_logged_user_but_user_not_logged", "Protocol.HandleIncomingData", PacketId, PacketName, Mapping(ConnectionID).PacketCount)
                     Exit Function
                     'He is logged. Reset idle counter if id is valid.
                 ElseIf PacketId <= ClientPacketID.[PacketCount] Then
@@ -900,8 +894,7 @@ Public Function HandleIncomingData(ByVal ConnectionID As Long, ByVal Message As 
             If Not IsMissing(optional_user_index) Then
                 Call SendData(SendTarget.ToGM, UserIndex, PrepareMessageConsoleMsg("[Error] Paquete desconocido: " & PacketId, e_FontTypeNames.FONTTYPE_GUILD))
             End If
-            Call LogDisconnectEvent("Protocol.HandleIncomingData", "KickConnection", UserIndex, ConnectionID, "unhandled_packet packet=" & CStr(PacketId), PacketId)
-            Call KickConnection(ConnectionID, "unhandled_packet packet=" & CStr(PacketId), "Protocol.HandleIncomingData")
+            Call KickConnection(ConnectionID, "unhandled_packet", "Protocol.HandleIncomingData", PacketId, PacketName, Mapping(ConnectionID).PacketCount)
             HandleIncomingData = False
             Exit Function
     End Select
@@ -915,8 +908,7 @@ Public Function HandleIncomingData(ByVal ConnectionID As Long, ByVal Message As 
         If Not IsMissing(optional_user_index) Then
             Call SendData(SendTarget.ToGM, UserIndex, PrepareMessageConsoleMsg("[Warning] " & errMsg, e_FontTypeNames.FONTTYPE_GUILD))
         End If
-        Call LogDisconnectEvent("Protocol.HandleIncomingData", "KickConnection", UserIndex, ConnectionID, "extra_bytes packet=" & CStr(PacketId) & " extra=" & CStr(reader.GetAvailable()), PacketId)
-        Call KickConnection(ConnectionID, "extra_bytes packet=" & CStr(PacketId) & " extra=" & CStr(reader.GetAvailable()), "Protocol.HandleIncomingData")
+        Call KickConnection(ConnectionID, "extra_bytes", "Protocol.HandleIncomingData", PacketId, PacketName, Mapping(ConnectionID).PacketCount, "extraBytes=" & CStr(reader.GetAvailable()))
         HandleIncomingData = False
         Exit Function
     End If

--- a/Codigo/TCP.bas
+++ b/Codigo/TCP.bas
@@ -553,9 +553,9 @@ ConnectNewUser_Err:
     Call TraceError(Err.Number, Err.Description, "TCP.ConnectNewUser", Erl)
 End Function
 
-Sub CloseSocket(ByVal UserIndex As Integer, Optional ByVal Reason As String = vbNullString, Optional ByVal Source As String = "TCP.CloseSocket")
+Sub CloseSocket(ByVal UserIndex As Integer, Optional ByVal Reason As String = vbNullString, Optional ByVal Source As String = "TCP.CloseSocket", Optional ByVal PacketId As Long = -1, Optional ByVal PacketName As String = vbNullString, Optional ByVal PacketCount As Long = -1, Optional ByVal Extra As String = vbNullString)
     On Error GoTo ErrHandler
-    Call LogDisconnectEvent(Source, "CloseSocket", UserIndex, UserList(UserIndex).ConnectionDetails.ConnID, Reason)
+    Call LogDisconnectDiag(Source, "CloseSocket", UserIndex, UserList(UserIndex).ConnectionDetails.ConnID, Reason, PacketId, PacketName, PacketCount, Extra)
     If UserIndex = LastUser Then
         Do Until UserList(LastUser).flags.UserLogged
             LastUser = LastUser - 1
@@ -563,7 +563,7 @@ Sub CloseSocket(ByVal UserIndex As Integer, Optional ByVal Reason As String = vb
         Loop
     End If
     With UserList(UserIndex)
-        If .ConnectionDetails.ConnIDValida Then Call CloseSocketSL(UserIndex, Reason, Source)
+        If .ConnectionDetails.ConnIDValida Then Call CloseSocketSL(UserIndex, Reason, Source, PacketId, PacketName, PacketCount, Extra)
         'mato los comercios seguros
         If IsValidUserRef(.ComUsu.DestUsu) Then
             If UserList(.ComUsu.DestUsu.ArrayIndex).flags.UserLogged Then
@@ -588,11 +588,11 @@ ErrHandler:
     Call TraceError(Err.Number, Err.Description, "TCP.CloseSocket", Erl)
 End Sub
 
-Sub CloseSocketSL(ByVal UserIndex As Integer, Optional ByVal Reason As String = vbNullString, Optional ByVal Source As String = "TCP.CloseSocketSL")
+Sub CloseSocketSL(ByVal UserIndex As Integer, Optional ByVal Reason As String = vbNullString, Optional ByVal Source As String = "TCP.CloseSocketSL", Optional ByVal PacketId As Long = -1, Optional ByVal PacketName As String = vbNullString, Optional ByVal PacketCount As Long = -1, Optional ByVal Extra As String = vbNullString)
     On Error GoTo CloseSocketSL_Err
     If UserList(UserIndex).ConnectionDetails.ConnIDValida Then
-        Call LogDisconnectEvent(Source, "CloseSocketSL", UserIndex, UserList(UserIndex).ConnectionDetails.ConnID, Reason)
-        Call modNetwork.Kick(UserList(UserIndex).ConnectionDetails.ConnID, Reason, Source)
+        Call LogDisconnectDiag(Source, "CloseSocketSL", UserIndex, UserList(UserIndex).ConnectionDetails.ConnID, Reason, PacketId, PacketName, PacketCount, Extra)
+        Call modNetwork.Kick(UserList(UserIndex).ConnectionDetails.ConnID, Reason, Source, PacketId, PacketName, PacketCount, Extra)
         UserList(UserIndex).ConnectionDetails.ConnIDValida = False
     End If
     Exit Sub

--- a/Codigo/modNetwork.bas
+++ b/Codigo/modNetwork.bas
@@ -97,7 +97,7 @@ Public Sub Flush(ByVal UserIndex As Long)
     Call Server.Flush(UserList(UserIndex).ConnectionDetails.ConnID)
 End Sub
 
-Public Sub Kick(ByVal Connection As Long, Optional ByVal Message As String = vbNullString, Optional ByVal Source As String = "modNetwork.Kick")
+Public Sub Kick(ByVal Connection As Long, Optional ByVal Message As String = vbNullString, Optional ByVal Source As String = "modNetwork.Kick", Optional ByVal PacketId As Long = -1, Optional ByVal PacketName As String = vbNullString, Optional ByVal PacketCount As Long = -1, Optional ByVal Extra As String = vbNullString)
     On Error GoTo Kick_ErrHandler:
     If IsFeatureEnabled("debug_connections") Then
         If (Message <> vbNullString) Then
@@ -109,9 +109,9 @@ Public Sub Kick(ByVal Connection As Long, Optional ByVal Message As String = vbN
     Dim UserRef As t_UserReference
     UserRef = Mapping(Connection).UserRef
     If IsValidUserRef(UserRef) And UserList(UserRef.ArrayIndex).flags.UserLogged Then
-        Call LogDisconnectEvent(Source, "Kick", UserRef.ArrayIndex, Connection, Message)
+        Call LogDisconnectDiag(Source, "Kick", UserRef.ArrayIndex, Connection, Message, PacketId, PacketName, PacketCount, Extra)
     Else
-        Call LogDisconnectEvent(Source, "Kick", 0, Connection, Message)
+        Call LogDisconnectDiag(Source, "Kick", 0, Connection, Message, PacketId, PacketName, PacketCount, Extra)
     End If
     If (Message <> vbNullString) Then
         If UserRef.ArrayIndex > 0 Then
@@ -200,9 +200,9 @@ Private Sub OnServerClose(ByVal Connection As Long)
     Dim UserRef As t_UserReference
     UserRef = Mapping(Connection).UserRef
     If IsValidUserRef(UserRef) Then
-        Call LogDisconnectEvent("modNetwork.OnServerClose", "remote_or_library_close", UserRef.ArrayIndex, Connection, "server_close_callback")
+        Call LogDisconnectDiag("modNetwork.OnServerClose", "remote_or_library_close", UserRef.ArrayIndex, Connection, "server_close_callback", -1, vbNullString, -1, "socket closed by remote peer, network layer or library callback")
     Else
-        Call LogDisconnectEvent("modNetwork.OnServerClose", "remote_or_library_close", 0, Connection, "server_close_callback")
+        Call LogDisconnectDiag("modNetwork.OnServerClose", "remote_or_library_close", 0, Connection, "server_close_callback", -1, vbNullString, -1, "socket closed by remote peer, network layer or library callback")
     End If
     If IsFeatureEnabled("debug_connections") Then
         If UserRef.ArrayIndex > 0 Then
@@ -235,7 +235,7 @@ Private Sub OnServerSend(ByVal Connection As Long, ByVal Message As Network.read
     On Error GoTo OnServerSend_Err:
     Exit Sub
 OnServerSend_Err:
-    Call Kick(Connection, "send_error err=" & CStr(Err.Number) & " desc=" & Err.Description, "modNetwork.OnServerSend")
+    Call Kick(Connection, "send_error", "modNetwork.OnServerSend_Err", -1, vbNullString, -1, "err=" & Err.Number & " desc=" & Err.Description)
     Call TraceError(Err.Number, Err.Description, "modNetwork.OnServerSend", Erl)
 End Sub
 
@@ -255,7 +255,7 @@ Private Sub OnServerRecv(ByVal Connection As Long, ByVal Message As Network.read
     End If
     Exit Sub
 OnServerRecv_Err:
-    Call Kick(Connection, "recv_error err=" & CStr(Err.Number) & " desc=" & Err.Description, "modNetwork.OnServerRecv")
+    Call Kick(Connection, "recv_error", "modNetwork.OnServerRecv_Err", -1, vbNullString, -1, "err=" & Err.Number & " desc=" & Err.Description)
     Call TraceError(Err.Number, Err.Description, "modNetwork.OnServerRecv", Erl)
 End Sub
 
@@ -272,14 +272,14 @@ ForcedClose_Err:
     Call TraceError(Err.Number, Err.Description, "modNetwork.ForcedClose", Erl)
 End Sub
 
-Public Sub KickConnection(ByVal Connection As Long, Optional ByVal Reason As String = vbNullString, Optional ByVal Source As String = "modNetwork.KickConnection")
+Public Sub KickConnection(ByVal Connection As Long, Optional ByVal Reason As String = vbNullString, Optional ByVal Source As String = "modNetwork.KickConnection", Optional ByVal PacketId As Long = -1, Optional ByVal PacketName As String = vbNullString, Optional ByVal PacketCount As Long = -1, Optional ByVal Extra As String = vbNullString)
     On Error GoTo ForcedClose_Err:
     Dim UserRef As t_UserReference
     UserRef = Mapping(Connection).UserRef
     If IsValidUserRef(UserRef) Then
-        Call LogDisconnectEvent(Source, "KickConnection", UserRef.ArrayIndex, Connection, Reason)
+        Call LogDisconnectDiag(Source, "KickConnection", UserRef.ArrayIndex, Connection, Reason, PacketId, PacketName, PacketCount, Extra)
     Else
-        Call LogDisconnectEvent(Source, "KickConnection", 0, Connection, Reason)
+        Call LogDisconnectDiag(Source, "KickConnection", 0, Connection, Reason, PacketId, PacketName, PacketCount, Extra)
     End If
     Call Server.Flush(Connection)
     Call Server.Kick(Connection, True)
@@ -607,12 +607,12 @@ Public Sub Flush(ByVal user_index As Long)
     'Nothing
 End Sub
 
-Public Sub KickConnection(ByVal Connection As Long, Optional ByVal Reason As String = vbNullString, Optional ByVal Source As String = "modNetwork.KickConnection")
+Public Sub KickConnection(ByVal Connection As Long, Optional ByVal Reason As String = vbNullString, Optional ByVal Source As String = "modNetwork.KickConnection", Optional ByVal PacketId As Long = -1, Optional ByVal PacketName As String = vbNullString, Optional ByVal PacketCount As Long = -1, Optional ByVal Extra As String = vbNullString)
 On Error GoTo KickConnection_err:
     Dim user_index As Integer
     user_index = 0
     If Mapping.Exists(Connection) Then user_index = Mapping.Item(Connection)
-    Call LogDisconnectEvent(Source, "KickConnection", user_index, Connection, Reason)
+    Call LogDisconnectDiag(Source, "KickConnection", user_index, Connection, Reason, PacketId, PacketName, PacketCount, Extra)
     Err.Clear
     Call dps.DestroyClient(Connection, 0, 0, 0)
     Exit Sub
@@ -622,7 +622,7 @@ KickConnection_err:
     End If
 End Sub
 
-Public Sub Kick(ByVal Connection As Long, Optional ByVal Message As String = vbNullString, Optional ByVal Source As String = "modNetwork.Kick")
+Public Sub Kick(ByVal Connection As Long, Optional ByVal Message As String = vbNullString, Optional ByVal Source As String = "modNetwork.Kick", Optional ByVal PacketId As Long = -1, Optional ByVal PacketName As String = vbNullString, Optional ByVal PacketCount As Long = -1, Optional ByVal Extra As String = vbNullString)
 On Error GoTo Kick_ErrHandler:
     If IsFeatureEnabled("debug_connections") Then
         If (Message <> vbNullString) Then
@@ -635,9 +635,9 @@ On Error GoTo Kick_ErrHandler:
     user_index = 0
     If Mapping.Exists(Connection) Then user_index = Mapping.Item(Connection)
     If user_index > 0 And UserList(user_index).flags.UserLogged Then
-        Call LogDisconnectEvent(Source, "Kick", user_index, Connection, Message)
+        Call LogDisconnectDiag(Source, "Kick", user_index, Connection, Message, PacketId, PacketName, PacketCount, Extra)
     Else
-        Call LogDisconnectEvent(Source, "Kick", 0, Connection, Message)
+        Call LogDisconnectDiag(Source, "Kick", 0, Connection, Message, PacketId, PacketName, PacketCount, Extra)
     End If
     If (Message <> vbNullString) Then
         If Mapping.Exists(Connection) Then

--- a/Example.feature_toggle.ini
+++ b/Example.feature_toggle.ini
@@ -1,5 +1,5 @@
 [INIT]
-TOGGLECOUNT=21
+TOGGLECOUNT=22
 [TOGGLE1]
 name=bandit_unequip_bonus
 value=1
@@ -63,3 +63,6 @@ value=1
 [TOGGLE21]
 name=EnablePatreonAlias
 value=1
+[TOGGLE22]
+name=debug_disconnects
+value=0


### PR DESCRIPTION
### Motivation

- Improve visibility into why logged-in users are being disconnected by capturing reason, source, packet id/name/count and user/connection info without changing gameplay behavior.  
- Ensure diagnostics are inert when `PYMMO = 0` and only active when the `debug_disconnects` feature flag is enabled.

### Description

- Added a new module `Codigo/DisconnectDiagnostics.bas` implementing `LogDisconnectDiag` (uses `On Error Resume Next`, `#If PYMMO = 0 Then Exit Sub`, `IsFeatureEnabled("debug_disconnects")` check), `GetClientPacketName`, and `CleanDisconnectDiagValue`, which emits a single compact `disconnect_diag ...` line via `LogInfoServidor` and also writes to `AddLogToCircularBuffer` when available.  
- Threaded optional packet metadata through root disconnect wrappers by adding Optional parameters to `modNetwork.Kick`, `modNetwork.KickConnection`, `TCP.CloseSocket`, and `TCP.CloseSocketSL` so existing call sites remain compatible.  
- Instrumented `Protocol.HandleIncomingData` to compute `PacketName` and pass `PacketId`, `PacketName`, and `PacketCount` into disconnect branches (packet overflow, invalid, unhandled, extra bytes, and packet-requires-logged-user/account cases).  
- Instrumented network error/close roots and anti-cheat timeout paths (`modNetwork.OnServerClose`, `modNetwork.OnServerRecv_Err`, `modNetwork.OnServerSend_Err`, `AntiCheat.KickUnregisteredPlayers`) to call the diagnostics helper with concise `reason`/`extra` context; added `debug_disconnects` toggle to `Example.feature_toggle.ini` (default `value=0`).

### Testing

- Ran `git diff --check` to validate no whitespace/patch problems and it passed.  
- Performed a line-count sanity script on the modified files (`Codigo/DisconnectDiagnostics.bas`, `Codigo/modNetwork.bas`, `Codigo/TCP.bas`, `Codigo/Protocol.bas`, `Codigo/AntiCheat.bas`, `Example.feature_toggle.ini`) to confirm expected writes.  
- Ran targeted `rg`/static searches to confirm instrumentation only touches disconnect/error roots and that normal `Send`/`Flush`/successful receive paths were not modified.  
- Changes were committed (work tree contains the new commit) after the automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f2aa7c3b08328843f8de9c4f561f4)