### PR TITLE
Fix wrap-safe 32-bit tick arithmetic

### DIFF
--- a/Codigo/Tests/Unit_ElapsedTime.bas
+++ b/Codigo/Tests/Unit_ElapsedTime.bas
@@ -9,14 +9,22 @@ Option Explicit
 ' ==========================================================================
 Public Function test_suite_elapsed_time() As Boolean
     Call UnitTesting.RunTest("test_ticks_elapsed_simple", test_ticks_elapsed_simple())
-    Call UnitTesting.RunTest("test_ticks_elapsed_wrap", test_ticks_elapsed_wrap())
+    Call UnitTesting.RunTest("test_ticks_elapsed_signed_boundary", test_ticks_elapsed_signed_boundary())
+    Call UnitTesting.RunTest("test_ticks_elapsed_true_wrap", test_ticks_elapsed_true_wrap())
+    Call UnitTesting.RunTest("test_ticks_elapsed_direct_subtraction_overflow", test_ticks_elapsed_direct_subtraction_overflow())
     Call UnitTesting.RunTest("test_tick_after_basic", test_tick_after_basic())
+    Call UnitTesting.RunTest("test_tick_after_signed_boundary", test_tick_after_signed_boundary())
+    Call UnitTesting.RunTest("test_tick_after_true_wrap", test_tick_after_true_wrap())
     Call UnitTesting.RunTest("test_pos_mod_positive", test_pos_mod_positive())
     Call UnitTesting.RunTest("test_pos_mod_negative", test_pos_mod_negative())
     Call UnitTesting.RunTest("test_pos_mod_zero_modulus", test_pos_mod_zero_modulus())
     Call UnitTesting.RunTest("test_add_mod32_simple", test_add_mod32_simple())
+    Call UnitTesting.RunTest("test_add_mod32_signed_boundary", test_add_mod32_signed_boundary())
+    Call UnitTesting.RunTest("test_add_mod32_true_wrap", test_add_mod32_true_wrap())
     Call UnitTesting.RunTest("test_deadline_passed_zero", test_deadline_passed_zero())
     Call UnitTesting.RunTest("test_deadline_passed_normal", test_deadline_passed_normal())
+    Call UnitTesting.RunTest("test_deadline_passed_signed_boundary", test_deadline_passed_signed_boundary())
+    Call UnitTesting.RunTest("test_deadline_passed_true_wrap", test_deadline_passed_true_wrap())
     test_suite_elapsed_time = True
 End Function
 
@@ -25,62 +33,86 @@ End Function
 Private Function test_ticks_elapsed_simple() As Boolean
     On Error GoTo Err_Handler
     test_ticks_elapsed_simple = True
-    ' Started at tick 100, now at tick 200: 200 - 100 = 100 elapsed
     If TicksElapsed(100, 200) <> 100 Then test_ticks_elapsed_simple = False: Exit Function
-    ' Started at tick 0, now at tick 1000: 1000 elapsed
     If TicksElapsed(0, 1000) <> 1000 Then test_ticks_elapsed_simple = False: Exit Function
-    ' Same start and current tick: 0 elapsed
     If TicksElapsed(500, 500) <> 0 Then test_ticks_elapsed_simple = False: Exit Function
     Exit Function
 Err_Handler:
     test_ticks_elapsed_simple = False
 End Function
 
-' Verifies TicksElapsed() handles tick counter wrap-around correctly.
-' When current < start (counter overflowed), elapsed should still be positive.
-Private Function test_ticks_elapsed_wrap() As Boolean
+' Crossing &H7FFFFFFF -> &H80000000 is the signed Long representation boundary,
+' not the real modulo-2^32 timer wrap.
+Private Function test_ticks_elapsed_signed_boundary() As Boolean
     On Error GoTo Err_Handler
-    test_ticks_elapsed_wrap = True
-    ' Simulate wrap-around: start was near Long.MaxValue, current is 100
-    ' This happens when GetTickCount overflows past 2^31. Elapsed must still be positive.
-    Dim elapsed As Double
-    elapsed = TicksElapsed(&H7FFFFFFF, 100)
-    If elapsed <= 0 Then test_ticks_elapsed_wrap = False: Exit Function
+    test_ticks_elapsed_signed_boundary = True
+    If TicksElapsed(&H7FFFFFF0, &H80000010) <> 32 Then test_ticks_elapsed_signed_boundary = False: Exit Function
     Exit Function
 Err_Handler:
-    test_ticks_elapsed_wrap = False
+    test_ticks_elapsed_signed_boundary = False
 End Function
 
-' Verifies TickAfter(a, b): True when a >= b, False when a < b.
-' Also checks the edge case where both are 0.
+' Crossing &HFFFFFFFF -> &H00000000 is the real modulo-2^32 timer wrap.
+Private Function test_ticks_elapsed_true_wrap() As Boolean
+    On Error GoTo Err_Handler
+    test_ticks_elapsed_true_wrap = True
+    If TicksElapsed(&HFFFFFFF0, &H10) <> 32 Then test_ticks_elapsed_true_wrap = False: Exit Function
+    Exit Function
+Err_Handler:
+    test_ticks_elapsed_true_wrap = False
+End Function
+
+' Verifies cases where direct signed Long subtraction would overflow before CDbl().
+Private Function test_ticks_elapsed_direct_subtraction_overflow() As Boolean
+    On Error GoTo Err_Handler
+    test_ticks_elapsed_direct_subtraction_overflow = True
+    If TicksElapsed(&H80000010, &H7FFFFFF0) <> 4294967264# Then test_ticks_elapsed_direct_subtraction_overflow = False: Exit Function
+    If TicksElapsed(&H7FFFFFF0, &H80000010) <> 32 Then test_ticks_elapsed_direct_subtraction_overflow = False: Exit Function
+    Exit Function
+Err_Handler:
+    test_ticks_elapsed_direct_subtraction_overflow = False
+End Function
+
+' Verifies TickAfter(a, b): True when a is at-or-after b, False when a is before b.
 Private Function test_tick_after_basic() As Boolean
     On Error GoTo Err_Handler
     test_tick_after_basic = True
-    ' 100 is after 50 (100 >= 50)
     If Not TickAfter(100, 50) Then test_tick_after_basic = False: Exit Function
-    ' 100 is at-or-after 100 (equal counts as "after")
     If Not TickAfter(100, 100) Then test_tick_after_basic = False: Exit Function
-    ' 50 is NOT after 100 (50 < 100)
     If TickAfter(50, 100) Then test_tick_after_basic = False: Exit Function
-    ' 0 is at-or-after 0 (edge case: both zero)
     If Not TickAfter(0, 0) Then test_tick_after_basic = False: Exit Function
     Exit Function
 Err_Handler:
     test_tick_after_basic = False
 End Function
 
+Private Function test_tick_after_signed_boundary() As Boolean
+    On Error GoTo Err_Handler
+    test_tick_after_signed_boundary = True
+    If Not TickAfter(&H80000010, &H7FFFFFF0) Then test_tick_after_signed_boundary = False: Exit Function
+    If TickAfter(&H7FFFFFF0, &H80000010) Then test_tick_after_signed_boundary = False: Exit Function
+    Exit Function
+Err_Handler:
+    test_tick_after_signed_boundary = False
+End Function
+
+Private Function test_tick_after_true_wrap() As Boolean
+    On Error GoTo Err_Handler
+    test_tick_after_true_wrap = True
+    If Not TickAfter(&H10, &HFFFFFFF0) Then test_tick_after_true_wrap = False: Exit Function
+    If TickAfter(&HFFFFFFF0, &H10) Then test_tick_after_true_wrap = False: Exit Function
+    Exit Function
+Err_Handler:
+    test_tick_after_true_wrap = False
+End Function
+
 ' Verifies PosMod() with positive inputs returns the standard remainder.
-' 10 mod 3 = 1, 9 mod 3 = 0, 0 mod 5 = 0, 7 mod 7 = 0.
 Private Function test_pos_mod_positive() As Boolean
     On Error GoTo Err_Handler
     test_pos_mod_positive = True
-    ' 10 / 3 = remainder 1
     If PosMod(10, 3) <> 1 Then test_pos_mod_positive = False: Exit Function
-    ' 9 / 3 = remainder 0 (evenly divisible)
     If PosMod(9, 3) <> 0 Then test_pos_mod_positive = False: Exit Function
-    ' 0 mod anything = 0
     If PosMod(0, 5) <> 0 Then test_pos_mod_positive = False: Exit Function
-    ' 7 mod 7 = 0 (evenly divisible)
     If PosMod(7, 7) <> 0 Then test_pos_mod_positive = False: Exit Function
     Exit Function
 Err_Handler:
@@ -88,15 +120,11 @@ Err_Handler:
 End Function
 
 ' Verifies PosMod() with negative inputs wraps to a positive result.
-' -1 mod 3 = 2, -3 mod 3 = 0, -7 mod 5 = 3.
 Private Function test_pos_mod_negative() As Boolean
     On Error GoTo Err_Handler
     test_pos_mod_negative = True
-    ' -1 mod 3: VB Mod gives -1, but PosMod wraps to 2 (positive result)
     If PosMod(-1, 3) <> 2 Then test_pos_mod_negative = False: Exit Function
-    ' -3 mod 3 = 0 (evenly divisible, even when negative)
     If PosMod(-3, 3) <> 0 Then test_pos_mod_negative = False: Exit Function
-    ' -7 mod 5: VB Mod gives -2, PosMod wraps to 3
     If PosMod(-7, 5) <> 3 Then test_pos_mod_negative = False: Exit Function
     Exit Function
 Err_Handler:
@@ -107,9 +135,7 @@ End Function
 Private Function test_pos_mod_zero_modulus() As Boolean
     On Error GoTo Err_Handler
     test_pos_mod_zero_modulus = True
-    ' Modulus of 0 is undefined; PosMod returns 0 as a safe fallback
     If PosMod(10, 0) <> 0 Then test_pos_mod_zero_modulus = False: Exit Function
-    ' Negative modulus is also invalid; returns 0
     If PosMod(10, -1) <> 0 Then test_pos_mod_zero_modulus = False: Exit Function
     Exit Function
 Err_Handler:
@@ -120,47 +146,76 @@ End Function
 Private Function test_add_mod32_simple() As Boolean
     On Error GoTo Err_Handler
     test_add_mod32_simple = True
-    ' Simple addition: 10 + 20 = 30
     If AddMod32(10, 20) <> 30 Then test_add_mod32_simple = False: Exit Function
-    ' Zero + zero = zero
     If AddMod32(0, 0) <> 0 Then test_add_mod32_simple = False: Exit Function
-    ' Adding zero is identity: 100 + 0 = 100
     If AddMod32(100, 0) <> 100 Then test_add_mod32_simple = False: Exit Function
     Exit Function
 Err_Handler:
     test_add_mod32_simple = False
 End Function
 
+Private Function test_add_mod32_signed_boundary() As Boolean
+    On Error GoTo Err_Handler
+    test_add_mod32_signed_boundary = True
+    If AddMod32(&H7FFFFFF0, &H20) <> &H80000010 Then test_add_mod32_signed_boundary = False: Exit Function
+    Exit Function
+Err_Handler:
+    test_add_mod32_signed_boundary = False
+End Function
+
+Private Function test_add_mod32_true_wrap() As Boolean
+    On Error GoTo Err_Handler
+    test_add_mod32_true_wrap = True
+    If AddMod32(&HFFFFFFF0, &H20) <> &H10 Then test_add_mod32_true_wrap = False: Exit Function
+    If AddMod32(&HFFFFFFFF, 1) <> 0 Then test_add_mod32_true_wrap = False: Exit Function
+    Exit Function
+Err_Handler:
+    test_add_mod32_true_wrap = False
+End Function
+
 ' Verifies DeadlinePassed() treats deadline=0 as "always passed" regardless
-' of the current tick value (even negative).
+' of the current tick value.
 Private Function test_deadline_passed_zero() As Boolean
     On Error GoTo Err_Handler
     test_deadline_passed_zero = True
-    ' A deadline of 0 is treated as "no deadline" / "already passed"
-    ' regardless of what the current tick is
     If Not DeadlinePassed(0, 0) Then test_deadline_passed_zero = False: Exit Function
     If Not DeadlinePassed(100, 0) Then test_deadline_passed_zero = False: Exit Function
-    ' Even a negative tick still counts as passed when deadline is 0
     If Not DeadlinePassed(-1, 0) Then test_deadline_passed_zero = False: Exit Function
     Exit Function
 Err_Handler:
     test_deadline_passed_zero = False
 End Function
 
-' Verifies DeadlinePassed() for normal cases: now >= deadline means passed,
-' now < deadline means not passed.
+' Verifies DeadlinePassed() for normal cases: now at-or-after deadline means passed.
 Private Function test_deadline_passed_normal() As Boolean
     On Error GoTo Err_Handler
     test_deadline_passed_normal = True
-    ' now=100, deadline=50: we're past the deadline
     If Not DeadlinePassed(100, 50) Then test_deadline_passed_normal = False: Exit Function
-    ' now=100, deadline=100: exactly at the deadline counts as passed
     If Not DeadlinePassed(100, 100) Then test_deadline_passed_normal = False: Exit Function
-    ' now=50, deadline=100: we haven't reached the deadline yet
     If DeadlinePassed(50, 100) Then test_deadline_passed_normal = False: Exit Function
     Exit Function
 Err_Handler:
     test_deadline_passed_normal = False
+End Function
+
+Private Function test_deadline_passed_signed_boundary() As Boolean
+    On Error GoTo Err_Handler
+    test_deadline_passed_signed_boundary = True
+    If Not DeadlinePassed(&H80000010, &H7FFFFFF0) Then test_deadline_passed_signed_boundary = False: Exit Function
+    If DeadlinePassed(&H7FFFFFF0, &H80000010) Then test_deadline_passed_signed_boundary = False: Exit Function
+    Exit Function
+Err_Handler:
+    test_deadline_passed_signed_boundary = False
+End Function
+
+Private Function test_deadline_passed_true_wrap() As Boolean
+    On Error GoTo Err_Handler
+    test_deadline_passed_true_wrap = True
+    If Not DeadlinePassed(&H10, &HFFFFFFF0) Then test_deadline_passed_true_wrap = False: Exit Function
+    If DeadlinePassed(&HFFFFFFF0, &H10) Then test_deadline_passed_true_wrap = False: Exit Function
+    Exit Function
+Err_Handler:
+    test_deadline_passed_true_wrap = False
 End Function
 
 #End If

--- a/Codigo/modElapsedTime.bas
+++ b/Codigo/modElapsedTime.bas
@@ -28,11 +28,16 @@ Option Explicit
 ' Why NOT to use masked GetTickCount() for timing
 ' ============================================
 '
-' Windows timeGetTime() returns a 32-bit unsigned millisecond counter:
-'   Range: 0 .. 4,294,967,295 (2^32 - 1)
-'   Wrap period: ~49.7 days
+' Windows timeGetTime() returns a modulo-2^32 millisecond counter.
+' VB6 stores that bit pattern in a signed Long:
+'   &H7FFFFFFF =  2147483647
+'   &H80000000 = -2147483648
+'   &HFFFFFFFF =          -1
 '
-' Our legacy wrapper applied a mask:
+' Crossing &H7FFFFFFF -> &H80000000 only changes the signed representation.
+' The real timer wrap is &HFFFFFFFF -> &H00000000 after ~49.7 days.
+'
+' Our older wrapper applied a mask:
 '   GetTickCount = timeGetTime() And &H7FFFFFFF
 '
 ' That forces the high (sign) bit to 0, so the value is always >= 0.
@@ -43,22 +48,20 @@ Option Explicit
 ' The problem: code that does naive subtraction across a wrap breaks.
 '
 ' Example:
-'   start = 2,147,482,647   ' (2^31 - 1000), just before wrap
-'   now   = 500             ' just after wrap
+'   start = 2,147,482,647   ' (2^31 - 1000), just before masked wrap
+'   now   = 500             ' just after masked wrap
 '
 '   naive = now - start     ' 500 - 2,147,482,647 = -2,147,482,147
 '   If naive > delay Then   ' always False (negative), even though 500 ms passed
 '
-' This means timers, respawns, cooldowns, etc. can "stall" for ~24.9 days
-' after a wrap if they rely on (now - start > delay).
-'
 ' Correct approach:
-'   - Use the full unmasked tick: GetTickCountRaw() (0..2^32-1)
+'   - Use the full unmasked tick: GetTickCountRaw()
+'   - Convert signed Long bit patterns to unsigned Double before arithmetic
 '   - Compute elapsed with wrap-safe math: TicksElapsed(start, now)
 '   - Or compare deadlines with unsigned logic: TickAfter(now, deadline)
 '
-' This ensures timers keep working correctly across the natural wrap of the
-' Windows tick counter.
+' Double exactly represents every 32-bit integer, so it is safe as a temporary
+' unsigned-32 arithmetic representation.
 '
 '
 '
@@ -72,7 +75,7 @@ Option Explicit
 '       start = GetTickCount()
 '       If GetTickCount() - start > delay Then ...
 '
-'   This breaks across the 2^31 wrap (~24.9 days). The subtraction
+'   This breaks across the 2^31 masked wrap (~24.9 days). The subtraction
 '   goes negative and the timer stalls.
 '
 ' Correct usage with wrap-safe helpers:
@@ -116,15 +119,16 @@ Option Explicit
 '       Do While Not TickAfter(GetTickCountRaw(), wakeAt): DoEvents: Loop
 '
 ' Helpers provided by this module:
-'   - GetTickCountRaw()  : unmasked 2^32 tick counter
+'   - GetTickCountRaw()  : raw modulo-2^32 tick counter bit pattern
 '   - TicksElapsed()     : wrap-safe elapsed (ms)
-'   - TickAfter()        : wrap-safe "is A after B?" compare
+'   - TickAfter()        : wrap-safe "is A at-or-after B?" compare
 '   - AddMod32()         : add with wrap (for deadlines/intervals)
 '   - PosMod()           : normalize to positive range
 '
 ' ==============================================================
 Private Declare Function timeGetTime Lib "winmm.dll" () As Long
 Private Const TICKS32 As Double = 4294967296#
+Private Const HALF_TICKS32 As Double = 2147483648#
 
 ' New raw version (preferred)
 Public Function GetTickCountRaw() As Long
@@ -133,15 +137,17 @@ Public Function GetTickCountRaw() As Long
 End Function
 
 Public Function TicksElapsed(ByVal startTick As Long, ByVal currentTick As Long) As Double
-    If currentTick >= startTick Then
-        TicksElapsed = CDbl(currentTick - startTick)
-    Else
-        TicksElapsed = (TICKS32 - CDbl(startTick)) + CDbl(currentTick)
-    End If
+    Dim elapsed As Double
+
+    elapsed = Unsigned32FromLong(currentTick) - Unsigned32FromLong(startTick)
+    If elapsed < 0# Then elapsed = elapsed + TICKS32
+
+    TicksElapsed = elapsed
 End Function
 
 Public Function TickAfter(ByVal a As Long, ByVal b As Long) As Boolean
-    TickAfter = (a - b) >= 0
+    ' Modular timestamp ordering is only unambiguous for intervals under 2^31 ms.
+    TickAfter = (TicksElapsed(b, a) < HALF_TICKS32)
 End Function
 
 Public Function PosMod(ByVal a As Double, ByVal m As Long) As Long
@@ -155,11 +161,10 @@ End Function
 
 ' Add two tick values modulo 2^32 (wrap-safe)
 Public Function AddMod32(ByVal a As Long, ByVal b As Long) As Long
-    Dim s As Double
-    s = CDbl(a And &HFFFFFFFF) + CDbl(b And &HFFFFFFFF)
-    ' reduce modulo 2^32
-    s = s - TICKS32 * Fix(s / TICKS32)
-    AddMod32 = CLng(s)
+    Dim sum As Double
+
+    sum = NormalizeUnsigned32(Unsigned32FromLong(a) + Unsigned32FromLong(b))
+    AddMod32 = LongFromUnsigned32(sum)
 End Function
 
 ' ==============================================================
@@ -169,26 +174,12 @@ End Function
 '
 ' Why not just use TickAfter(now, deadline)?
 ' ------------------------------------------
-' The standard trick:
-'     TickAfter = (now - deadline) >= 0
-' works correctly on a modulo-2^32 tick ring as long as the
-' unsigned distance between "now" and "deadline" is < 2^31.
+' The comparison itself is handled by TickAfter(). DeadlinePassed() only adds
+' the server's legacy sentinel rule: deadline=0 means "no active future
+' deadline", so it is always treated as already passed.
 '
-' But in our stun/cooldown code, we sometimes store StunEndTime=0
-' to mean "no stun / unset".
-'
-' Problem:
-'   If deadline=0 and now has the high bit set
-'   (e.g. nowRaw = &H86F0E019 = -2031327897 signed),
-'   then (now - 0) is negative in signed math.
-'   TickAfter() returns False ? interpreted as "deadline not passed"
-'   ? player/NPC is treated as still stunned.
-'
-' In reality, a deadline of 0 should always mean "already expired".
-'
-' Fix:
-'   Special-case deadline=0 as always passed.
-'   Otherwise fall back to the wrap-safe TickAfter compare.
+' Without that sentinel case, a stored zero deadline would become ambiguous
+' once real raw ticks legitimately pass through the high signed Long bit.
 '
 ' Usage:
 '   If DeadlinePassed(GetTickCountRaw(), counters.StunEndTime) Then ...
@@ -198,6 +189,29 @@ Public Function DeadlinePassed(ByVal nowRaw As Long, ByVal deadline As Long) As 
     If deadline = 0 Then
         DeadlinePassed = True        ' treat 0 as "no deadline"
     Else
-        DeadlinePassed = (nowRaw - deadline) >= 0   ' wrap-safe TickAfter
+        DeadlinePassed = TickAfter(nowRaw, deadline)
     End If
+End Function
+
+Private Function Unsigned32FromLong(ByVal value As Long) As Double
+    If value < 0 Then
+        Unsigned32FromLong = CDbl(value) + TICKS32
+    Else
+        Unsigned32FromLong = CDbl(value)
+    End If
+End Function
+
+Private Function LongFromUnsigned32(ByVal value As Double) As Long
+    If value >= HALF_TICKS32 Then
+        LongFromUnsigned32 = CLng(value - TICKS32)
+    Else
+        LongFromUnsigned32 = CLng(value)
+    End If
+End Function
+
+Private Function NormalizeUnsigned32(ByVal value As Double) As Double
+    value = value - TICKS32 * Fix(value / TICKS32)
+    If value < 0# Then value = value + TICKS32
+
+    NormalizeUnsigned32 = value
 End Function


### PR DESCRIPTION
## Summary
- fix wrap-safe unsigned 32-bit tick arithmetic in modElapsedTime
- prevent VB6 Long overflow when crossing the signed representation boundary
- add exact regression coverage for signed-boundary and true modulo wrap behavior

## Validation
- VB6 unit-test build: passed
- Unit tests: 279 passed, 0 failed
- Normal VB6 server build: passed

## Notes
- Commit author and committer are DudeNoland.
- Existing unrelated Server.VBP local changes were not included.