### PR TITLE
Extract NPC ranged attack capability check

### DIFF
--- a/Codigo/AI_NPC.bas
+++ b/Codigo/AI_NPC.bas
@@ -453,8 +453,8 @@ Private Sub AI_CaminarConRumbo(ByVal NpcIndex As Integer, ByRef rumbo As t_World
                         NpcList(NpcIndex).pathFindingInfo.RangoVision = Min(SvrConfig.GetValue("NPC_MAX_VISION_RANGE"), NpcList(NpcIndex).pathFindingInfo.RangoVision + _
                                 PATH_VISION_DELTA)
                     End If
-                    If NpcList(NpcIndex).TargetUser.ArrayIndex <> 0 And NpcList(NpcIndex).flags.LanzaSpells = 0 And _
-                       NpcList(NpcIndex).flags.Inmovilizado = 0 And NpcList(NpcIndex).flags.AttackedBy = vbNullString Then
+                    If NpcList(NpcIndex).TargetUser.ArrayIndex <> 0 And Not NpcPuedeAtacarADistancia(NpcIndex) And _
+                       NpcList(NpcIndex).flags.AttackedBy = vbNullString Then
                         Call NpcMarkTargetUnreachable(NpcIndex)
                     End If
                     Call AnimacionIdle(NpcIndex, True)
@@ -594,6 +594,14 @@ Private Function ComputeNpcRangedRetreatDestination(ByVal NpcIndex As Integer, B
 ContinueOrbitSearch:
     Next attempt
     ComputeNpcRangedRetreatDestination = npcPos
+
+Private Function NpcPuedeAtacarADistancia(ByVal NpcIndex As Integer) As Boolean
+    With NpcList(NpcIndex)
+        If .flags.Paralizado <> 0 Or .flags.Inmovilizado <> 0 Then Exit Function
+
+        NpcPuedeAtacarADistancia = .AttackRange > 1 Or _
+                (.flags.LanzaSpells > 0 And IntervaloPermiteLanzarHechizo(NpcIndex))
+    End With
 End Function
 
 Private Sub NpcMarkTargetUnreachable(ByVal NpcIndex As Integer)


### PR DESCRIPTION
Refactor the NPC ranged attack condition into a dedicated private function `NpcPuedeAtacarADistancia` for better code maintainability. This function encapsulates the logic for determining if an NPC can attack at distance, including checks for paralysis, immobility, attack range, and spell casting capability. This reduces code duplication and makes the condition in `AI_CaminarConRumbo` more readable.