### PR TITLE
Add castle DB migration scripts

### DIFF
--- a/ScriptsDB/20260724-01-change first castle coordinate val.sql
+++ b/ScriptsDB/20260724-01-change first castle coordinate val.sql
@@ -1,0 +1,6 @@
+-- Update castle coordinates for castle_id = 1
+UPDATE castle_coordinates 
+SET inside_map = 758, 
+    inside_x = 50, 
+    inside_y = 72 
+WHERE castle_id = 1;

--- a/ScriptsDB/20260724-02-regenerate castle table.sql
+++ b/ScriptsDB/20260724-02-regenerate castle table.sql
@@ -1,0 +1,15 @@
+DROP table IF EXISTS castle;
+
+CREATE TABLE "castle" (
+	"id" INTEGER PRIMARY KEY AUTOINCREMENT,
+	"trigger" integer NOT NULL,
+	"owner_account_id"  integer NULL UNIQUE,
+	"owner_character_id" integer NULL UNIQUE,
+	"spawner_obj_id" integer NOT NULL UNIQUE,
+	"portal_obj_id" integer NOT NULL UNIQUE,
+	"foundation_date" timestamp DEFAULT NULL,
+	"is_active" integer DEFAULT 0,
+	"name" varchar(255) DEFAULT NULL,
+	FOREIGN KEY (owner_account_id) REFERENCES account(id) ON DELETE CASCADE ON UPDATE CASCADE,
+	FOREIGN KEY (owner_character_id) REFERENCES user(id) ON DELETE CASCADE ON UPDATE CASCADE
+);


### PR DESCRIPTION
Introduces two ScriptsDB SQL scripts: one updates the inside map/X/Y coordinates for castle_id = 1, and another drops and recreates the `castle` table with explicit ownership fields, unique constraints, activation/name columns, and cascading foreign keys to `account` and `user`.