### PR TITLE
Only melee NPCs mark targets unreachable

### DIFF
--- a/Codigo/AI_NPC.bas
+++ b/Codigo/AI_NPC.bas
@@ -453,8 +453,8 @@ Private Sub AI_CaminarConRumbo(ByVal NpcIndex As Integer, ByRef rumbo As t_World
                         NpcList(NpcIndex).pathFindingInfo.RangoVision = Min(SvrConfig.GetValue("NPC_MAX_VISION_RANGE"), NpcList(NpcIndex).pathFindingInfo.RangoVision + _
                                 PATH_VISION_DELTA)
                     End If
-                    If NpcList(NpcIndex).TargetUser.ArrayIndex <> 0 And NpcList(NpcIndex).flags.LanzaSpells = 0 And _
-                       NpcList(NpcIndex).flags.Inmovilizado = 0 And NpcList(NpcIndex).flags.AttackedBy = vbNullString Then
+                    If NpcList(NpcIndex).TargetUser.ArrayIndex <> 0 And NpcList(NpcIndex).AttackRange <= 1 And _
+                       NpcList(NpcIndex).flags.LanzaSpells = 0 And NpcList(NpcIndex).flags.AttackedBy = vbNullString Then
                         Call NpcMarkTargetUnreachable(NpcIndex)
                     End If
                     Call AnimacionIdle(NpcIndex, True)


### PR DESCRIPTION
Change target-unreachable condition to require AttackRange <= 1 and remove the flags.Inmovilizado check. Now NPCs will mark their TargetUser unreachable only if they are melee (attack range 1), don't cast spells, and aren't currently marked as being attacked. This prevents ranged NPCs from incorrectly marking targets unreachable and avoids the immobilized flag blocking the unreachable-marking logic.