### PR TITLE
Avisar al jugador cuando no tiene herramienta equipada.

### DIFF
--- a/Codigo/Trabajo.bas
+++ b/Codigo/Trabajo.bas
@@ -969,7 +969,11 @@ Public Sub AlquimistaConstruirItem(ByVal UserIndex As Integer, ByVal ItemIndex A
     ' Check if the equipped tool index is valid
     Dim ToolIndex As Integer
     ToolIndex = UserList(UserIndex).invent.EquippedWorkingToolObjIndex
-    If ToolIndex < LBound(ObjData) Or ToolIndex > UBound(ObjData) Then
+    If ToolIndex = 0 Then
+        'Msg376=Antes de usar la herramienta deberías equipártela.
+        Call WriteLocaleMsg(UserIndex, MSG_MUST_EQUIP_TOOL_FIRST, e_FontTypeNames.FONTTYPE_INFO)
+        Exit Sub
+    ElseIf ToolIndex < LBound(ObjData) Or ToolIndex > UBound(ObjData) Then
         Call TraceError(1003, "EquippedWorkingToolObjIndex out of range: " & ToolIndex, "AlquimistaConstruirItem", Erl)
         Exit Sub
     End If


### PR DESCRIPTION
Agrega una validación temprana en AlquimistaConstruirItem (Codigo/Trabajo.bas) para manejar el caso ToolIndex = 0: envía un mensaje localizado (MSG_MUST_EQUIP_TOOL_FIRST) y sale de la Sub. Mantiene el comportamiento existente de TraceError para valores de ToolIndex realmente fuera de rango. Mejora el feedback al usuario y evita traces de error innecesarios cuando simplemente no hay herramienta equipada.

Este fix surge de un log de producción (Error 1003 - EquippedWorkingToolObjIndex out of range: 0, Event ID 783815) que indicaba que el caso "sin herramienta equipada" estaba siendo tratado como un error de rango genuino.