### PR TITLE
Fix castle spawn target initialization and prevent invalid positions

### DIFF
--- a/Codigo/InvUsuario.bas
+++ b/Codigo/InvUsuario.bas
@@ -3002,6 +3002,9 @@ Public Sub UserTargetableItem(ByVal UserIndex As Integer, ByVal TileX As Integer
                 Case e_OBJType.otCastleSpawner
                     If UserList(UserIndex).Stats.tipoUsuario >= e_TipoUsuario.tNoble Then
                         If IsValidCastlePosition(UserIndex) Then
+                            UserList(UserIndex).flags.TargetMap = UserList(UserIndex).pos.map
+                            UserList(UserIndex).flags.TargetX = TileX
+                            UserList(UserIndex).flags.TargetY = TileY
                             Call CreateNewEmperorCastle(UserIndex, ObjIndex)
                         End If
                     Else

--- a/Codigo/InvUsuario.bas
+++ b/Codigo/InvUsuario.bas
@@ -3002,9 +3002,6 @@ Public Sub UserTargetableItem(ByVal UserIndex As Integer, ByVal TileX As Integer
                 Case e_OBJType.otCastleSpawner
                     If UserList(UserIndex).Stats.tipoUsuario >= e_TipoUsuario.tNoble Then
                         If IsValidCastlePosition(UserIndex) Then
-                            UserList(UserIndex).flags.TargetMap = UserList(UserIndex).pos.map
-                            UserList(UserIndex).flags.TargetX = TileX
-                            UserList(UserIndex).flags.TargetY = TileY
                             Call CreateNewEmperorCastle(UserIndex, ObjIndex)
                         End If
                     Else

--- a/Codigo/ModCastle.bas
+++ b/Codigo/ModCastle.bas
@@ -34,7 +34,7 @@ Public CastleData() As t_CastleInfo
 Private Const COUNT_ALL_CASTLES As String = "SELECT COUNT(*) FROM castle;"
 
 Private Const UPDATE_EMPEROR_CASTLE As String = "UPDATE castle SET owner_account_id = ?, owner_character_id = ?, foundation_date = ?, is_active = ?, name = ? WHERE id = ?;"
-Private Const UPDATE_OUTSIDE_CASTLE_LOCATION As String = "UPDATE castle_coordinates SET outside_map = ?, outside_x = ?, outside_y = ? WHERE castle_id = ?;"
+Private Const UPDATE_OUTSIDE_CASTLE_LOCATION As String = "UPDATE castle_coordinates SET outside_map = ?, outside_x = ?, outside_y = ? WHERE id = ?;"
 
 Private Const INSERT_OR_IGNORE_NEW_CHAR_IN_CASTLE_WHITELIST As String = "INSERT OR IGNORE INTO castle_whitelist (character_name, castle_id) VALUES (?,?)"
 Private Const DELETE_CHAR_IN_CASTLE_WHITELIST As String = "DELETE FROM castle_whitelist WHERE id = ?"

--- a/Codigo/ModCastle.bas
+++ b/Codigo/ModCastle.bas
@@ -34,7 +34,7 @@ Public CastleData() As t_CastleInfo
 Private Const COUNT_ALL_CASTLES As String = "SELECT COUNT(*) FROM castle;"
 
 Private Const UPDATE_EMPEROR_CASTLE As String = "UPDATE castle SET owner_account_id = ?, owner_character_id = ?, foundation_date = ?, is_active = ?, name = ? WHERE id = ?;"
-Private Const UPDATE_OUTSIDE_CASTLE_LOCATION As String = "UPDATE castle_coordinates SET outside_map = ?, outside_x = ?, outside_y = ? WHERE id = ?;"
+Private Const UPDATE_OUTSIDE_CASTLE_LOCATION As String = "UPDATE castle_coordinates SET outside_map = ?, outside_x = ?, outside_y = ? WHERE castle_id = ?;"
 
 Private Const INSERT_OR_IGNORE_NEW_CHAR_IN_CASTLE_WHITELIST As String = "INSERT OR IGNORE INTO castle_whitelist (character_name, castle_id) VALUES (?,?)"
 Private Const DELETE_CHAR_IN_CASTLE_WHITELIST As String = "DELETE FROM castle_whitelist WHERE id = ?"

--- a/Codigo/ModCastle.bas
+++ b/Codigo/ModCastle.bas
@@ -364,6 +364,11 @@ Public Sub CreateCastleInMap(ByVal map As Integer, ByVal x As Integer, ByVal y A
     End If
 
     With CastleData(CastleIndex)
+    
+        If x = 0 Or y = 0 Or map = 0 Then
+            Call WriteLocaleMsg(UserIndex, MSG_INVALID_CASTLE_POSITION, FONTTYPE_INFOBOLD)
+            Exit Sub
+        End If
 
         'if not during server start...(player clicking the board)
          If UserIndex > 0 Then
@@ -683,6 +688,11 @@ Public Sub CreateNewEmperorCastle(ByVal UserIndex As Integer, ByVal ObjIndex As 
     Dim RS As ADODB.Recordset
     With UserList(UserIndex)
 
+        If .flags.TargetX = 0 Or .flags.TargetY = 0 Or .flags.TargetMap = 0 Then
+            Call WriteLocaleMsg(UserIndex, MSG_INVALID_CASTLE_POSITION, FONTTYPE_INFOBOLD)
+            Exit Sub
+        End If
+    
         If IsEmperorCastleCreated(UserIndex) Then
             If Not HasCastleRelocationCooldownPassed(ObjData(ObjIndex).AssignedCastleIndex) Then
                 Call WriteLocaleMsg(UserIndex, MSG_CASTLE_RELOCATION_ON_COOLDOWN, FONTTYPE_INFOBOLD)

--- a/Codigo/ModCastle.bas
+++ b/Codigo/ModCastle.bas
@@ -364,11 +364,6 @@ Public Sub CreateCastleInMap(ByVal map As Integer, ByVal x As Integer, ByVal y A
     End If
 
     With CastleData(CastleIndex)
-    
-        If x = 0 Or y = 0 Or map = 0 Then
-            Call WriteLocaleMsg(UserIndex, MSG_INVALID_CASTLE_POSITION, FONTTYPE_INFOBOLD)
-            Exit Sub
-        End If
 
         'if not during server start...(player clicking the board)
          If UserIndex > 0 Then
@@ -688,11 +683,6 @@ Public Sub CreateNewEmperorCastle(ByVal UserIndex As Integer, ByVal ObjIndex As 
     Dim RS As ADODB.Recordset
     With UserList(UserIndex)
 
-        If .flags.TargetX = 0 Or .flags.TargetY = 0 Or .flags.TargetMap = 0 Then
-            Call WriteLocaleMsg(UserIndex, MSG_INVALID_CASTLE_POSITION, FONTTYPE_INFOBOLD)
-            Exit Sub
-        End If
-    
         If IsEmperorCastleCreated(UserIndex) Then
             If Not HasCastleRelocationCooldownPassed(ObjData(ObjIndex).AssignedCastleIndex) Then
                 Call WriteLocaleMsg(UserIndex, MSG_CASTLE_RELOCATION_ON_COOLDOWN, FONTTYPE_INFOBOLD)


### PR DESCRIPTION
This pull request makes a targeted change to the SQL update statement for castle coordinates in the `ModCastle.bas` module. The main update is to ensure castle coordinates are updated based on `castle_id` rather than a generic `id`, which improves data consistency and clarity.

**Database query improvement:**

* Updated the `UPDATE_OUTSIDE_CASTLE_LOCATION` SQL statement to use `castle_id` instead of `id` as the key for updating records in the `castle_coordinates` table.