### PR TITLE
Add new Patreon tiers (Noble / Emperador) mapped to Leyenda

### DIFF
--- a/Codigo/CharacterPersistence.bas
+++ b/Codigo/CharacterPersistence.bas
@@ -520,7 +520,7 @@ Public Function GetPatronTierFromAccountID(ByVal account_id) As e_TipoUsuario
                 GetPatronTierFromAccountID = e_TipoUsuario.tAventurero
             Case patron_tier_heroe
                 GetPatronTierFromAccountID = e_TipoUsuario.tHeroe
-            Case patron_tier_leyenda
+            Case patron_tier_leyenda, patron_tier_noble, patron_tier_emperador
                 GetPatronTierFromAccountID = e_TipoUsuario.tLeyenda
             Case Else
                 GetPatronTierFromAccountID = e_TipoUsuario.tNormal

--- a/Codigo/Declares.bas
+++ b/Codigo/Declares.bas
@@ -2446,6 +2446,8 @@ End Type
 Public Const patron_tier_aventurero As Long = 6057393
 Public Const patron_tier_heroe      As Long = 6057394
 Public Const patron_tier_leyenda    As Long = 6057395
+Public Const patron_tier_noble      As Long = 28929328
+Public Const patron_tier_emperador  As Long = 28929365
 
 Public Enum e_TipoUsuario
     tNormal = 0


### PR DESCRIPTION
### Motivation
- Support two new Patreon tiers (Noble de Argentum and Emperador de Argentum) so accounts using those IDs receive the existing Leyenda benefits without changing gameplay or internal enums.
- Keep the change minimal and localized to tier constants and the account-to-internal-tier mapping.

### Description
- Added `patron_tier_noble = 28929328` and `patron_tier_emperador = 28929365` next to the existing Patreon constants in `Codigo/Declares.bas`.
- Updated `GetPatronTierFromAccountID` in `Codigo/CharacterPersistence.bas` so `patron_tier_noble` and `patron_tier_emperador` are treated as `e_TipoUsuario.tLeyenda` (`Case patron_tier_leyenda, patron_tier_noble, patron_tier_emperador`).
- Did not add or change any `Enum` values, inventory/character slots, timers, maps, house keys, skins, or database migrations.
- Changes are minimal and limited to `Codigo/Declares.bas` and `Codigo/CharacterPersistence.bas` only.

### Testing
- Ran a repository-wide search with `rg` for the old and new Patreon IDs and for common patterns/assumptions about tier counts to confirm no other code required modification, and the search returned no places that needed changes beyond the mapping update.
- Ran `git diff --check` to verify there are no whitespace or diff issues and it passed without errors.
- Verified the updated lines in `Codigo/Declares.bas` and `Codigo/CharacterPersistence.bas` to ensure the new constants and mapping are present and correct.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b08b727208328a588e7f8d5f5f162)