### PR TITLE
Omitir efectos secundarios no positivos.

### DIFF
--- a/Codigo/ApplyEffectOnParty.cls
+++ b/Codigo/ApplyEffectOnParty.cls
@@ -274,6 +274,7 @@ Private Sub ApplyEffectTo(ByVal TargetId As Integer, ByVal TargetType As e_Refer
         EffectIdToApply = ApplyEffectId
     Else
         EffectIdToApply = SecondaryEffect
+        If EffectIdToApply <= 0 Then Exit Sub
     End If
     If TargetType = eUser Then
         If UserList(TargetId).Stats.MinHp > 0 Then


### PR DESCRIPTION
Agrega un guard en ApplyEffectOnParty.cls para salir temprano cuando el SecondaryEffect elegido es cero o negativo. Esto evita intentos de aplicar IDs de efecto inválidos (<= 0) en la rama ApplyEffectTo, evitando errores de runtime o comportamiento no intencionado.

Sin este guard, cualquier .dat que use SecondaryEffectId=0 va a crashear el servidor apenas otro miembro del grupo entre en el área del efecto.