### PR TITLE
Add indexes for user-related tables

### DIFF
--- a/ScriptsDB/20260720-01-Add more indexes to tables.sql
+++ b/ScriptsDB/20260720-01-Add more indexes to tables.sql
@@ -1,0 +1,6 @@
+CREATE INDEX idx_pet_user_id ON pet(user_id);
+CREATE INDEX idx_spell_user_id ON spell(user_id);
+CREATE INDEX idx_skillpoint_user_id ON skillpoint(user_id);
+CREATE INDEX idx_inventory_item_user_id ON inventory_item(user_id);
+CREATE INDEX idx_bank_item_user_id ON bank_item(user_id);
+CREATE INDEX idx_accounts ON account(id);


### PR DESCRIPTION
Adds a new DB migration script creating indexes on `user_id` across `pet`, `spell`, `skillpoint`, `inventory_item`, and `bank_item`, plus an index on `account(id)`. This improves lookup and join performance for account/user-scoped queries.

### IMPORTANT, RUN VACCUUM AFTER MERGE