### PR TITLE
Harden castle map coordinate bounds

### DIFF
--- a/Codigo/InvUsuario.bas
+++ b/Codigo/InvUsuario.bas
@@ -451,10 +451,10 @@ DropObj_Err:
     Call TraceError(Err.Number, Err.Description, "InvUsuario.DropObj", Erl)
 End Sub
 
-Sub EraseObj(ByVal num As Integer, ByVal Map As Integer, ByVal x As Integer, ByVal y As Integer)
+Sub EraseObj(ByVal amount As Integer, ByVal map As Integer, ByVal x As Integer, ByVal y As Integer)
     On Error GoTo EraseObj_Err
     Dim Rango As Byte
-    MapData(Map, x, y).ObjInfo.amount = MapData(Map, x, y).ObjInfo.amount - num
+    MapData(map, x, y).ObjInfo.amount = MapData(map, x, y).ObjInfo.amount - amount
     If MapData(Map, x, y).ObjInfo.amount <= 0 Then
         MapData(Map, x, y).ObjInfo.ObjIndex = 0
         MapData(Map, x, y).ObjInfo.amount = 0

--- a/Codigo/ModCastle.bas
+++ b/Codigo/ModCastle.bas
@@ -450,6 +450,7 @@ Public Sub DestroyCastleInMap(ByVal map As Integer, ByVal x As Integer, ByVal y 
     Dim CastleSignObj As t_Obj
     CastleSignObj.Amount = 1
     CastleSignObj.ObjIndex = CASTLE_SIGN_POST_OBJ_INDEX
+    Call MakeObj(CastleSignObj, map, x, y)
 End Sub
 
 Public Function IsEmperorCastleCreated(ByVal UserIndex As Integer) As Boolean

--- a/Codigo/ModCastle.bas
+++ b/Codigo/ModCastle.bas
@@ -28,7 +28,8 @@ Private Const SELECT_ALL_CASTLE_WHITELISTS As String = "Select * FROM castle_whi
 Private Const SELECT_ALL_CASTLES As String = "SELECT * FROM castle;"
 Private Const SELECT_ALL_CASTLE_COORDINATES = "SELECT * FROM castle_coordinates;"
 
-Private Const CASTLE_OBJ = 6382
+Private Const CASTLE_MOCKUP_OBJ_INDEX = 6382
+Private Const CASTLE_SIGN_POST_OBJ_INDEX = 63419
 Public Const EMPEROR_RELIC_OBJ_INDEX_1 = 6362
 Public Const EMPEROR_RELIC_OBJ_INDEX_20 = 6381
 
@@ -366,7 +367,7 @@ Public Sub CreateCastleInMap(ByVal map As Integer, ByVal x As Integer, ByVal y A
         'create castle visual mockup
         Dim CastleObj As t_Obj
         CastleObj.Amount = 1
-        CastleObj.ObjIndex = CASTLE_OBJ
+        CastleObj.ObjIndex = CASTLE_MOCKUP_OBJ_INDEX
         
         Call MakeObj(CastleObj, map, x, y)
     
@@ -406,7 +407,6 @@ Public Sub DestroyCastleInMap(ByVal map As Integer, ByVal x As Integer, ByVal y 
     MapData(map, x - 2, y - 1).TileExit.x = 0
     MapData(map, x - 2, y - 1).TileExit.y = 0
     
-    
      'restore castle foundation trigger
     MapData(map, x, y).trigger = e_Trigger.CASTLE_FOUNDATION_POSITION
         
@@ -419,6 +419,11 @@ Public Sub DestroyCastleInMap(ByVal map As Integer, ByVal x As Integer, ByVal y 
         MapData(.castle_coordinates.inside.map, .castle_coordinates.inside.x + 1, .castle_coordinates.inside.y + 1).TileExit.x = 0
         MapData(.castle_coordinates.inside.map, .castle_coordinates.inside.x + 1, .castle_coordinates.inside.y + 1).TileExit.y = 0
     End With
+    
+    'create castle sign post
+    Dim CastleSignObj As t_Obj
+    CastleSignObj.Amount = 1
+    CastleSignObj.ObjIndex = CASTLE_SIGN_POST_OBJ_INDEX
 End Sub
 
 Public Function IsEmperorCastleCreated(ByVal UserIndex As Integer) As Boolean
@@ -427,7 +432,7 @@ Public Function IsEmperorCastleCreated(ByVal UserIndex As Integer) As Boolean
     For i = 1 To UBound(CastleData)
         If CastleData(i).owner_account_id = UserList(UserIndex).AccountID Then
             
-            If (MapData(CastleData(i).castle_coordinates.outside.map, CastleData(i).castle_coordinates.outside.x, CastleData(i).castle_coordinates.outside.y).ObjInfo.ObjIndex = CASTLE_OBJ) Then
+            If (MapData(CastleData(i).castle_coordinates.outside.map, CastleData(i).castle_coordinates.outside.x, CastleData(i).castle_coordinates.outside.y).ObjInfo.ObjIndex = CASTLE_MOCKUP_OBJ_INDEX) Then
                 IsEmperorCastleCreated = True
             End If
             

--- a/Codigo/ModCastle.bas
+++ b/Codigo/ModCastle.bas
@@ -224,6 +224,7 @@ Public Sub CreateCastleInMap(ByVal map As Integer, ByVal x As Integer, ByVal y A
     
     With CastleData(CastleIndex)
     
+        'if not during server start...(player clicking the board)
          If UserIndex > 0 Then
             .castle_coordinates.outside.map = map
             .castle_coordinates.outside.x = x
@@ -232,7 +233,29 @@ Public Sub CreateCastleInMap(ByVal map As Integer, ByVal x As Integer, ByVal y A
             .is_active = 1
             .owner_account_id = UserList(UserIndex).AccountID
             .owner_char_id = UserList(UserIndex).Id
+            Call CastleWhiteList.Add(CastleData(CastleIndex).owner_account_id, CastleData(CastleIndex).trigger)
         End If
+        
+        'erase preemptively all blocks, triggers, objects and npcs in the zone
+        Dim i As Integer
+        Dim j As Integer
+        For i = x - 8 To x + 6
+            For j = y - 8 To y + 2
+            
+            MapData(map, i, j).Blocked = 0
+            MapData(map, i, j).trigger = e_Trigger.nada
+        
+            If MapData(map, i, j).ObjInfo.ObjIndex > 0 Then
+                Call EraseObj(MapData(map, i, j).ObjInfo.Amount, map, i, j)
+            End If
+            
+            If MapData(map, i, j).NpcIndex > 0 Then
+                Call QuitarNPC(MapData(map, i, j).NpcIndex, eAiResetNpc)
+            End If
+            
+            Next j
+        Next i
+        
 
         'first layer from the bottom
         MapData(map, x - 3, y).Blocked = e_Block.ALL_SIDES
@@ -243,6 +266,7 @@ Public Sub CreateCastleInMap(ByVal map As Integer, ByVal x As Integer, ByVal y A
         MapData(map, x + 1, y).Blocked = e_Block.ALL_SIDES
         MapData(map, x + 2, y).Blocked = e_Block.ALL_SIDES
         MapData(map, x + 3, y).Blocked = e_Block.ALL_SIDES
+        MapData(map, x, y).trigger = e_Trigger.CASTLE_FOUNDATION_POSITION
         MapData(map, x - 1, y).trigger = .trigger
         MapData(map, x - 2, y).trigger = .trigger
         MapData(map, x - 1, y + 1).trigger = .trigger
@@ -338,7 +362,16 @@ Public Sub CreateCastleInMap(ByVal map As Integer, ByVal x As Integer, ByVal y A
         MapData(map, x + 1, y - 7).Blocked = e_Block.ALL_SIDES
         MapData(map, x + 2, y - 7).Blocked = e_Block.ALL_SIDES
         MapData(map, x + 3, y - 7).Blocked = e_Block.ALL_SIDES
-    
+        
+        'create castle inside tile exits to the outside part
+        MapData(.castle_coordinates.inside.map, .castle_coordinates.inside.x, .castle_coordinates.inside.y + 1).TileExit.map = .castle_coordinates.outside.map
+        MapData(.castle_coordinates.inside.map, .castle_coordinates.inside.x, .castle_coordinates.inside.y + 1).TileExit.x = .castle_coordinates.outside.x - 2
+        MapData(.castle_coordinates.inside.map, .castle_coordinates.inside.x, .castle_coordinates.inside.y + 1).TileExit.y = .castle_coordinates.outside.y + 1
+        
+        MapData(.castle_coordinates.inside.map, .castle_coordinates.inside.x + 1, .castle_coordinates.inside.y + 1).TileExit.map = .castle_coordinates.outside.map
+        MapData(.castle_coordinates.inside.map, .castle_coordinates.inside.x + 1, .castle_coordinates.inside.y + 1).TileExit.x = .castle_coordinates.outside.x - 1
+        MapData(.castle_coordinates.inside.map, .castle_coordinates.inside.x + 1, .castle_coordinates.inside.y + 1).TileExit.y = .castle_coordinates.outside.y + 1
+        
     End With
     
 End Sub
@@ -347,112 +380,46 @@ End Sub
 Public Sub DestroyCastleInMap(ByVal map As Integer, ByVal x As Integer, ByVal y As Integer, ByVal CastleIndex As Integer)
     Call EraseObj(MapData(map, x, y).ObjInfo.Amount, map, x, y)
     
-    With CastleData(CastleIndex)
-        'first layer from the bottom
-        MapData(map, x - 3, y).Blocked = 0
-        MapData(map, x - 4, y).Blocked = 0
-        MapData(map, x - 5, y).Blocked = 0
-        MapData(map, x - 6, y).Blocked = 0
-        MapData(map, x + 1, y).Blocked = 0
-        MapData(map, x + 2, y).Blocked = 0
-        MapData(map, x + 3, y).Blocked = 0
-        MapData(map, x - 1, y).trigger = e_Trigger.nada
-        MapData(map, x - 2, y).trigger = e_Trigger.nada
-        MapData(map, x - 1, y + 1).trigger = e_Trigger.nada
-        MapData(map, x - 2, y + 1).trigger = e_Trigger.nada
+     'remove everything
+    Dim i As Integer
+    Dim j As Integer
+    For i = x - 8 To x + 6
+        For j = y - 8 To y + 2
         
-        
-        'second layer form the bottom
-        MapData(map, x, y - 1).Blocked = 0
-        MapData(map, x - 3, y - 1).Blocked = 0
-        MapData(map, x - 4, y - 1).Blocked = 0
-        MapData(map, x - 5, y - 1).Blocked = 0
-        MapData(map, x - 6, y - 1).Blocked = 0
-        MapData(map, x + 1, y - 1).Blocked = 0
-        MapData(map, x + 2, y - 1).Blocked = 0
-        MapData(map, x + 3, y - 1).Blocked = 0
-        
-        
-        MapData(map, x - 1, y - 1).TileExit.map = 0
-        MapData(map, x - 1, y - 1).TileExit.x = 0
-        MapData(map, x - 1, y - 1).TileExit.y = 0
-        
-        MapData(map, x - 2, y - 1).TileExit.map = 0
-        MapData(map, x - 2, y - 1).TileExit.x = 0
-        MapData(map, x - 2, y - 1).TileExit.y = 0
-        
-        'third layer form the bottom
-        MapData(map, x, y - 2).Blocked = 0
-        MapData(map, x - 1, y - 2).Blocked = 0
-        MapData(map, x - 2, y - 2).Blocked = 0
-        MapData(map, x - 3, y - 2).Blocked = 0
-        MapData(map, x - 4, y - 2).Blocked = 0
-        MapData(map, x - 5, y - 2).Blocked = 0
-        MapData(map, x - 6, y - 2).Blocked = 0
-        MapData(map, x + 1, y - 2).Blocked = 0
-        MapData(map, x + 2, y - 2).Blocked = 0
-        MapData(map, x + 3, y - 2).Blocked = 0
-        
-         'fourth layer form the bottom
-        MapData(map, x, y - 3).Blocked = 0
-        MapData(map, x - 1, y - 3).Blocked = 0
-        MapData(map, x - 2, y - 3).Blocked = 0
-        MapData(map, x - 3, y - 3).Blocked = 0
-        MapData(map, x - 4, y - 3).Blocked = 0
-        MapData(map, x - 5, y - 3).Blocked = 0
-        MapData(map, x - 6, y - 3).Blocked = 0
-        MapData(map, x + 1, y - 3).Blocked = 0
-        MapData(map, x + 2, y - 3).Blocked = 0
-        MapData(map, x + 3, y - 3).Blocked = 0
-        
-         'fifth layer form the bottom
-        MapData(map, x, y - 4).Blocked = 0
-        MapData(map, x - 1, y - 4).Blocked = 0
-        MapData(map, x - 2, y - 4).Blocked = 0
-        MapData(map, x - 3, y - 4).Blocked = 0
-        MapData(map, x - 4, y - 4).Blocked = 0
-        MapData(map, x - 5, y - 4).Blocked = 0
-        MapData(map, x - 6, y - 4).Blocked = 0
-        MapData(map, x + 1, y - 4).Blocked = 0
-        MapData(map, x + 2, y - 4).Blocked = 0
-        MapData(map, x + 3, y - 4).Blocked = 0
-        
-         'sixth layer form the bottom
-        MapData(map, x, y - 5).Blocked = 0
-        MapData(map, x - 1, y - 5).Blocked = 0
-        MapData(map, x - 2, y - 5).Blocked = 0
-        MapData(map, x - 3, y - 5).Blocked = 0
-        MapData(map, x - 4, y - 5).Blocked = 0
-        MapData(map, x - 5, y - 5).Blocked = 0
-        MapData(map, x - 6, y - 5).Blocked = 0
-        MapData(map, x + 1, y - 5).Blocked = 0
-        MapData(map, x + 2, y - 5).Blocked = 0
-        MapData(map, x + 3, y - 5).Blocked = 0
-        
-         'seventh layer form the bottom
-        MapData(map, x, y - 6).Blocked = 0
-        MapData(map, x - 1, y - 6).Blocked = 0
-        MapData(map, x - 2, y - 6).Blocked = 0
-        MapData(map, x - 3, y - 6).Blocked = 0
-        MapData(map, x - 4, y - 6).Blocked = 0
-        MapData(map, x - 5, y - 6).Blocked = 0
-        MapData(map, x - 6, y - 6).Blocked = 0
-        MapData(map, x + 1, y - 6).Blocked = 0
-        MapData(map, x + 2, y - 6).Blocked = 0
-        MapData(map, x + 3, y - 6).Blocked = 0
-        
-         'eighth layer form the bottom
-        MapData(map, x, y - 7).Blocked = 0
-        MapData(map, x - 1, y - 7).Blocked = 0
-        MapData(map, x - 2, y - 7).Blocked = 0
-        MapData(map, x - 3, y - 7).Blocked = 0
-        MapData(map, x - 4, y - 7).Blocked = 0
-        MapData(map, x - 5, y - 7).Blocked = 0
-        MapData(map, x - 6, y - 7).Blocked = 0
-        MapData(map, x + 1, y - 7).Blocked = 0
-        MapData(map, x + 2, y - 7).Blocked = 0
-        MapData(map, x + 3, y - 7).Blocked = 0
+        MapData(map, i, j).Blocked = 0
+        MapData(map, i, j).trigger = e_Trigger.nada
     
+        If MapData(map, i, j).ObjInfo.ObjIndex > 0 Then
+            Call EraseObj(MapData(map, i, j).ObjInfo.Amount, map, i, j)
+        End If
+        
+        If MapData(map, i, j).NpcIndex > 0 Then
+            Call QuitarNPC(MapData(map, i, j).NpcIndex, eAiResetNpc)
+        End If
+        
+        Next j
+    Next i
+
+    MapData(map, x - 1, y - 1).TileExit.map = 0
+    MapData(map, x - 1, y - 1).TileExit.x = 0
+    MapData(map, x - 1, y - 1).TileExit.y = 0
+    
+    MapData(map, x - 2, y - 1).TileExit.map = 0
+    MapData(map, x - 2, y - 1).TileExit.x = 0
+    MapData(map, x - 2, y - 1).TileExit.y = 0
+    
+    
+     'restore castle foundation trigger
+    MapData(map, x, y).trigger = e_Trigger.CASTLE_FOUNDATION_POSITION
+        
+     With CastleData(CastleIndex)
+        MapData(.castle_coordinates.inside.map, .castle_coordinates.inside.x, .castle_coordinates.inside.y + 1).TileExit.map = 0
+        MapData(.castle_coordinates.inside.map, .castle_coordinates.inside.x, .castle_coordinates.inside.y + 1).TileExit.x = 0
+        MapData(.castle_coordinates.inside.map, .castle_coordinates.inside.x, .castle_coordinates.inside.y + 1).TileExit.y = 0
+    
+        MapData(.castle_coordinates.inside.map, .castle_coordinates.inside.x + 1, .castle_coordinates.inside.y + 1).TileExit.map = 0
+        MapData(.castle_coordinates.inside.map, .castle_coordinates.inside.x + 1, .castle_coordinates.inside.y + 1).TileExit.x = 0
+        MapData(.castle_coordinates.inside.map, .castle_coordinates.inside.x + 1, .castle_coordinates.inside.y + 1).TileExit.y = 0
     End With
 End Sub
 

--- a/Codigo/ModCastle.bas
+++ b/Codigo/ModCastle.bas
@@ -34,13 +34,9 @@ Private Const CastleXPositiveOffset As Integer = 6
 Private Const CastleYPositiveOffset As Integer = 2
 
 Private Const CASTLE_MOCKUP_OBJ_INDEX = 6382
-Private Const CASTLE_SIGN_POST_OBJ_INDEX = 63419
+Private Const CASTLE_SIGN_POST_OBJ_INDEX = 6419
 Public Const EMPEROR_RELIC_OBJ_INDEX_1 = 6362
 Public Const EMPEROR_RELIC_OBJ_INDEX_20 = 6381
-
-
-
-
 
 Public Sub LoadCastleModule()
     On Error GoTo LoadCastleModule_Err
@@ -170,8 +166,7 @@ Public Function IsValidCastlePosition(ByVal UserIndex As Integer) As Boolean
             Call WriteLocaleMsg(UserIndex, MSG_INVALID_CASTLE_POSITION, FONTTYPE_INFOBOLD)
             Exit Function
         End If
-    
-    
+        
         CastleTopLeftCorner.x = .flags.TargetX - CastleXNegativeOffstet
         CastleTopLeftCorner.y = .flags.TargetY - CastleYNegativeOffset
         CastleTopLeftCorner.map = .flags.TargetMap
@@ -183,8 +178,8 @@ Public Function IsValidCastlePosition(ByVal UserIndex As Integer) As Boolean
         UserTargetX = .flags.TargetX
         UserTargetY = .flags.TargetY
         UserTargetMap = .flags.TargetMap
+        
     End With
-    
     
     If MapData(UserTargetMap, UserTargetX, UserTargetY).trigger <> e_Trigger.CASTLE_FOUNDATION_POSITION Then
         Call WriteLocaleMsg(UserIndex, MSG_INVALID_CASTLE_POSITION, FONTTYPE_INFOBOLD)
@@ -201,6 +196,16 @@ Public Function IsValidCastlePosition(ByVal UserIndex As Integer) As Boolean
         Exit Function
     End If
     
+    If MapData(UserTargetMap, UserTargetX, UserTargetY).ObjInfo.ObjIndex = CASTLE_MOCKUP_OBJ_INDEX Then
+        'castle already in position, cant delete another emperor castle errormsg TODO
+        Exit Function
+    End If
+    
+    If MapData(UserTargetMap, UserTargetX, UserTargetY).ObjInfo.ObjIndex <> CASTLE_SIGN_POST_OBJ_INDEX Then
+        'sign post not in position, call an admin errormsg TODO
+        Exit Function
+    End If
+    
     Dim i As Integer
     Dim j As Integer
     For i = CastleTopLeftCorner.x To CastleBottomRightCorner.x
@@ -213,6 +218,7 @@ Public Function IsValidCastlePosition(ByVal UserIndex As Integer) As Boolean
             
         Next j
     Next i
+    
     IsValidCastlePosition = True
 End Function
 
@@ -457,14 +463,16 @@ Public Function IsEmperorCastleCreated(ByVal UserIndex As Integer) As Boolean
     IsEmperorCastleCreated = False
     Dim i As Integer
     For i = 1 To UBound(CastleData)
-        If CastleData(i).owner_account_id = UserList(UserIndex).AccountID Then
-            
-            If (MapData(CastleData(i).castle_coordinates.outside.map, CastleData(i).castle_coordinates.outside.x, CastleData(i).castle_coordinates.outside.y).ObjInfo.ObjIndex = CASTLE_MOCKUP_OBJ_INDEX) Then
-                IsEmperorCastleCreated = True
+        With CastleData(i)
+            If .owner_account_id = UserList(UserIndex).AccountID Then
+                
+                If (MapData(.castle_coordinates.outside.map, .castle_coordinates.outside.x, .castle_coordinates.outside.y).ObjInfo.ObjIndex = CASTLE_MOCKUP_OBJ_INDEX) Then
+                    IsEmperorCastleCreated = True
+                End If
+                
+                Exit For
             End If
-            
-            Exit For
-        End If
+        End With
     Next i
 End Function
 
@@ -476,8 +484,6 @@ HasCastleRelocationCooldownPassed = False
         HasCastleRelocationCooldownPassed = True
     End If
 End Function
-
-
 
 Public Sub CreateNewEmperorCastle(ByVal UserIndex As Integer, ByVal ObjIndex As Integer)
     On Error GoTo CreateEmperorCastle_Err
@@ -508,7 +514,6 @@ Public Sub CreateNewEmperorCastle(ByVal UserIndex As Integer, ByVal ObjIndex As 
 CreateEmperorCastle_Err:
 Call TraceError(Err.Number, Err.Description, "ModCastle.CreateEmperorCastle", Erl)
 End Sub
-
 
 Function CheckCastleEntryWhiteList(ByVal UserIndex As Integer, ByVal trigger As Integer) As Boolean
    CheckCastleEntryWhiteList = False

--- a/Codigo/ModCastle.bas
+++ b/Codigo/ModCastle.bas
@@ -28,7 +28,7 @@ Private Const SELECT_ALL_CASTLE_WHITELISTS As String = "Select * FROM castle_whi
 Private Const SELECT_ALL_CASTLES As String = "SELECT * FROM castle;"
 Private Const SELECT_ALL_CASTLE_COORDINATES = "SELECT * FROM castle_coordinates;"
 
-Private Const CastleXNegativeOffstet As Integer = 8
+Private Const CastleXNegativeOffset As Integer = 8
 Private Const CastleYNegativeOffset As Integer = 8
 Private Const CastleXPositiveOffset As Integer = 6
 Private Const CastleYPositiveOffset As Integer = 2
@@ -37,6 +37,15 @@ Private Const CASTLE_MOCKUP_OBJ_INDEX = 6382
 Private Const CASTLE_SIGN_POST_OBJ_INDEX = 6419
 Public Const EMPEROR_RELIC_OBJ_INDEX_1 = 6362
 Public Const EMPEROR_RELIC_OBJ_INDEX_20 = 6381
+
+Private Function IsCastleFootprintInMapBounds(ByVal map As Integer, ByVal x As Integer, ByVal y As Integer) As Boolean
+    IsCastleFootprintInMapBounds = False
+
+    If Not InMapBounds(map, x - CastleXNegativeOffset, y - CastleYNegativeOffset) Then Exit Function
+    If Not InMapBounds(map, x + CastleXPositiveOffset, y + CastleYPositiveOffset) Then Exit Function
+
+    IsCastleFootprintInMapBounds = True
+End Function
 
 Public Sub LoadCastleModule()
     On Error GoTo LoadCastleModule_Err
@@ -167,7 +176,7 @@ Public Function IsValidCastlePosition(ByVal UserIndex As Integer) As Boolean
             Exit Function
         End If
         
-        CastleTopLeftCorner.x = .flags.TargetX - CastleXNegativeOffstet
+        CastleTopLeftCorner.x = .flags.TargetX - CastleXNegativeOffset
         CastleTopLeftCorner.y = .flags.TargetY - CastleYNegativeOffset
         CastleTopLeftCorner.map = .flags.TargetMap
         
@@ -181,17 +190,22 @@ Public Function IsValidCastlePosition(ByVal UserIndex As Integer) As Boolean
         
     End With
     
-    If MapData(UserTargetMap, UserTargetX, UserTargetY).trigger <> e_Trigger.CASTLE_FOUNDATION_POSITION Then
-        Call WriteLocaleMsg(UserIndex, MSG_INVALID_CASTLE_POSITION, FONTTYPE_INFOBOLD)
-        Exit Function
-    End If
-    
     If UserList(UserIndex).pos.map <> UserTargetMap Then
         Call LogError("Usuario " & UserList(UserIndex).Name & "Interactuando con un mapa fuera de su rango, revisar")
         Exit Function
     End If
-    
+
     If Not IsValidMapIndex(UserTargetMap) Then
+        Call WriteLocaleMsg(UserIndex, MSG_INVALID_CASTLE_POSITION, FONTTYPE_INFOBOLD)
+        Exit Function
+    End If
+    
+    If Not IsCastleFootprintInMapBounds(UserTargetMap, UserTargetX, UserTargetY) Then
+        Call WriteLocaleMsg(UserIndex, MSG_INVALID_CASTLE_POSITION, FONTTYPE_INFOBOLD)
+        Exit Function
+    End If
+    
+    If MapData(UserTargetMap, UserTargetX, UserTargetY).trigger <> e_Trigger.CASTLE_FOUNDATION_POSITION Then
         Call WriteLocaleMsg(UserIndex, MSG_INVALID_CASTLE_POSITION, FONTTYPE_INFOBOLD)
         Exit Function
     End If
@@ -224,6 +238,14 @@ End Function
 
 
 Public Sub CreateCastleInMap(ByVal map As Integer, ByVal x As Integer, ByVal y As Integer, ByVal CastleIndex As Integer, Optional ByVal UserIndex As Integer = 0)
+    If Not IsCastleFootprintInMapBounds(map, x, y) Then
+        Call LogInfoServidor("CreateCastleInMap outside map bounds. map=" & CStr(map) & _
+            " x=" & CStr(x) & _
+            " y=" & CStr(y) & _
+            " CastleIndex=" & CStr(CastleIndex) & _
+            " UserIndex=" & CStr(UserIndex))
+        Exit Sub
+    End If
     
     With CastleData(CastleIndex)
 
@@ -241,7 +263,7 @@ Public Sub CreateCastleInMap(ByVal map As Integer, ByVal x As Integer, ByVal y A
         
         Dim CastleTopLeftCorner As t_WorldPos
         Dim CastleBottomRightCorner As t_WorldPos
-        CastleTopLeftCorner.x = x - CastleXNegativeOffstet
+        CastleTopLeftCorner.x = x - CastleXNegativeOffset
         CastleTopLeftCorner.y = y - CastleYNegativeOffset
         CastleTopLeftCorner.map = map
         
@@ -377,6 +399,22 @@ Public Sub CreateCastleInMap(ByVal map As Integer, ByVal x As Integer, ByVal y A
         MapData(map, x + 3, y - 7).Blocked = e_Block.ALL_SIDES
         
         'create castle inside tile exits to the outside part
+        If Not InMapBounds(.castle_coordinates.inside.map, .castle_coordinates.inside.x, .castle_coordinates.inside.y + 1) Then
+            Call LogInfoServidor("CreateCastleInMap invalid inside exit 1. map=" & CStr(.castle_coordinates.inside.map) & _
+                " x=" & CStr(.castle_coordinates.inside.x) & _
+                " y=" & CStr(.castle_coordinates.inside.y + 1) & _
+                " CastleIndex=" & CStr(CastleIndex))
+            Exit Sub
+        End If
+
+        If Not InMapBounds(.castle_coordinates.inside.map, .castle_coordinates.inside.x + 1, .castle_coordinates.inside.y + 1) Then
+            Call LogInfoServidor("CreateCastleInMap invalid inside exit 2. map=" & CStr(.castle_coordinates.inside.map) & _
+                " x=" & CStr(.castle_coordinates.inside.x + 1) & _
+                " y=" & CStr(.castle_coordinates.inside.y + 1) & _
+                " CastleIndex=" & CStr(CastleIndex))
+            Exit Sub
+        End If
+
         MapData(.castle_coordinates.inside.map, .castle_coordinates.inside.x, .castle_coordinates.inside.y + 1).TileExit.map = .castle_coordinates.outside.map
         MapData(.castle_coordinates.inside.map, .castle_coordinates.inside.x, .castle_coordinates.inside.y + 1).TileExit.x = .castle_coordinates.outside.x - 2
         MapData(.castle_coordinates.inside.map, .castle_coordinates.inside.x, .castle_coordinates.inside.y + 1).TileExit.y = .castle_coordinates.outside.y + 1
@@ -398,12 +436,22 @@ End Sub
 
 
 Public Sub DestroyCastleInMap(ByVal map As Integer, ByVal x As Integer, ByVal y As Integer, ByVal CastleIndex As Integer)
-    Call EraseObj(MapData(map, x, y).ObjInfo.Amount, map, x, y)
+    If Not IsCastleFootprintInMapBounds(map, x, y) Then
+        Call LogInfoServidor("DestroyCastleInMap outside map bounds. map=" & CStr(map) & _
+            " x=" & CStr(x) & _
+            " y=" & CStr(y) & _
+            " CastleIndex=" & CStr(CastleIndex))
+        Exit Sub
+    End If
+
+    If MapData(map, x, y).ObjInfo.Amount > 0 Then
+        Call EraseObj(MapData(map, x, y).ObjInfo.Amount, map, x, y)
+    End If
     
      'remove everything
     Dim CastleTopLeftCorner As t_WorldPos
     Dim CastleBottomRightCorner As t_WorldPos
-    CastleTopLeftCorner.x = x - CastleXNegativeOffstet
+    CastleTopLeftCorner.x = x - CastleXNegativeOffset
     CastleTopLeftCorner.y = y - CastleYNegativeOffset
     CastleTopLeftCorner.map = map
     
@@ -443,6 +491,22 @@ Public Sub DestroyCastleInMap(ByVal map As Integer, ByVal x As Integer, ByVal y 
     MapData(map, x, y).trigger = e_Trigger.CASTLE_FOUNDATION_POSITION
         
      With CastleData(CastleIndex)
+        If Not InMapBounds(.castle_coordinates.inside.map, .castle_coordinates.inside.x, .castle_coordinates.inside.y + 1) Then
+            Call LogInfoServidor("DestroyCastleInMap invalid inside exit 1. map=" & CStr(.castle_coordinates.inside.map) & _
+                " x=" & CStr(.castle_coordinates.inside.x) & _
+                " y=" & CStr(.castle_coordinates.inside.y + 1) & _
+                " CastleIndex=" & CStr(CastleIndex))
+            Exit Sub
+        End If
+
+        If Not InMapBounds(.castle_coordinates.inside.map, .castle_coordinates.inside.x + 1, .castle_coordinates.inside.y + 1) Then
+            Call LogInfoServidor("DestroyCastleInMap invalid inside exit 2. map=" & CStr(.castle_coordinates.inside.map) & _
+                " x=" & CStr(.castle_coordinates.inside.x + 1) & _
+                " y=" & CStr(.castle_coordinates.inside.y + 1) & _
+                " CastleIndex=" & CStr(CastleIndex))
+            Exit Sub
+        End If
+
         MapData(.castle_coordinates.inside.map, .castle_coordinates.inside.x, .castle_coordinates.inside.y + 1).TileExit.map = 0
         MapData(.castle_coordinates.inside.map, .castle_coordinates.inside.x, .castle_coordinates.inside.y + 1).TileExit.x = 0
         MapData(.castle_coordinates.inside.map, .castle_coordinates.inside.x, .castle_coordinates.inside.y + 1).TileExit.y = 0
@@ -465,6 +529,13 @@ Public Function IsEmperorCastleCreated(ByVal UserIndex As Integer) As Boolean
     For i = 1 To UBound(CastleData)
         With CastleData(i)
             If .owner_account_id = UserList(UserIndex).AccountID Then
+                If Not InMapBounds(.castle_coordinates.outside.map, .castle_coordinates.outside.x, .castle_coordinates.outside.y) Then
+                    Call LogInfoServidor("IsEmperorCastleCreated outside map bounds. map=" & CStr(.castle_coordinates.outside.map) & _
+                        " x=" & CStr(.castle_coordinates.outside.x) & _
+                        " y=" & CStr(.castle_coordinates.outside.y) & _
+                        " CastleIndex=" & CStr(i))
+                    Exit For
+                End If
                 
                 If (MapData(.castle_coordinates.outside.map, .castle_coordinates.outside.x, .castle_coordinates.outside.y).ObjInfo.ObjIndex = CASTLE_MOCKUP_OBJ_INDEX) Then
                     IsEmperorCastleCreated = True

--- a/Codigo/ModCastle.bas
+++ b/Codigo/ModCastle.bas
@@ -28,6 +28,11 @@ Private Const SELECT_ALL_CASTLE_WHITELISTS As String = "Select * FROM castle_whi
 Private Const SELECT_ALL_CASTLES As String = "SELECT * FROM castle;"
 Private Const SELECT_ALL_CASTLE_COORDINATES = "SELECT * FROM castle_coordinates;"
 
+Private Const CastleXNegativeOffstet As Integer = 8
+Private Const CastleYNegativeOffset As Integer = 8
+Private Const CastleXPositiveOffset As Integer = 6
+Private Const CastleYPositiveOffset As Integer = 2
+
 Private Const CASTLE_MOCKUP_OBJ_INDEX = 6382
 Private Const CASTLE_SIGN_POST_OBJ_INDEX = 63419
 Public Const EMPEROR_RELIC_OBJ_INDEX_1 = 6362
@@ -167,12 +172,12 @@ Public Function IsValidCastlePosition(ByVal UserIndex As Integer) As Boolean
         End If
     
     
-        CastleTopLeftCorner.x = .flags.TargetX - 6
-        CastleTopLeftCorner.y = .flags.TargetY - 7
+        CastleTopLeftCorner.x = .flags.TargetX - CastleXNegativeOffstet
+        CastleTopLeftCorner.y = .flags.TargetY - CastleYNegativeOffset
         CastleTopLeftCorner.map = .flags.TargetMap
         
-        CastleBottomRightCorner.x = .flags.TargetX + 3
-        CastleBottomRightCorner.y = .flags.TargetY
+        CastleBottomRightCorner.x = .flags.TargetX + CastleXPositiveOffset
+        CastleBottomRightCorner.y = .flags.TargetY + CastleYPositiveOffset
         CastleBottomRightCorner.map = .flags.TargetMap
         
         UserTargetX = .flags.TargetX
@@ -213,9 +218,9 @@ End Function
 
 
 Public Sub CreateCastleInMap(ByVal map As Integer, ByVal x As Integer, ByVal y As Integer, ByVal CastleIndex As Integer, Optional ByVal UserIndex As Integer = 0)
-
-    With CastleData(CastleIndex)
     
+    With CastleData(CastleIndex)
+
         'if not during server start...(player clicking the board)
          If UserIndex > 0 Then
             .castle_coordinates.outside.map = map
@@ -228,11 +233,21 @@ Public Sub CreateCastleInMap(ByVal map As Integer, ByVal x As Integer, ByVal y A
             Call CastleWhiteList.Add(.owner_account_id, .trigger)
         End If
         
+        Dim CastleTopLeftCorner As t_WorldPos
+        Dim CastleBottomRightCorner As t_WorldPos
+        CastleTopLeftCorner.x = x - CastleXNegativeOffstet
+        CastleTopLeftCorner.y = y - CastleYNegativeOffset
+        CastleTopLeftCorner.map = map
+        
+        CastleBottomRightCorner.x = x + CastleXPositiveOffset
+        CastleBottomRightCorner.y = y + CastleYPositiveOffset
+        CastleBottomRightCorner.map = map
+        
         'erase preemptively all blocks, triggers, objects and npcs in the zone
         Dim i As Integer
         Dim j As Integer
-        For i = x - 8 To x + 6
-            For j = y - 8 To y + 2
+        For i = CastleTopLeftCorner.x To CastleBottomRightCorner.x
+            For j = CastleTopLeftCorner.y To CastleBottomRightCorner.y
             
             MapData(map, i, j).Blocked = 0
             MapData(map, i, j).trigger = e_Trigger.nada
@@ -380,10 +395,21 @@ Public Sub DestroyCastleInMap(ByVal map As Integer, ByVal x As Integer, ByVal y 
     Call EraseObj(MapData(map, x, y).ObjInfo.Amount, map, x, y)
     
      'remove everything
+    Dim CastleTopLeftCorner As t_WorldPos
+    Dim CastleBottomRightCorner As t_WorldPos
+    CastleTopLeftCorner.x = x - CastleXNegativeOffstet
+    CastleTopLeftCorner.y = y - CastleYNegativeOffset
+    CastleTopLeftCorner.map = map
+    
+    CastleBottomRightCorner.x = x + CastleXPositiveOffset
+    CastleBottomRightCorner.y = y + CastleYPositiveOffset
+    CastleBottomRightCorner.map = map
+    
+    'erase preemptively all blocks, triggers, objects and npcs in the zone
     Dim i As Integer
     Dim j As Integer
-    For i = x - 8 To x + 6
-        For j = y - 8 To y + 2
+    For i = CastleTopLeftCorner.x To CastleBottomRightCorner.x
+        For j = CastleTopLeftCorner.y To CastleBottomRightCorner.y
         
         MapData(map, i, j).Blocked = 0
         MapData(map, i, j).trigger = e_Trigger.nada

--- a/Codigo/ModCastle.bas
+++ b/Codigo/ModCastle.bas
@@ -212,16 +212,7 @@ End Function
 
 
 Public Sub CreateCastleInMap(ByVal map As Integer, ByVal x As Integer, ByVal y As Integer, ByVal CastleIndex As Integer, Optional ByVal UserIndex As Integer = 0)
-    'preemptively erase any object in the same tile of the foundation trigger
-    If MapData(map, x, y).ObjInfo.Amount > 0 Then
-        Call EraseObj(MapData(map, x, y).ObjInfo.Amount, map, x, y)
-    End If
-    Dim CastleObj As t_Obj
-    CastleObj.Amount = 1
-    CastleObj.ObjIndex = CASTLE_OBJ
-    
-    Call MakeObj(CastleObj, map, x, y)
-    
+
     With CastleData(CastleIndex)
     
         'if not during server start...(player clicking the board)
@@ -233,7 +224,7 @@ Public Sub CreateCastleInMap(ByVal map As Integer, ByVal x As Integer, ByVal y A
             .is_active = 1
             .owner_account_id = UserList(UserIndex).AccountID
             .owner_char_id = UserList(UserIndex).Id
-            Call CastleWhiteList.Add(CastleData(CastleIndex).owner_account_id, CastleData(CastleIndex).trigger)
+            Call CastleWhiteList.Add(.owner_account_id, .trigger)
         End If
         
         'erase preemptively all blocks, triggers, objects and npcs in the zone
@@ -372,6 +363,13 @@ Public Sub CreateCastleInMap(ByVal map As Integer, ByVal x As Integer, ByVal y A
         MapData(.castle_coordinates.inside.map, .castle_coordinates.inside.x + 1, .castle_coordinates.inside.y + 1).TileExit.x = .castle_coordinates.outside.x - 1
         MapData(.castle_coordinates.inside.map, .castle_coordinates.inside.x + 1, .castle_coordinates.inside.y + 1).TileExit.y = .castle_coordinates.outside.y + 1
         
+        'create castle visual mockup
+        Dim CastleObj As t_Obj
+        CastleObj.Amount = 1
+        CastleObj.ObjIndex = CASTLE_OBJ
+        
+        Call MakeObj(CastleObj, map, x, y)
+    
     End With
     
 End Sub

--- a/ScriptsDB/20260624-05-insert castle coordinates.sql
+++ b/ScriptsDB/20260624-05-insert castle coordinates.sql
@@ -1,2 +1,2 @@
 INSERT INTO castle_coordinates (castle_id,inside_map, inside_x, inside_y) VALUES
-(1,347,50,72);
+(1,758,50,72);


### PR DESCRIPTION
### Motivation

- Prevent any out-of-bounds `MapData(...)` access when creating, destroying or validating castle footprints so a bad coordinate or a foundation near the map edge cannot crash or corrupt map state.
- Fix a small constant name typo to make future edits and audits clearer.

### Description

- Renamed `CastleXNegativeOffstet` to `CastleXNegativeOffset` and updated all references while preserving existing footprint offsets and object indexes (`CASTLE_MOCKUP_OBJ_INDEX` and `CASTLE_SIGN_POST_OBJ_INDEX`).
- Added `IsCastleFootprintInMapBounds(map, x, y)` to validate the full castle rectangle using the negative/positive offsets before any castle-relative `MapData` access.
- Added early guards in `CreateCastleInMap` and `DestroyCastleInMap` to exit if the full footprint is out of bounds, and made the center-tile object erase conditional on a positive `ObjInfo.Amount` in `DestroyCastleInMap`.
- Validated inside-exit tiles with `InMapBounds(...)` before writing or clearing their `TileExit` fields in both creation and destruction, and added a defensive `InMapBounds` check in `IsEmperorCastleCreated` before reading `MapData` for stored castle coordinates.
- Adjusted `IsValidCastlePosition` to run the full-footprint bounds check before any `MapData(...)` reads or looping through footprint tiles, and added searchable log messages containing procedure name, map/x/y, and `CastleIndex` where applicable.

### Testing

- Ran a repository audit for the changes with `rg -n "Offstet|IsCastleFootprintInMapBounds|MapData\(" Codigo/ModCastle.bas` to confirm all castle-relative `MapData` usages are covered, and the audit succeeded.
- Ran `git diff --check -- Codigo/ModCastle.bas` (style/trailing-whitespace checks) and the check passed after trimming trailing whitespace.
- Performed a manual code review of `Codigo/ModCastle.bas` to ensure no castle-relative `MapData(...)` calls remain unguarded, and the review succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46c6fb88748328aa5549a6766bbd69)