### PR TITLE
Impedir venta de skins a comerciantes

### DIFF
--- a/Codigo/Comercio.bas
+++ b/Codigo/Comercio.bas
@@ -97,6 +97,10 @@ Public Sub Comercio(ByVal Modo As eModoComercio, ByVal UserIndex As Integer, ByV
         Objeto.ObjIndex = UserList(UserIndex).invent.Object(Slot).ObjIndex
         If Objeto.ObjIndex = 0 Then
             Exit Sub
+        ElseIf EsSkinNoComprablePorComerciante(ObjData(Objeto.ObjIndex).OBJType) Then
+            'Msg1084= Lo siento, no puedo comprarte ese item.
+            Call WriteLocaleMsg(UserIndex, MSG_NO_SIENTO_PUEDO_COMPRARTE_ESE_ITEM, e_FontTypeNames.FONTTYPE_TALK)
+            Exit Sub
         ElseIf ObjData(Objeto.ObjIndex).Newbie = 1 Then
             'Msg1083= Lo siento, no comercio objetos para newbies.
             Call WriteLocaleMsg(UserIndex, MSG_NO_SIENTO_COMERCIO_OBJETOS_NEWBIES, e_FontTypeNames.FONTTYPE_TALK)
@@ -215,6 +219,13 @@ Private Function SlotEnNPCInv(ByVal NpcIndex As Integer, ByVal Objeto As Integer
     End With
 SlotEnNPCInv_Err:
     Call TraceError(Err.Number, Err.Description, "modSistemaComercio.SlotEnNPCInv", Erl)
+End Function
+
+Private Function EsSkinNoComprablePorComerciante(ByVal OBJType As e_OBJType) As Boolean
+    Select Case OBJType
+        Case e_OBJType.otSkinsWings, e_OBJType.otSkinsArmours, e_OBJType.otSkinsShields, e_OBJType.otSkinsHelmets, e_OBJType.otSkinsWeapons, e_OBJType.otSkinsBoats
+            EsSkinNoComprablePorComerciante = True
+    End Select
 End Function
 
 Private Function Descuento(ByVal UserIndex As Integer) As Single

--- a/Codigo/Comercio.bas
+++ b/Codigo/Comercio.bas
@@ -223,7 +223,9 @@ End Function
 
 Private Function EsSkinNoComprablePorComerciante(ByVal OBJType As e_OBJType) As Boolean
     Select Case OBJType
-        Case e_OBJType.otSkinsWings, e_OBJType.otSkinsArmours, e_OBJType.otSkinsShields, e_OBJType.otSkinsHelmets, e_OBJType.otSkinsWeapons, e_OBJType.otSkinsBoats
+        Case e_OBJType.otSkinsWings, e_OBJType.otSkinsArmours, e_OBJType.otSkinsShields, _
+            e_OBJType.otSkinsHelmets, e_OBJType.otSkinsWeapons, e_OBJType.otSkinsBoats, _
+            e_OBJType.otSkinsSpells
             EsSkinNoComprablePorComerciante = True
     End Select
 End Function


### PR DESCRIPTION
### Motivation
- Evitar que los NPC comerciantes compren skins (alas, armaduras, escudos, cascos, armas y botes) cuando un usuario intenta venderlos al comerciante.
- Mantener la lógica clara y centralizada para futuros cambios en la lista de tipos no comprables.

### Description
- Añadida comprobación en el flujo de venta dentro de `Codigo/Comercio.bas` para rechazar objetos cuyo tipo sea skin y mostrar el mensaje estándar `MSG_NO_SIENTO_PUEDO_COMPRARTE_ESE_ITEM`.
- Introducida la función auxiliar `EsSkinNoComprablePorComerciante(OBJType As e_OBJType)` en `Codigo/Comercio.bas` que lista explícitamente `otSkinsWings`, `otSkinsArmours`, `otSkinsShields`, `otSkinsHelmets`, `otSkinsWeapons` y `otSkinsBoats` como no comprables.
- El cambio modifica únicamente `Codigo/Comercio.bas` y no altera otras rutas de negocio ni mensajes existentes.

### Testing
- Ejecutado `git diff --check` y no reportó errores, por lo que el parche no introduce problemas detectados por la verificación de diff.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36de9671f4832897ca13c67422b123)