### PR TITLE
Fix castle whitelist pushback tile direction

### DIFF
--- a/Codigo/GameLogic.bas
+++ b/Codigo/GameLogic.bas
@@ -327,7 +327,7 @@ Public Sub DoTileEvents(ByVal UserIndex As Integer, ByVal Map As Integer, ByVal 
             If MapData(Map, x, y).trigger >= EMPEROR_CASTLE_ENTRY_1 Then
                 If MapData(Map, x, y).trigger <= EMPEROR_CASTLE_ENTRY_20 Then
                     If Not CheckCastleEntryWhiteList(UserIndex, MapData(map, x, y).trigger) Then
-                        Call WarpUserChar(UserIndex, map, x, y - 1, False)
+                        Call WarpUserChar(UserIndex, map, x, y + 1, False)
                         Call WriteLocaleMsg(UserIndex, MSG_NOT_IN_THE_CASTLE_WHITELIST, FONTTYPE_INFOBOLD)
                         Exit Sub
                     End If


### PR DESCRIPTION
When a player without whitelist access steps on an Emperor Castle entry trigger, the rejection warp now moves them to `y + 1` instead of `y - 1`. This aligns the pushback direction with the intended entry flow and prevents warping to the wrong adjacent tile.