### PR TITLE
Always set castle inside tile exits

### DIFF
--- a/Codigo/ModCastle.bas
+++ b/Codigo/ModCastle.bas
@@ -517,7 +517,6 @@ Public Sub CreateCastleInMap(ByVal map As Integer, ByVal x As Integer, ByVal y A
         MapData(map, x + 3, y - 7).Blocked = e_Block.ALL_SIDES
 
         'create castle inside tile exits to the outside part
-        #If DEBUGGING = 0 Then
         If Not InMapBounds(.castle_coordinates.inside.map, .castle_coordinates.inside.x, .castle_coordinates.inside.y + 1) Then
             Call LogInfoServidor("CreateCastleInMap invalid inside exit 1. map=" & CStr(.castle_coordinates.inside.map) & _
                 " x=" & CStr(.castle_coordinates.inside.x) & _
@@ -541,7 +540,6 @@ Public Sub CreateCastleInMap(ByVal map As Integer, ByVal x As Integer, ByVal y A
         MapData(.castle_coordinates.inside.map, .castle_coordinates.inside.x + 1, .castle_coordinates.inside.y + 1).TileExit.map = .castle_coordinates.outside.map
         MapData(.castle_coordinates.inside.map, .castle_coordinates.inside.x + 1, .castle_coordinates.inside.y + 1).TileExit.x = .castle_coordinates.outside.x - 1
         MapData(.castle_coordinates.inside.map, .castle_coordinates.inside.x + 1, .castle_coordinates.inside.y + 1).TileExit.y = .castle_coordinates.outside.y + 1
-        #End If
 
         'erase castle sign
         If MapData(map, x, y).ObjInfo.Amount > 0 Then


### PR DESCRIPTION
Remove the `#If DEBUGGING = 0` guard in `CreateCastleInMap` so inside-exit bounds checks, logging, and tile-exit wiring run in all builds. This keeps castle exit setup consistent in debug mode and helps surface invalid coordinates during development.