### PR TITLE
Agregar cooldown para próxima solicitud al abandonar/ser expulsado de un clan.

### DIFF
--- a/Codigo/CharacterPersistence.bas
+++ b/Codigo/CharacterPersistence.bas
@@ -320,7 +320,7 @@ Private Sub SetupUserBasicInfo(ByRef User As t_User, ByRef RS As ADODB.Recordset
         .Stats.Advertencias = RS!warnings
         .GuildIndex = SanitizeNullValue(RS!Guild_Index, 0)
         .LastGuildRejection = SanitizeNullValue(RS!guild_rejected_because, vbNullString)
-        .LastGuildLeave = RS(!LastGuildLeave)
+        .LastGuildLeave = RS!last_guild_leave
     End With
 End Sub
 
@@ -649,7 +649,7 @@ Private Sub SaveCharacterMainDB(ByRef U As t_User, ByRef QueryBreakdown As Strin
     Params(post_increment(i)) = U.flags.ReturnPos.y
     Params(post_increment(i)) = U.Stats.JineteLevel
     Params(post_increment(i)) = U.Char.BackpackAnim
-    Params(post_increment(i)) = DateToSQLite(U.LastGuildLeaveTimestamp)
+    Params(post_increment(i)) = DateToSQLite(U.LastGuildLeave)
     ' WHERE block
     Params(post_increment(i)) = U.Id
     Debug.Assert i = UBound(Params) + 1

--- a/Codigo/CharacterPersistence.bas
+++ b/Codigo/CharacterPersistence.bas
@@ -320,6 +320,7 @@ Private Sub SetupUserBasicInfo(ByRef User As t_User, ByRef RS As ADODB.Recordset
         .Stats.Advertencias = RS!warnings
         .GuildIndex = SanitizeNullValue(RS!Guild_Index, 0)
         .LastGuildRejection = SanitizeNullValue(RS!guild_rejected_because, vbNullString)
+        .LastGuildLeave = RS(!LastGuildLeave)
     End With
 End Sub
 
@@ -585,7 +586,7 @@ End Sub
 Private Sub SaveCharacterMainDB(ByRef U As t_User, ByRef QueryBreakdown As String)
     Dim QueryTimer As Long
     Dim Params() As Variant
-    ReDim Params(61)
+    ReDim Params(62)
     Dim i As Integer
     Params(post_increment(i)) = U.Stats.ELV
     Params(post_increment(i)) = U.Stats.Exp
@@ -648,6 +649,7 @@ Private Sub SaveCharacterMainDB(ByRef U As t_User, ByRef QueryBreakdown As Strin
     Params(post_increment(i)) = U.flags.ReturnPos.y
     Params(post_increment(i)) = U.Stats.JineteLevel
     Params(post_increment(i)) = U.Char.BackpackAnim
+    Params(post_increment(i)) = DateToSQLite(U.LastGuildLeaveTimestamp)
     ' WHERE block
     Params(post_increment(i)) = U.Id
     Debug.Assert i = UBound(Params) + 1

--- a/Codigo/CharacterPersistence.bas
+++ b/Codigo/CharacterPersistence.bas
@@ -320,7 +320,7 @@ Private Sub SetupUserBasicInfo(ByRef User As t_User, ByRef RS As ADODB.Recordset
         .Stats.Advertencias = RS!warnings
         .GuildIndex = SanitizeNullValue(RS!Guild_Index, 0)
         .LastGuildRejection = SanitizeNullValue(RS!guild_rejected_because, vbNullString)
-        .LastGuildLeave = RS!last_guild_leave
+        .LastGuildLeave = SanitizeNullValue(RS!last_guild_leave, -657434)
     End With
 End Sub
 

--- a/Codigo/CharacterPersistence.bas
+++ b/Codigo/CharacterPersistence.bas
@@ -320,7 +320,7 @@ Private Sub SetupUserBasicInfo(ByRef User As t_User, ByRef RS As ADODB.Recordset
         .Stats.Advertencias = RS!warnings
         .GuildIndex = SanitizeNullValue(RS!Guild_Index, 0)
         .LastGuildRejection = SanitizeNullValue(RS!guild_rejected_because, vbNullString)
-        .LastGuildLeave = SanitizeNullValue(RS!last_guild_leave, -657434)
+        .LastGuildLeave = SanitizeNullValue(RS!last_guild_leave, MIN_DATE_AS_LONG)
     End With
 End Sub
 

--- a/Codigo/Consts.bas
+++ b/Codigo/Consts.bas
@@ -45,6 +45,7 @@ Public Const DEFAULT_NPC_STRAFE_DURATION_MS         As Long = 900
 'General consts
 Public Const MAX_INTEGER                            As Integer = 32767
 Public Const MAX_LONG                               As Long = 2147483647
+Public Const MIN_DATE_AS_LONG                       As Long = -657434
 
 
 'FX

--- a/Codigo/Database_Queries.bas
+++ b/Codigo/Database_Queries.bas
@@ -129,6 +129,7 @@ Private Sub ConstruirQuery_CargarPersonaje()
     QueryBuilder.Append "is_locked_in_mao,"
     QueryBuilder.Append "jinete_level,"
     QueryBuilder.Append "backpack_id"
+    QueryBuilder.Append "last_guild_leave"
     QueryBuilder.Append " FROM user WHERE id= ?"
     ' Guardo la query ensamblada
     QUERY_LOAD_MAINPJ = QueryBuilder.ToString

--- a/Codigo/Database_Queries.bas
+++ b/Codigo/Database_Queries.bas
@@ -303,6 +303,7 @@ Private Sub ConstruirQuery_GuardarPersonaje()
     QueryBuilder.Append "return_y = ?, "
     QueryBuilder.Append "jinete_level = ?, "
     QueryBuilder.Append "backpack_id = ? "
+    QueryBuilder.Append "last_guild_leave = ?"
     QueryBuilder.Append "WHERE id = ?"
     ' Guardo la query ensamblada
     QUERY_UPDATE_MAINPJ = QueryBuilder.ToString

--- a/Codigo/Database_Queries.bas
+++ b/Codigo/Database_Queries.bas
@@ -128,7 +128,7 @@ Private Sub ConstruirQuery_CargarPersonaje()
     QueryBuilder.Append "is_reset,"
     QueryBuilder.Append "is_locked_in_mao,"
     QueryBuilder.Append "jinete_level,"
-    QueryBuilder.Append "backpack_id"
+    QueryBuilder.Append "backpack_id,"
     QueryBuilder.Append "last_guild_leave"
     QueryBuilder.Append " FROM user WHERE id= ?"
     ' Guardo la query ensamblada
@@ -303,7 +303,7 @@ Private Sub ConstruirQuery_GuardarPersonaje()
     QueryBuilder.Append "return_x = ?, "
     QueryBuilder.Append "return_y = ?, "
     QueryBuilder.Append "jinete_level = ?, "
-    QueryBuilder.Append "backpack_id = ? "
+    QueryBuilder.Append "backpack_id = ?, "
     QueryBuilder.Append "last_guild_leave = ?"
     QueryBuilder.Append "WHERE id = ?"
     ' Guardo la query ensamblada

--- a/Codigo/Declares.bas
+++ b/Codigo/Declares.bas
@@ -3021,7 +3021,7 @@ Public Type t_User
     FundandoGuildAlineacion As e_ALINEACION_GUILD     'esto esta aca hasta que se parchee el cliente y se pongan cadenas de datos distintas para cada alineacion
     EscucheClan As Integer
     LastGuildRejection As String
-    LastGuildLeaveTimestamp As Date
+    LastGuildLeave As Date
     KeyCrypt As Integer
     AreasInfo As t_AreaInfo
     QuestStats As t_QuestStats

--- a/Codigo/Declares.bas
+++ b/Codigo/Declares.bas
@@ -3021,6 +3021,7 @@ Public Type t_User
     FundandoGuildAlineacion As e_ALINEACION_GUILD     'esto esta aca hasta que se parchee el cliente y se pongan cadenas de datos distintas para cada alineacion
     EscucheClan As Integer
     LastGuildRejection As String
+    LastGuildLeaveTimestamp As Date
     KeyCrypt As Integer
     AreasInfo As t_AreaInfo
     QuestStats As t_QuestStats

--- a/Codigo/ServerConfig.cls
+++ b/Codigo/ServerConfig.cls
@@ -107,6 +107,7 @@ Public Function LoadSettings(ByVal Filename As String) As Long
     mSettings.Add "JineteLevel7Speed", CSng(val(reader.GetValue("CONFIGURACIONES", "JineteLevel7Speed", "1.30")))
     mSettings.Add "JineteLevel8Speed", CSng(val(reader.GetValue("CONFIGURACIONES", "JineteLevel8Speed", "1.45")))
     mSettings.Add "JineteLevel9Speed", CSng(val(reader.GetValue("CONFIGURACIONES", "JineteLevel9Speed", "1.50")))
+    mSettings.Add "GuildLeaveCooldownInDays", CLng(val(reader.GetValue("CONFIGURACIONES", "GuildLeaveCooldownInDays", "1")))
     mSettings.Add "CostoPreSubasta", CLng(val(reader.GetValue("CONFIGURACIONES", "CostoPreSubasta", "500")))
     mSettings.Add "MaxJailTime", CLng(val(reader.GetValue("CONFIGURACIONES", "MaxJailTime", "8640")))
     mSettings.Add "DropMult", CInt(val(reader.GetValue("CONFIGURACIONES", "DropMult", 1)))

--- a/Codigo/modGuilds.bas
+++ b/Codigo/modGuilds.bas
@@ -859,9 +859,6 @@ Public Function a_NuevoAspirante(ByVal UserIndex As Integer, ByRef clan As Strin
         refError = 2010 'Ya perteneces a un clan, debes salir del mismo antes de solicitar ingresar a otro.
         Exit Function
     End If
-    If IsAspirantOnGuildJoinCooldown(UserIndex) Then
-        Exit Function
-    End If
     If EsNewbie(UserIndex) Then
         refError = 2005 'Los newbies no tienen derecho a entrar a un clan.
         Exit Function
@@ -878,6 +875,9 @@ Public Function a_NuevoAspirante(ByVal UserIndex As Integer, ByRef clan As Strin
     If guilds(NuevoGuildIndex).CantidadAspirantes >= MAXASPIRANTES Then
         refError = 2008 'El clan tiene demasiados aspirantes. Contáctate con un miembro para que procese las solicitudes.
         Exit Function
+    End If
+    If IsAspirantOnGuildJoinCooldown(UserIndex) Then
+        refError = 2225
     End If
     Dim NuevoGuildAspirantes() As String
     NuevoGuildAspirantes = guilds(NuevoGuildIndex).GetAspirantes()
@@ -1196,18 +1196,12 @@ GetGuildMemberList_Err:
     Call TraceError(Err.Number, Err.Description, "modGuilds.GetGuildMemberList", Erl)
 End Function
 
-Public Function IsAspirantOnGuildJoinCooldown(ByVal UserIndex As Integer, Optional ByRef CharacterName As String) As Boolean
+Public Function IsAspirantOnGuildJoinCooldown(ByVal UserIndex As Integer) As Boolean
     IsAspirantOnGuildJoinCooldown = True
     Dim GuildLeaveCooldownInDays As Long
-    Dim CharacterLastLeave As Date
     GuildLeaveCooldownInDays = SvrConfig.GetValue("GuildLeaveCooldownInDays")
     With UserList(UserIndex)
-        If .flags.UserLogged Then
-            CharacterLastLeave = .LastGuildLeave
-        Else
-            CharacterLastLeave = GetLastGuildLeaveFromDb(CharacterName)
-        End If
-        If .LastGuildLeave - DateTime.Now <= GuildLeaveCooldownInDays Then
+        If CLng(.LastGuildLeave - DateTime.Now) <= GuildLeaveCooldownInDays Then
                 'cant rejoin errormsg
             Exit Function
         End If
@@ -1215,19 +1209,6 @@ Public Function IsAspirantOnGuildJoinCooldown(ByVal UserIndex As Integer, Option
     End With
 End Function
 
-Public Function GetLastGuildLeaveFromDb(ByRef CharacterName As String) As String
-    On Error GoTo GetLastGuildLeaveFromDb_Err
-        Dim RS As ADODB.Recordset
-        Set RS = Query(GET_CHARACTER_LAST_GUILD_JOIN, LCase(CharacterName))
-        If RS Is Nothing Or RS.RecordCount = 0 Then
-            Debug.Assert False
-            Exit Function
-            'character doesnt exist in db?
-        End If
-        GetLastGuildLeaveFromDb = (RS!last_guild_leave)
-GetLastGuildLeaveFromDb_Err:
-    Call TraceError(Err.Number, Err.Description, "modGuilds.GetLastGuildLeaveFromDb", Erl)
-End Function
 
 Public Sub UpdateLastGuildLeaveToDb(ByRef CharacterName As String)
     On Error GoTo UpdateLastGuildLeaveToDb_Err

--- a/Codigo/modGuilds.bas
+++ b/Codigo/modGuilds.bas
@@ -32,8 +32,10 @@ Public CANTIDADDECLANES           As Integer 'cantidad actual de clanes en el se
 Private guilds(1 To MAX_GUILDS)   As clsClan 'array global de guilds, se indexa por userlist().guildindex
 Private Const CANTIDADMAXIMACODEX As Byte = 8 'cantidad maxima de codecs que se pueden definir
 Public Const MAXASPIRANTES        As Byte = 10 'cantidad maxima de aspirantes que puede tener un clan acumulados a la vez
-Private Const COOLDOWN_ABANDON_HORAS   As Integer = 24
-Private Const COOLDOWN_EXPULSION_HORAS As Integer = 48
+Private Const GET_CHARACTER_LAST_GUILD_JOIN As String = "SELECT last_guild_leave_timestamp FROM user WHERE name = ?"
+Private Const UPDATE_CHARACTER_LAST_GUILD_JOIN As String = "UPDATE user SET last_guild_leave_timestamp = ? WHERE name = ?"
+
+
 
 'alineaciones permitidas
 Public Enum e_ALINEACION_GUILD
@@ -146,9 +148,9 @@ Public Function m_EcharMiembroDeClan(ByVal Expulsador As Integer, ByVal ExpellUs
                 If m_EsGuildLeader(ExpellUserId, GI) Then guilds(GI).SetLeader (guilds(GI).Fundador)
                 Call guilds(GI).DesConectarMiembro(UserReference.ArrayIndex)
                 Call guilds(GI).ExpulsarMiembro(ExpellUserId)
-                Call AplicarCooldownClan(ExpellUserId, UserList(Expulsador).Id <> ExpellUserId)
                 Call LogClanes(ExpelledName & " ha sido expulsado de " & guilds(GI).GuildName & " Expulsador = " & Expulsador)
                 UserList(UserReference.ArrayIndex).GuildIndex = 0
+                UserList(UserReference.ArrayIndex).LastGuildLeaveTimestamp = DateTime.Now
                 Map = UserList(UserReference.ArrayIndex).pos.Map
                 If MapInfo(Map).SoloClanes And MapInfo(Map).Salida.Map <> 0 Then
                     Call WarpUserChar(UserReference.ArrayIndex, MapInfo(Map).Salida.Map, MapInfo(Map).Salida.x, MapInfo(Map).Salida.y, True)
@@ -170,8 +172,8 @@ Public Function m_EcharMiembroDeClan(ByVal Expulsador As Integer, ByVal ExpellUs
             If m_PuedeSalirDeClan(ExpellUserId, GI, Expulsador) Then
                 If m_EsGuildLeader(ExpellUserId, GI) Then guilds(GI).SetLeader (guilds(GI).Fundador)
                 Call guilds(GI).ExpulsarMiembro(ExpellUserId)
-                Call AplicarCooldownClan(ExpellUserId, UserList(Expulsador).Id <> ExpellUserId)
                 Call LogClanes(ExpelledName & " ha sido expulsado de " & guilds(GI).GuildName & " Expulsador = " & Expulsador)
+                Call UpdateLastGuildLeaveToDb(ExpelledName)
                 Map = GetMapDatabase(ExpelledName)
                 If MapInfo(Map).SoloClanes And MapInfo(Map).Salida.Map <> 0 Then
                     Call SetPositionDatabase(ExpelledName, MapInfo(Map).Salida.Map, MapInfo(Map).Salida.x, MapInfo(Map).Salida.y)
@@ -857,8 +859,7 @@ Public Function a_NuevoAspirante(ByVal UserIndex As Integer, ByRef clan As Strin
         refError = 2010 'Ya perteneces a un clan, debes salir del mismo antes de solicitar ingresar a otro.
         Exit Function
     End If
-    If TieneCooldownClan(UserList(UserIndex).Id) Then
-        refError = "No puedes unirte a un clan por " & TiempoRestanteCooldown(UserList(UserIndex).Id) & " más."
+    If IsAspirantOnGuildJoinCooldown(UserIndex) Then
         Exit Function
     End If
     If EsNewbie(UserIndex) Then
@@ -1195,63 +1196,51 @@ GetGuildMemberList_Err:
     Call TraceError(Err.Number, Err.Description, "modGuilds.GetGuildMemberList", Erl)
 End Function
 
-Private Sub AplicarCooldownClan(ByVal UserId As Long, ByVal EsExpulsion As Boolean)
-    On Error GoTo AplicarCooldownClan_Err
-    Dim horas     As Integer
-    Dim expiresAt As Long
-    horas = IIf(EsExpulsion, COOLDOWN_EXPULSION_HORAS, COOLDOWN_ABANDON_HORAS)
-    expiresAt = CLng(DateDiff("s", #1/1/1970#, DateAdd("h", horas, Now())))
-    Call Execute( _
-        "INSERT INTO guild_cooldowns (user_id, expires_at, reason) VALUES (?,?,?) " & _
-        "ON CONFLICT(user_id) DO UPDATE SET expires_at = excluded.expires_at, reason = excluded.reason;", _
-        UserId, expiresAt, IIf(EsExpulsion, 2, 1))
-    Exit Sub
-AplicarCooldownClan_Err:
-    Call TraceError(Err.Number, Err.Description, "modGuilds.AplicarCooldownClan", Erl)
+Public Function IsAspirantOnGuildJoinCooldown(ByVal UserIndex As Integer, Optional ByRef CharacterName As String) As Boolean
+    IsAspirantOnGuildJoinCooldown = True
+    Dim GuildLeaveCooldownInDays As Long
+    Dim CharacterLastLeave As Date
+    GuildLeaveCooldownInDays = SvrConfig.GetValue("GuildLeaveCooldownInDays")
+    With UserList(UserIndex)
+        If .flags.UserLogged Then
+            CharacterLastLeave = .LastGuildLeaveTimestamp
+        Else
+            CharacterLastLeave = GetLastGuildLeaveFromDb()
+            End If
+        End If
+        If .LastGuildLeaveTimestamp - DateTime.Now <= GuildLeaveCooldownInDays Then
+                'cant rejoin errormsg
+            Exit Function
+        End If
+        IsAspirantOnGuildJoinCooldown = False
+    End With
+End Function
+
+Public Function GetLastGuildLeaveFromDb() As String
+    On Error GoTo GetLastGuildLeaveFromDb_Err
+        Dim RS As ADODB.Recordset
+        Set RS = Query(GET_CHARACTER_LAST_GUILD_JOIN, LCase(CharacterName))
+        If RS Is Nothing Or RS.RecordCount = 0 Then
+            Debug.Assert False
+            Exit Function
+            'character doesnt exist in db?
+        End If
+        GetLastGuildLeaveFromDb = (RS!last_guild_leave_timestamp)
+GetLastGuildLeaveFromDb_Err:
+    Call TraceError(Err.Number, Err.Description, "modGuilds.GetLastGuildLeaveFromDb", Erl)
+End Function
+
+Public Sub UpdateLastGuildLeaveToDb(ByRef CharacterName As String)
+    On Error GoTo UpdateLastGuildLeaveToDb_Err
+    Dim RS As ADODB.Recordset
+    Set RS = Query(UPDATE_CHARACTER_LAST_GUILD_JOIN, DateTime.Now, CharacterName)
+    If RS Is Nothing Or RS.RecordCount = 0 Then
+        Debug.Assert False
+        Exit Function
+            'character doesnt exist in db?
+    End If
+UpdateLastGuildLeaveToDb_Err:
+    Call TraceError(Err.Number, Err.Description, "modGuilds.UpdateLastGuildLeaveToDb", Erl)
 End Sub
 
-Private Function TieneCooldownClan(ByVal UserId As Long) As Boolean
-    On Error GoTo TieneCooldownClan_Err
-    Dim RS      As ADODB.Recordset
-    Dim ahoraTs As Long
-    ahoraTs = CLng(DateDiff("s", #1/1/1970#, Now()))
-    Set RS = Query( _
-        "SELECT 1 FROM guild_cooldowns WHERE user_id = ? AND expires_at > ? LIMIT 1;", _
-        UserId, ahoraTs)
-    TieneCooldownClan = (Not RS Is Nothing) And (RS.RecordCount > 0)
-    Exit Function
-TieneCooldownClan_Err:
-    Call TraceError(Err.Number, Err.Description, "modGuilds.TieneCooldownClan", Erl)
-End Function
-
-Private Function TiempoRestanteCooldown(ByVal UserId As Long) As String
-    On Error GoTo TiempoRestanteCooldown_Err
-    Dim RS        As ADODB.Recordset
-    Dim ahoraTs   As Long
-    Dim diffSeg   As Long
-    Dim horas     As Long
-    Dim minutos   As Long
-    Dim resultado As String
-    ahoraTs = CLng(DateDiff("s", #1/1/1970#, Now()))
-    Set RS = Query( _
-        "SELECT expires_at FROM guild_cooldowns WHERE user_id = ? AND expires_at > ? LIMIT 1;", _
-        UserId, ahoraTs)
-    If RS Is Nothing Or RS.RecordCount = 0 Then
-        TiempoRestanteCooldown = ""
-        Exit Function
-    End If
-    diffSeg = RS.Fields("expires_at").value - ahoraTs
-    horas = diffSeg \ 3600
-    minutos = (diffSeg Mod 3600) \ 60
-    If horas > 0 Then
-        resultado = horas & " hora" & IIf(horas <> 1, "s", "")
-        If minutos > 0 Then resultado = resultado & " y " & minutos & " minuto" & IIf(minutos <> 1, "s", "")
-    Else
-        resultado = minutos & " minuto" & IIf(minutos <> 1, "s", "")
-    End If
-    TiempoRestanteCooldown = resultado
-    Exit Function
-TiempoRestanteCooldown_Err:
-    Call TraceError(Err.Number, Err.Description, "modGuilds.TiempoRestanteCooldown", Erl)
-End Function
 

--- a/Codigo/modGuilds.bas
+++ b/Codigo/modGuilds.bas
@@ -1224,7 +1224,7 @@ Public Function GetLastGuildLeaveFromDb(ByRef CharacterName As String) As String
             Exit Function
             'character doesnt exist in db?
         End If
-        GetLastGuildLeaveFromDb = (RS!last_guild_leave_timestamp)
+        GetLastGuildLeaveFromDb = (RS!last_guild_leave)
 GetLastGuildLeaveFromDb_Err:
     Call TraceError(Err.Number, Err.Description, "modGuilds.GetLastGuildLeaveFromDb", Erl)
 End Function

--- a/Codigo/modGuilds.bas
+++ b/Codigo/modGuilds.bas
@@ -32,7 +32,8 @@ Public CANTIDADDECLANES           As Integer 'cantidad actual de clanes en el se
 Private guilds(1 To MAX_GUILDS)   As clsClan 'array global de guilds, se indexa por userlist().guildindex
 Private Const CANTIDADMAXIMACODEX As Byte = 8 'cantidad maxima de codecs que se pueden definir
 Public Const MAXASPIRANTES        As Byte = 10 'cantidad maxima de aspirantes que puede tener un clan acumulados a la vez
-
+Private Const COOLDOWN_ABANDON_HORAS   As Integer = 24
+Private Const COOLDOWN_EXPULSION_HORAS As Integer = 48
 
 'alineaciones permitidas
 Public Enum e_ALINEACION_GUILD
@@ -145,6 +146,7 @@ Public Function m_EcharMiembroDeClan(ByVal Expulsador As Integer, ByVal ExpellUs
                 If m_EsGuildLeader(ExpellUserId, GI) Then guilds(GI).SetLeader (guilds(GI).Fundador)
                 Call guilds(GI).DesConectarMiembro(UserReference.ArrayIndex)
                 Call guilds(GI).ExpulsarMiembro(ExpellUserId)
+                Call AplicarCooldownClan(ExpellUserId, UserList(Expulsador).Id <> ExpellUserId)
                 Call LogClanes(ExpelledName & " ha sido expulsado de " & guilds(GI).GuildName & " Expulsador = " & Expulsador)
                 UserList(UserReference.ArrayIndex).GuildIndex = 0
                 Map = UserList(UserReference.ArrayIndex).pos.Map
@@ -168,6 +170,7 @@ Public Function m_EcharMiembroDeClan(ByVal Expulsador As Integer, ByVal ExpellUs
             If m_PuedeSalirDeClan(ExpellUserId, GI, Expulsador) Then
                 If m_EsGuildLeader(ExpellUserId, GI) Then guilds(GI).SetLeader (guilds(GI).Fundador)
                 Call guilds(GI).ExpulsarMiembro(ExpellUserId)
+                Call AplicarCooldownClan(ExpellUserId, UserList(Expulsador).Id <> ExpellUserId)
                 Call LogClanes(ExpelledName & " ha sido expulsado de " & guilds(GI).GuildName & " Expulsador = " & Expulsador)
                 Map = GetMapDatabase(ExpelledName)
                 If MapInfo(Map).SoloClanes And MapInfo(Map).Salida.Map <> 0 Then
@@ -854,6 +857,10 @@ Public Function a_NuevoAspirante(ByVal UserIndex As Integer, ByRef clan As Strin
         refError = 2010 'Ya perteneces a un clan, debes salir del mismo antes de solicitar ingresar a otro.
         Exit Function
     End If
+    If TieneCooldownClan(UserList(UserIndex).Id) Then
+        refError = "No puedes unirte a un clan por " & TiempoRestanteCooldown(UserList(UserIndex).Id) & " más."
+        Exit Function
+    End If
     If EsNewbie(UserIndex) Then
         refError = 2005 'Los newbies no tienen derecho a entrar a un clan.
         Exit Function
@@ -1187,3 +1194,64 @@ Public Function GetGuildMemberList(ByVal GuildName As String) As Long()
 GetGuildMemberList_Err:
     Call TraceError(Err.Number, Err.Description, "modGuilds.GetGuildMemberList", Erl)
 End Function
+
+Private Sub AplicarCooldownClan(ByVal UserId As Long, ByVal EsExpulsion As Boolean)
+    On Error GoTo AplicarCooldownClan_Err
+    Dim horas     As Integer
+    Dim expiresAt As Long
+    horas = IIf(EsExpulsion, COOLDOWN_EXPULSION_HORAS, COOLDOWN_ABANDON_HORAS)
+    expiresAt = CLng(DateDiff("s", #1/1/1970#, DateAdd("h", horas, Now())))
+    Call Execute( _
+        "INSERT INTO guild_cooldowns (user_id, expires_at, reason) VALUES (?,?,?) " & _
+        "ON CONFLICT(user_id) DO UPDATE SET expires_at = excluded.expires_at, reason = excluded.reason;", _
+        UserId, expiresAt, IIf(EsExpulsion, 2, 1))
+    Exit Sub
+AplicarCooldownClan_Err:
+    Call TraceError(Err.Number, Err.Description, "modGuilds.AplicarCooldownClan", Erl)
+End Sub
+
+Private Function TieneCooldownClan(ByVal UserId As Long) As Boolean
+    On Error GoTo TieneCooldownClan_Err
+    Dim RS      As ADODB.Recordset
+    Dim ahoraTs As Long
+    ahoraTs = CLng(DateDiff("s", #1/1/1970#, Now()))
+    Set RS = Query( _
+        "SELECT 1 FROM guild_cooldowns WHERE user_id = ? AND expires_at > ? LIMIT 1;", _
+        UserId, ahoraTs)
+    TieneCooldownClan = (Not RS Is Nothing) And (RS.RecordCount > 0)
+    Exit Function
+TieneCooldownClan_Err:
+    Call TraceError(Err.Number, Err.Description, "modGuilds.TieneCooldownClan", Erl)
+End Function
+
+Private Function TiempoRestanteCooldown(ByVal UserId As Long) As String
+    On Error GoTo TiempoRestanteCooldown_Err
+    Dim RS        As ADODB.Recordset
+    Dim ahoraTs   As Long
+    Dim diffSeg   As Long
+    Dim horas     As Long
+    Dim minutos   As Long
+    Dim resultado As String
+    ahoraTs = CLng(DateDiff("s", #1/1/1970#, Now()))
+    Set RS = Query( _
+        "SELECT expires_at FROM guild_cooldowns WHERE user_id = ? AND expires_at > ? LIMIT 1;", _
+        UserId, ahoraTs)
+    If RS Is Nothing Or RS.RecordCount = 0 Then
+        TiempoRestanteCooldown = ""
+        Exit Function
+    End If
+    diffSeg = RS.Fields("expires_at").value - ahoraTs
+    horas = diffSeg \ 3600
+    minutos = (diffSeg Mod 3600) \ 60
+    If horas > 0 Then
+        resultado = horas & " hora" & IIf(horas <> 1, "s", "")
+        If minutos > 0 Then resultado = resultado & " y " & minutos & " minuto" & IIf(minutos <> 1, "s", "")
+    Else
+        resultado = minutos & " minuto" & IIf(minutos <> 1, "s", "")
+    End If
+    TiempoRestanteCooldown = resultado
+    Exit Function
+TiempoRestanteCooldown_Err:
+    Call TraceError(Err.Number, Err.Description, "modGuilds.TiempoRestanteCooldown", Erl)
+End Function
+

--- a/Codigo/modGuilds.bas
+++ b/Codigo/modGuilds.bas
@@ -878,6 +878,7 @@ Public Function a_NuevoAspirante(ByVal UserIndex As Integer, ByRef clan As Strin
     End If
     If IsAspirantOnGuildJoinCooldown(UserIndex) Then
         refError = 2225
+        Exit Function
     End If
     Dim NuevoGuildAspirantes() As String
     NuevoGuildAspirantes = guilds(NuevoGuildIndex).GetAspirantes()
@@ -1201,7 +1202,7 @@ Public Function IsAspirantOnGuildJoinCooldown(ByVal UserIndex As Integer) As Boo
     Dim GuildLeaveCooldownInDays As Long
     GuildLeaveCooldownInDays = SvrConfig.GetValue("GuildLeaveCooldownInDays")
     With UserList(UserIndex)
-        If CLng(.LastGuildLeave - DateTime.Now) <= GuildLeaveCooldownInDays Then
+        If CLng(DateTime.Now - .LastGuildLeave) <= GuildLeaveCooldownInDays Then
                 'cant rejoin errormsg
             Exit Function
         End If
@@ -1213,7 +1214,7 @@ End Function
 Public Sub UpdateLastGuildLeaveToDb(ByRef CharacterName As String)
     On Error GoTo UpdateLastGuildLeaveToDb_Err
     Dim RS As ADODB.Recordset
-    Set RS = Query(UPDATE_CHARACTER_LAST_GUILD_JOIN, DateTime.Now, CharacterName)
+    Set RS = Query(UPDATE_CHARACTER_LAST_GUILD_JOIN, DateToSQLite(DateTime.Now), CharacterName)
     If RS Is Nothing Or RS.RecordCount = 0 Then
         Debug.Assert False
         Exit Sub

--- a/Codigo/modGuilds.bas
+++ b/Codigo/modGuilds.bas
@@ -32,8 +32,8 @@ Public CANTIDADDECLANES           As Integer 'cantidad actual de clanes en el se
 Private guilds(1 To MAX_GUILDS)   As clsClan 'array global de guilds, se indexa por userlist().guildindex
 Private Const CANTIDADMAXIMACODEX As Byte = 8 'cantidad maxima de codecs que se pueden definir
 Public Const MAXASPIRANTES        As Byte = 10 'cantidad maxima de aspirantes que puede tener un clan acumulados a la vez
-Private Const GET_CHARACTER_LAST_GUILD_JOIN As String = "SELECT last_guild_leave_timestamp FROM user WHERE name = ?"
-Private Const UPDATE_CHARACTER_LAST_GUILD_JOIN As String = "UPDATE user SET last_guild_leave_timestamp = ? WHERE name = ?"
+Private Const GET_CHARACTER_LAST_GUILD_JOIN As String = "SELECT last_guild_leave FROM user WHERE name = ?"
+Private Const UPDATE_CHARACTER_LAST_GUILD_JOIN As String = "UPDATE user SET last_guild_leave = ? WHERE name = ?"
 
 
 
@@ -150,7 +150,7 @@ Public Function m_EcharMiembroDeClan(ByVal Expulsador As Integer, ByVal ExpellUs
                 Call guilds(GI).ExpulsarMiembro(ExpellUserId)
                 Call LogClanes(ExpelledName & " ha sido expulsado de " & guilds(GI).GuildName & " Expulsador = " & Expulsador)
                 UserList(UserReference.ArrayIndex).GuildIndex = 0
-                UserList(UserReference.ArrayIndex).LastGuildLeaveTimestamp = DateTime.Now
+                UserList(UserReference.ArrayIndex).LastGuildLeave = DateTime.Now
                 Map = UserList(UserReference.ArrayIndex).pos.Map
                 If MapInfo(Map).SoloClanes And MapInfo(Map).Salida.Map <> 0 Then
                     Call WarpUserChar(UserReference.ArrayIndex, MapInfo(Map).Salida.Map, MapInfo(Map).Salida.x, MapInfo(Map).Salida.y, True)
@@ -896,7 +896,7 @@ Public Function a_NuevoAspirante(ByVal UserIndex As Integer, ByRef clan As Strin
             Call guilds(ViejoGuildINdex).RetirarAspirante(UserList(UserIndex).name)
         End If
     End If
-    Call SendData(SendTarget.ToDiosesYclan, NuevoGuildIndex, PrepareMessageGuildChat("Msg2039¬" & UserList(UserIndex).name, 7))  'Msg2039=Clan: [¬1] ha enviado solicitud para unirse al clan.
+    Call SendData(SendTarget.ToDiosesYclan, NuevoGuildIndex, PrepareMessageGuildChat("Msg2039¬" & UserList(UserIndex).Name, 7))  'Msg2039=Clan: [¬1] ha enviado solicitud para unirse al clan.
     Call guilds(NuevoGuildIndex).NuevoAspirante(UserList(UserIndex).name, Solicitud)
     a_NuevoAspirante = True
     Exit Function
@@ -1203,12 +1203,11 @@ Public Function IsAspirantOnGuildJoinCooldown(ByVal UserIndex As Integer, Option
     GuildLeaveCooldownInDays = SvrConfig.GetValue("GuildLeaveCooldownInDays")
     With UserList(UserIndex)
         If .flags.UserLogged Then
-            CharacterLastLeave = .LastGuildLeaveTimestamp
+            CharacterLastLeave = .LastGuildLeave
         Else
-            CharacterLastLeave = GetLastGuildLeaveFromDb()
-            End If
+            CharacterLastLeave = GetLastGuildLeaveFromDb(CharacterName)
         End If
-        If .LastGuildLeaveTimestamp - DateTime.Now <= GuildLeaveCooldownInDays Then
+        If .LastGuildLeave - DateTime.Now <= GuildLeaveCooldownInDays Then
                 'cant rejoin errormsg
             Exit Function
         End If
@@ -1216,7 +1215,7 @@ Public Function IsAspirantOnGuildJoinCooldown(ByVal UserIndex As Integer, Option
     End With
 End Function
 
-Public Function GetLastGuildLeaveFromDb() As String
+Public Function GetLastGuildLeaveFromDb(ByRef CharacterName As String) As String
     On Error GoTo GetLastGuildLeaveFromDb_Err
         Dim RS As ADODB.Recordset
         Set RS = Query(GET_CHARACTER_LAST_GUILD_JOIN, LCase(CharacterName))
@@ -1236,7 +1235,7 @@ Public Sub UpdateLastGuildLeaveToDb(ByRef CharacterName As String)
     Set RS = Query(UPDATE_CHARACTER_LAST_GUILD_JOIN, DateTime.Now, CharacterName)
     If RS Is Nothing Or RS.RecordCount = 0 Then
         Debug.Assert False
-        Exit Function
+        Exit Sub
             'character doesnt exist in db?
     End If
 UpdateLastGuildLeaveToDb_Err:

--- a/Example.Configuracion.ini
+++ b/Example.Configuracion.ini
@@ -48,6 +48,7 @@ JineteLevel8Speed=1.40
 JineteLevel9Speed=1.45
 UnassistedSpellsAllowed=1,5,348,52,349,61,62,63,64,65
 CostoPreSubasta=500
+GuildLeaveCooldownInDays=1
 
 [EVENTOS]
 'Hora de evento= Tipo Evento - Duracion - Multiplacion

--- a/ScriptsDB/20260628-01-add new user column last guild leave timestamp.sql
+++ b/ScriptsDB/20260628-01-add new user column last guild leave timestamp.sql
@@ -1,0 +1,2 @@
+ALTER TABLE user
+    ADD COLUMN last_guild_leave_timestamp timestamp DEFAULT NULL;

--- a/ScriptsDB/20260628-01-add new user column last guild leave timestamp.sql
+++ b/ScriptsDB/20260628-01-add new user column last guild leave timestamp.sql
@@ -1,2 +1,2 @@
 ALTER TABLE user
-    ADD COLUMN last_guild_leave_timestamp timestamp DEFAULT NULL;
+    ADD COLUMN last_guild_leave timestamp DEFAULT NULL;


### PR DESCRIPTION
This pull request implements a cooldown system that prevents players from rejoining a guild immediately after leaving or being expelled. The main changes include adding a new `last_guild_leave` field to track when a user last left a guild, updating the database schema and queries to support this field, and enforcing the cooldown logic when a player tries to join a new guild.

**Guild Leave Cooldown Feature**

- Added a new field `last_guild_leave` to the user database and the `t_User` type to store the timestamp of the last guild departure. [[1]](diffhunk://#diff-be30f8d6f6f2ed9c9570df895c777df9f48a06c3700af4b4682bdf4a9191488dR1-R2) [[2]](diffhunk://#diff-9682fb78ca936b593db35585cec8ff7c38ac045a2cc5f5f6b140d03aa0488813R3024)
- Updated all relevant database queries and persistence logic to read and write the new `last_guild_leave` field, including schema migration, loading, and saving character data. [[1]](diffhunk://#diff-ead2ded658afad950352e65b036a6d2ed31c6f6513da6b6cdb49959d4e75c1a8L131-R132) [[2]](diffhunk://#diff-ead2ded658afad950352e65b036a6d2ed31c6f6513da6b6cdb49959d4e75c1a8L305-R307) [[3]](diffhunk://#diff-a150242508384727509fd46f3c7da29f276070fe3b13aae000eb6f0eb8ebfce1R323) [[4]](diffhunk://#diff-a150242508384727509fd46f3c7da29f276070fe3b13aae000eb6f0eb8ebfce1L588-R589) [[5]](diffhunk://#diff-a150242508384727509fd46f3c7da29f276070fe3b13aae000eb6f0eb8ebfce1R652)
- When a user is expelled from a guild, their `LastGuildLeave` is updated both in memory and in the database. [[1]](diffhunk://#diff-b2ccea6f3556f4576052f0b476d99507989aa53adfdefbb895a1c032a53a0494R153) [[2]](diffhunk://#diff-b2ccea6f3556f4576052f0b476d99507989aa53adfdefbb895a1c032a53a0494R176)
- Introduced the configuration setting `GuildLeaveCooldownInDays` (default 1 day) to control the cooldown period, and added support for reading this setting. [[1]](diffhunk://#diff-59ca86992bf73e207f7b406d1b8343684e9f4abb5a4715856d713afabe6683caR51) [[2]](diffhunk://#diff-fedd426df109d681b672cad28e9de0aaad27fde618f427a8f885d256db78ad8aR110)

**Cooldown Enforcement Logic**

- Implemented the function `IsAspirantOnGuildJoinCooldown` to check if a user is still within the cooldown period before allowing them to apply to a new guild, and enforced this check in the guild application process. [[1]](diffhunk://#diff-b2ccea6f3556f4576052f0b476d99507989aa53adfdefbb895a1c032a53a0494R879-R882) [[2]](diffhunk://#diff-b2ccea6f3556f4576052f0b476d99507989aa53adfdefbb895a1c032a53a0494R1199-R1227)

**Supporting Changes**

- Added new SQL query constants and utility functions to support updating and retrieving the `last_guild_leave` field.

These changes ensure that players cannot immediately rejoin or apply to another guild after leaving or being expelled, enforcing a configurable cooldown period for fair guild management.