### PR TITLE
Usar .pos y corregir posición del texto flotante de facción

### DIFF
--- a/Codigo/Modulo_UsUaRiOs.bas
+++ b/Codigo/Modulo_UsUaRiOs.bas
@@ -1973,8 +1973,8 @@ Sub HandleFactionScoreForKill(ByVal UserIndex As Integer, ByVal TargetIndex As I
             Call PenalizeFactionScoreLegionAndCouncil(UserIndex, TargetIndex)
         Else
             'Mantener comportamiento original
-            Call WriteTextOverTile(UserIndex, "+" & max(Score, 0), UserList(TargetIndex).pos.x, UserList(TargetIndex).pos.y, FontTypeToColor(GetFontTypeByFactionStatus(.Faccion.Status)))
             Call WriteLocaleMsg(UserIndex, MSG_FACTION_POINTS_GAINED, GetFontTypeByFactionStatus(.Faccion.Status), max(Score, 0) & "¬" & UserList(TargetIndex).Name)
+            Call WriteTextOverTile(UserIndex, "+" & max(Score, 0), .pos.x, .pos.y, FontTypeToColor(GetFontTypeByFactionStatus(.faccion.Status)))
             .Faccion.FactionScore = .Faccion.FactionScore + max(Score, 0)
         End If
     End With
@@ -1998,8 +1998,8 @@ Sub HandleFactionScoreForAssist(ByVal UserIndex As Integer, ByVal TargetIndex As
             .Faccion.FactionScore = newScore
         Else
             'Mantener comportamiento original
-            Call WriteTextOverTile(UserIndex, "+" & max(Score, 0), UserList(TargetIndex).pos.x, UserList(TargetIndex).pos.y, FontTypeToColor(GetFontTypeByFactionStatus(.Faccion.Status)))
             Call WriteLocaleMsg(UserIndex, MSG_FACTION_POINTS_GAINED, GetFontTypeByFactionStatus(.Faccion.Status), max(Score, 0) & "¬" & UserList(TargetIndex).Name)
+            Call WriteTextOverTile(UserIndex, "+" & max(Score, 0), .pos.x, .pos.y, FontTypeToColor(GetFontTypeByFactionStatus(.faccion.Status)))
             .Faccion.FactionScore = .Faccion.FactionScore + max(Score, 0)
         End If
     End With
@@ -2027,7 +2027,7 @@ Sub PenalizeFactionScoreLegionAndCouncil(ByVal Attacker As Integer, ByVal Target
         newScore = .Faccion.FactionScore + Score
         If newScore < 0 Then newScore = 0
         .Faccion.FactionScore = newScore
-        Call WriteTextOverTile(Attacker, CStr(Score), UserList(Target).pos.x, UserList(Target).pos.y, FontTypeToColor(GetFontTypeByFactionStatus(.Faccion.Status)))
+        Call WriteTextOverTile(Attacker, CStr(Score), .pos.x, .pos.y, FontTypeToColor(GetFontTypeByFactionStatus(.faccion.Status)))
     End With
     Exit Sub
 PenalizeFactionScoreLegionAndCouncil_Err:


### PR DESCRIPTION
Se reemplazan las referencias explícitas a UserList(TargetIndex).pos.x/y (o UserList(Target).pos.x/y) por .pos.x/.pos.y del propio bloque With de cada función, para que el texto flotante ("+N"/"-N" puntos de facción) se dibuje sobre el atacante —quien recibe el puntaje— en vez de sobre la víctima.

Bug que corrige: WriteTextOverTile usaba la posición de la víctima como coordenada del texto. Como esa función envía el paquete únicamente a la conexión del atacante (SendTarget.ToIndex), el cliente nunca mostraba nada visible en pantalla si la posición enviada no coincidía con dónde el atacante esperaba ver el texto (sobre sí mismo), a diferencia del patrón ya usado y funcional en GetExpForUser para el "+puntos de experiencia".

Funciones afectadas: HandleFactionScoreForKill, HandleFactionScoreForAssist, PenalizeFactionScoreLegionAndCouncil.