### PR TITLE
Restaurar borrado de item del inventario

### DIFF
--- a/Codigo/Protocol.bas
+++ b/Codigo/Protocol.bas
@@ -7917,15 +7917,45 @@ End Sub
 
 Private Sub HandleDeleteItem(ByVal UserIndex As Integer)
     On Error GoTo HandleDeleteItem_Err:
-    
     Dim isSkin As Boolean
     Dim Slot As Byte
     isSkin = reader.ReadBool
     Slot = reader.ReadInt8()
-    
-    Call WriteConsoleMsg(UserIndex, "Funcion deshabilitada momentaneamente / Function disabled temporarily.", e_FontTypeNames.FONTTYPE_INFO)
+
+    With UserList(UserIndex)
+
+        If Not isSkin Then
+            If Slot > getMaxInventorySlots(UserIndex) Or Slot <= 0 Then Exit Sub
+            If MapInfo(.pos.Map).Seguro = 0 Or EsMapaEvento(.pos.Map) Then
+                'Msg1285= Solo puedes eliminar items en zona segura.
+                Call WriteLocaleMsg(UserIndex, MSG_SOLO_PUEDES_ELIMINAR_ITEMS_ZONA_SEGURA, e_FontTypeNames.FONTTYPE_INFO)
+                Exit Sub
+            End If
+            If .flags.Muerto = 1 Then
+                'Msg1286= No puede eliminar items cuando estas muerto.
+                Call WriteLocaleMsg(UserIndex, MSG_NO_PUEDE_ELIMINAR_ITEMS_CUANDO_MUERTO, e_FontTypeNames.FONTTYPE_INFO)
+                Exit Sub
+            End If
+            If .invent.Object(Slot).Equipped = 0 Then
+                .invent.Object(Slot).amount = 0
+                .invent.Object(Slot).Equipped = 0
+                .invent.Object(Slot).ObjIndex = 0
+                Call UpdateUserInv(False, UserIndex, Slot)
+                'Msg1287= Objeto eliminado correctamente.
+                Call WriteLocaleMsg(UserIndex, MSG_OBJETO_ELIMINADO_CORRECTAMENTE, e_FontTypeNames.FONTTYPE_INFO)
+            Else
+                'Msg1288= No puedes eliminar un objeto estando equipado.
+                Call WriteLocaleMsg(UserIndex, MSG_NO_PUEDES_ELIMINAR_OBJETO_ESTANDO_EQUIPADO, e_FontTypeNames.FONTTYPE_INFO)
+                Exit Sub
+            End If
+        Else
+            Call WriteLocaleMsg(UserIndex, "Funcion deshabilitada momentaneamente / Function disabled temporarily.", e_FontTypeNames.FONTTYPE_INFO)
+            Exit Sub
+        End If
+    End With
+
     Exit Sub
-    
+
 HandleDeleteItem_Err:
     Call TraceError(Err.Number, Err.Description, "Protocol.HandleDeleteItem", Erl)
 End Sub


### PR DESCRIPTION
Reemplaza el handler que estaba deshabilitado por el flujo completo de HandleDeleteItem. Se restaura la lógica tal cual estaba antes, sin modificar el comportamiento original.

Lee isSkin y Slot del paquete. Si isSkin es false, valida slot, zona segura (no en mapa de evento), que el usuario no este muerto y que el item no este equipado. Si pasa las validaciones, limpia el slot, actualiza el inventario y confirma con un mensaje al usuario. Si algo falla, informa por que no se pudo borrar.

El borrado de skins sigue deshabilitado con el mismo mensaje de siempre.