### PR TITLE
Fix underworld hours across midnight

### DIFF
--- a/Codigo/ModUnderworld.bas
+++ b/Codigo/ModUnderworld.bas
@@ -154,10 +154,13 @@ End Function
 Public Function IsUnderworldOpen() As Boolean
     Dim currentHour As Integer
     currentHour = Hour(Now)
-    If currentHour >= UnderworldLowerLimitOfTime And currentHour < UnderworldUpperLimitOfTime Then
-        IsUnderworldOpen = True
+    ' Check if the range wraps around midnight
+    If UnderworldLowerLimitOfTime > UnderworldUpperLimitOfTime Then
+        ' Wraps midnight: e.g., 18 to 1 means 6pm to 1am
+        IsUnderworldOpen = (currentHour >= UnderworldLowerLimitOfTime Or currentHour < UnderworldUpperLimitOfTime)
     Else
-        IsUnderworldOpen = False
+        ' Normal range: e.g., 9 to 17 means 9am to 5pm
+        IsUnderworldOpen = (currentHour >= UnderworldLowerLimitOfTime And currentHour < UnderworldUpperLimitOfTime)
     End If
 End Function
 


### PR DESCRIPTION
Update `IsUnderworldOpen` to correctly evaluate schedules that span midnight (for example, 18:00 to 01:00). The old logic only worked for same-day ranges, causing nighttime windows to be treated as closed.