### PR TITLE
Add lava spawning support for NPCs

### DIFF
--- a/Codigo/Declares.bas
+++ b/Codigo/Declares.bas
@@ -3129,6 +3129,7 @@ Public Type t_NPCFlags
     OldHostil As Byte
     AguaValida As Byte
     TierraInvalida As Byte
+    LavaValida As Byte
     ' UseAINow As Boolean No se usa, borrar de la DB!!!!
     Sound As Integer
     AttackedBy As String
@@ -3223,6 +3224,7 @@ Public Type t_NpcInfoCache
     AguaValida As Integer
     GlobalQuestBossIndex As Integer
     TierraInvalida As Integer
+    LavaValida As Integer
     Faccion As Integer
     ElementalTags As Long
     npcType As Integer

--- a/Codigo/GameLogic.bas
+++ b/Codigo/GameLogic.bas
@@ -509,25 +509,25 @@ Function ClosestLegalPosNPC(ByVal NpcIndex As Integer, ByVal MaxRange As Integer
         Do
             tY = .pos.y - LoopC
             For tX = .pos.x - LoopC To .pos.x + LoopC
-                If ValidNPCSpawnPos(ClosestLegalPosNPC, .pos.Map, tX, tY, .flags.AguaValida = 1, .flags.TierraInvalida = 0, IgnoreUsers, IgnoreDeadUsers) Then
+                If ValidNPCSpawnPos(ClosestLegalPosNPC, .pos.Map, tX, tY, .flags.AguaValida = 1, .flags.TierraInvalida = 0, .flags.LavaValida = 1, IgnoreUsers, IgnoreDeadUsers) Then
                     Exit Function
                 End If
             Next
             tX = .pos.x - LoopC
             For tY = .pos.y - LoopC + 1 To .pos.y + LoopC - 1
-                If ValidNPCSpawnPos(ClosestLegalPosNPC, .pos.Map, tX, tY, .flags.AguaValida = 1, .flags.TierraInvalida = 0, IgnoreUsers, IgnoreDeadUsers) Then
+                If ValidNPCSpawnPos(ClosestLegalPosNPC, .pos.Map, tX, tY, .flags.AguaValida = 1, .flags.TierraInvalida = 0, .flags.LavaValida = 1, IgnoreUsers, IgnoreDeadUsers) Then
                     Exit Function
                 End If
             Next
             tX = .pos.x + LoopC
             For tY = .pos.y - LoopC + 1 To .pos.y + LoopC - 1
-                If ValidNPCSpawnPos(ClosestLegalPosNPC, .pos.Map, tX, tY, .flags.AguaValida = 1, .flags.TierraInvalida = 0, IgnoreUsers, IgnoreDeadUsers) Then
+                If ValidNPCSpawnPos(ClosestLegalPosNPC, .pos.Map, tX, tY, .flags.AguaValida = 1, .flags.TierraInvalida = 0, .flags.LavaValida = 1, IgnoreUsers, IgnoreDeadUsers) Then
                     Exit Function
                 End If
             Next
             tY = .pos.y + LoopC
             For tX = .pos.x - LoopC To .pos.x + LoopC
-                If ValidNPCSpawnPos(ClosestLegalPosNPC, .pos.Map, tX, tY, .flags.AguaValida = 1, .flags.TierraInvalida = 0, IgnoreUsers, IgnoreDeadUsers) Then
+                If ValidNPCSpawnPos(ClosestLegalPosNPC, .pos.Map, tX, tY, .flags.AguaValida = 1, .flags.TierraInvalida = 0, .flags.LavaValida = 1, IgnoreUsers, IgnoreDeadUsers) Then
                     Exit Function
                 End If
             Next
@@ -545,9 +545,12 @@ Private Function ValidNPCSpawnPos(OutPos As t_WorldPos, _
                                   ByVal y As Integer, _
                                   ByVal AguaValida As Boolean, _
                                   ByVal TierraValida As Boolean, _
+                                  ByVal LavaValida As Boolean, _
                                   ByVal IgnoreUsers As Boolean, _
                                   ByVal IgnoreDeadUsers As Boolean) As Boolean
     If LegalPos(Map, x, y, AguaValida, TierraValida, , False) Then
+        If HayLava(Map, x, y) <> LavaValida Then Exit Function
+
         If TestSpawnTrigger(Map, x, y) Then
             If Not HayPCarea(Map, x, y, IgnoreDeadUsers) Or IgnoreUsers Then
                 ValidNPCSpawnPos = True

--- a/Codigo/General.bas
+++ b/Codigo/General.bas
@@ -358,7 +358,7 @@ EsArbol_Err:
     Call TraceError(Err.Number, Err.Description, "General.EsArbol", Erl)
 End Function
 
-Private Function HayLava(ByVal Map As Integer, ByVal x As Integer, ByVal y As Integer) As Boolean
+Public Function HayLava(ByVal Map As Integer, ByVal x As Integer, ByVal y As Integer) As Boolean
     On Error GoTo HayLava_Err
     If Map > 0 And Map < NumMaps + 1 And x > 0 And x < 101 And y > 0 And y < 101 Then
         If (MapData(Map, x, y).Graphic(1) >= 5837 And MapData(Map, x, y).Graphic(1) <= 5852) _

--- a/Codigo/MODULO_NPCs.bas
+++ b/Codigo/MODULO_NPCs.bas
@@ -269,6 +269,7 @@ Sub ResetNpcFlags(ByVal NpcIndex As Integer)
         .AfectaParalisis = 0
         .ImmuneToSpells = 0
         .AguaValida = 0
+        .LavaValida = 0
         .AttackedBy = vbNullString
         .AttackedTime = 0
         .AttackedFirstBy = vbNullString
@@ -494,7 +495,8 @@ Public Function CrearNPC(NroNPC As Integer, Mapa As Integer, OrigPos As t_WorldP
         PuedeAgua = .flags.AguaValida = 1
         PuedeTierra = .flags.TierraInvalida = 0
         'Necesita ser respawned en un lugar especifico
-        If .flags.RespawnOrigPos And InMapBounds(OrigPos.Map, OrigPos.x, OrigPos.y) Then
+        If .flags.RespawnOrigPos And InMapBounds(OrigPos.Map, OrigPos.x, OrigPos.y) _
+                And (HayLava(OrigPos.Map, OrigPos.x, OrigPos.y) = (.flags.LavaValida = 1)) Then
             Map = OrigPos.Map
             x = OrigPos.x
             y = OrigPos.y
@@ -735,6 +737,7 @@ Public Function MoveNPCChar(ByVal NpcIndex As Integer, ByVal nHeading As Byte) A
         nPos = .pos
         Call HeadtoPos(nHeading, nPos)
         esGuardia = .npcType = e_NPCType.GuardiaReal Or .npcType = e_NPCType.GuardiasCaos
+        If .flags.LavaValida = 1 And Not HayLava(nPos.Map, nPos.x, nPos.y) Then Exit Function
         ' es una posicion legal
         If LegalWalkNPC(nPos.Map, nPos.x, nPos.y, nHeading, .flags.AguaValida = 1, .flags.TierraInvalida = 0, IsValidUserRef(.MaestroUser), , esGuardia) Then
             UserIndex = MapData(.pos.Map, nPos.x, nPos.y).UserIndex
@@ -1005,6 +1008,7 @@ Private Sub LoadNpcInfoIntoCache(ByVal NpcNumber As Integer)
         .Movement = Val(LeerNPCs.GetValue(SectionName, "Movement"))
         .AguaValida = Val(LeerNPCs.GetValue(SectionName, "AguaValida"))
         .TierraInvalida = Val(LeerNPCs.GetValue(SectionName, "TierraInValida"))
+        .LavaValida = Val(LeerNPCs.GetValue(SectionName, "LavaValida"))
         .Faccion = Val(LeerNPCs.GetValue(SectionName, "Faccion"))
         .ElementalTags = Val(LeerNPCs.GetValue(SectionName, "ElementalTags"))
         .GlobalQuestBossIndex = val(LeerNPCs.GetValue(SectionName, "GlobalQuestBossIndex"))
@@ -1391,6 +1395,7 @@ Private Sub InitializeNpcFromInfo(ByVal NpcIndex As Integer, _
         .flags.AguaValida = Info.AguaValida
         .flags.GlobalQuestBossIndex = Info.GlobalQuestBossIndex
         .flags.TierraInvalida = Info.TierraInvalida
+        .flags.LavaValida = Info.LavaValida
         .flags.Faccion = Info.Faccion
         .flags.ElementalTags = Info.ElementalTags
         .npcType = Info.npcType


### PR DESCRIPTION
Add PuedeLava flag to allow NPCs to spawn and respawn on lava tiles. This includes:
- New PuedeLava field in NPC flags and cache structures
- Updated ValidNPCSpawnPos to check for lava when PuedeLava flag is set
- Loading PuedeLava from NPC configuration files
- Made HayLava function public and refined lava tile detection logic