### PR TITLE
Disconnect unlogged connections on packet overflow; preserve toggle for logged users

### DIFF
--- a/Codigo/Protocol.bas
+++ b/Codigo/Protocol.bas
@@ -196,19 +196,29 @@ Public Function HandleIncomingData(ByVal ConnectionID As Long, ByVal Message As 
                     Call SendData(SendTarget.ToAdminsYDioses, UserIndex, PrepareMessageConsoleMsg("Control Paquetes---> El usuario " & GetUserGMName(UserIndex) & _
                             " | Iteración paquetes | Último paquete: " & PacketId & ".", e_FontTypeNames.FONTTYPE_FIGHT))
                 End If
-                Mapping(ConnectionID).PacketCount = 0
-                If IsFeatureEnabled("kick_packet_overflow") Then
-                    Call KickConnection(ConnectionID, "packet_overflow", "Protocol.HandleIncomingData", PacketId, PacketName, PacketCountAtOverflow)
-                End If
             Else
                 If Not IsMissing(optional_user_index) Then ' userindex may be invalid here
                     Call SendData(SendTarget.ToAdminsYDioses, UserIndex, PrepareMessageConsoleMsg( _
                             "Control Paquetes---> Usuario desconocido | Iteración paquetes | Último paquete: " & PacketId & ".", e_FontTypeNames.FONTTYPE_FIGHT))
                 End If
-                Mapping(ConnectionID).PacketCount = 0
-                If IsFeatureEnabled("kick_packet_overflow") Then
-                    Call KickConnection(ConnectionID, "packet_overflow", "Protocol.HandleIncomingData", PacketId, PacketName, PacketCountAtOverflow)
-                End If
+            End If
+            Mapping(ConnectionID).PacketCount = 0
+            ' Packet overflow before a user is fully logged in is treated as protocol/login abuse.
+            ' There is no legitimate gameplay traffic yet, so disconnect these connections
+            ' regardless of the kick_packet_overflow feature toggle.
+            '
+            ' For fully logged-in users we keep the existing feature-toggle behavior because
+            ' normal gameplay can legitimately create packet bursts, especially during combat
+            ' or after lag/TCP buffering.
+            '
+            ' IMPORTANT: VB6 does not short-circuit And/Or expressions. Keep the UserIndex
+            ' checks split and never access UserList(UserIndex) unless UserIndex > 0.
+            If UserIndex <= 0 Then
+                Call KickConnection(ConnectionID, "packet_overflow", "Protocol.HandleIncomingData", PacketId, PacketName, PacketCountAtOverflow)
+            ElseIf Not UserList(UserIndex).flags.UserLogged Then
+                Call KickConnection(ConnectionID, "packet_overflow", "Protocol.HandleIncomingData", PacketId, PacketName, PacketCountAtOverflow)
+            ElseIf IsFeatureEnabled("kick_packet_overflow") Then
+                Call KickConnection(ConnectionID, "packet_overflow", "Protocol.HandleIncomingData", PacketId, PacketName, PacketCountAtOverflow)
             End If
             Exit Function
         End If


### PR DESCRIPTION
### Motivation

- Prevent protocol/login abuse by ensuring connections that overflow packet counts before a user is fully logged in are always disconnected, while avoiding false positives for legitimate in-game packet bursts.

### Description

- Move `Mapping(ConnectionID).PacketCount` reset out of the inner branches and centralize overflow handling in `Protocol.HandleIncomingData` when `Mapping(ConnectionID).PacketCount > 100`.
- Always call `KickConnection` for connections with `UserIndex <= 0` or where `UserList(UserIndex).flags.UserLogged` is false to treat pre-login packet floods as abuse, regardless of the `kick_packet_overflow` feature toggle.  
- For fully logged users keep the previous behavior and only `KickConnection` when `IsFeatureEnabled("kick_packet_overflow")` is true.  
- Add explanatory comments and a VB6-specific note to avoid accessing `UserList(UserIndex)` unless `UserIndex > 0` because VB6 does not short-circuit logical expressions.

### Testing

- Ran the existing automated test suite which includes packet handling unit tests and all tests completed successfully.  
- Executed simulated packet flood scenarios for unlogged and logged users to verify unlogged connections are always disconnected and logged users respect the `kick_packet_overflow` toggle, and these integration checks passed.  
- Performed a simple build verification of `Protocol.bas` with the server test harness and no regressions were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a304c394c4883289b532ed16e19235d)