### PR TITLE
Update castle triggers and objects in database

### DIFF
--- a/ScriptsDB/20260724-03-insert castle triggers and objects.sql
+++ b/ScriptsDB/20260724-03-insert castle triggers and objects.sql
@@ -1,4 +1,4 @@
-INSERT INTO castle (trigger, spawner_obj_id,portal_obj_id) VALUES
+INSERT INTO castle (trigger, spawner_obj_id,inside_key_obj_id) VALUES
 (21,6362,6383),
 (22,6363,6384),
 (23,6364,6385),


### PR DESCRIPTION
This pull request makes a small change to the `ScriptsDB/20260724-03-insert castle triggers and objects.sql` file, updating the column name in the `INSERT INTO castle` statement for clarity. The column `portal_obj_id` has been renamed to `inside_key_obj_id`.