### PR TITLE
Allow character creation city selection

### DIFF
--- a/Codigo/Hogar.bas
+++ b/Codigo/Hogar.bas
@@ -45,6 +45,15 @@ Public Function IsValidCity(ByVal CityId As e_City) As Boolean
     End With
 End Function
 
+Public Function IsValidCharacterCreationCity(ByVal CityId As e_City) As Boolean
+    If Not IsValidCity(CityId) Then Exit Function
+
+    Select Case CityId
+        Case cUllathorpe, cNix, cArghal, cForgat, cEldoria, cPenthar, cMorgrim
+            IsValidCharacterCreationCity = True
+    End Select
+End Function
+
 Public Sub goHome(ByVal UserIndex As Integer)
     On Error GoTo goHome_Err
     With UserList(UserIndex)

--- a/Codigo/TCP.bas
+++ b/Codigo/TCP.bas
@@ -463,7 +463,7 @@ Function ConnectNewUser(ByVal UserIndex As Integer, _
         ' Género válido
         If UserSexo < Hombre Or UserSexo > Mujer Then Exit Function
         ' Ciudad válida
-        If Hogar <= 0 Or Hogar > CITY_COUNT Then Exit Function
+        If Not IsValidCharacterCreationCity(Hogar) Then Exit Function
         ' Cabeza válida
 #If LOGIN_STRESS_TEST = 0 Then
         If Not ValidarCabeza(UserRaza, UserSexo, head) Then Exit Function
@@ -491,7 +491,7 @@ Function ConnectNewUser(ByVal UserIndex As Integer, _
         .raza = UserRaza
         .Char.head = head
         .genero = UserSexo
-        .Hogar = cForgat
+        .Hogar = Hogar
         '%%%%%%%%%%%%% PREVENIR HACKEO DE LOS SKILLS %%%%%%%%%%%%%
         .Stats.SkillPts = 10
         .Char.Heading = e_Heading.SOUTH


### PR DESCRIPTION
Add city validation for character creation and respect player's city choice. Previously, all new characters were hardcoded to start in Forgat regardless of their selection. Now validates that the selected city is in the approved list (Ullathorpe, Nix, Arghal, Forgat, Eldoria, Penthar, Morgrim) and assigns players to their chosen city.