### PR TITLE
New selective wood shield reflect sound

### DIFF
--- a/Codigo/Declares.bas
+++ b/Codigo/Declares.bas
@@ -1499,7 +1499,7 @@ Public Const SND_RESURRECCION    As Byte = 117
 
 Public Const SND_SACARARMA           As Byte = 25
 Public Const SND_ESCUDO              As Byte = 37
-Public Const SND_ESCUDO_MADERA As Byte = SND_ESCUDO ' TODO: reemplazar cuando haya sonido propio
+Public Const SND_ESCUDO_MADERA       As Integer = 2053
 Public Const MARTILLOHERRERO         As Byte = 41
 Public Const LABUROCARPINTERO        As Byte = 42
 Public Const SND_BEBER               As Byte = 135


### PR DESCRIPTION
This pull request updates the sound constant for the wooden shield in `Declares.bas`. The constant `SND_ESCUDO_MADERA` now has its own unique value instead of sharing the same value as `SND_ESCUDO`.

Sound constant updates:

* Changed `SND_ESCUDO_MADERA` from an alias of `SND_ESCUDO` to a unique integer value (`2053`), allowing for a distinct sound effect for wooden shields.