### PR TITLE
Fix wrap-safe GlobalFrameTime arithmetic

### DIFF
--- a/Codigo/AI_NPC.bas
+++ b/Codigo/AI_NPC.bas
@@ -1385,7 +1385,7 @@ UsuarioAtacableConMelee_Err:
 End Function
 
 Private Function CanCastSpell(ByRef Npc As t_Npc, ByVal Slot As Integer) As Boolean
-    CanCastSpell = GlobalFrameTime - Npc.Spells(Slot).lastUse > (Npc.Spells(Slot).Cd * 1000)
+    CanCastSpell = TicksElapsed(Npc.Spells(Slot).lastUse, GlobalFrameTime) > (Npc.Spells(Slot).Cd * 1000)
 End Function
 
 Public Function GetAvailableSpellEffects(ByVal NpcIndex As Integer) As Long

--- a/Codigo/GameLogic.bas
+++ b/Codigo/GameLogic.bas
@@ -2085,7 +2085,7 @@ Public Function PrepareStatusMsgsForNpcs(ByVal TargetNpcIndex As Integer, ByVal 
         If GetOwnedBy(TargetNpcIndex) <> 0 Then
             Call SetMask(NpcStatusMask, e_NpcInfoMask.Fighting)
             extraStrings = extraStrings & .flags.AttackedBy & "|"
-            extraStrings = extraStrings & CLng((IntervaloNpcOwner - (GlobalFrameTime - .flags.AttackedTime)) / 1000) & "-"
+            extraStrings = extraStrings & CLng((IntervaloNpcOwner - (TicksElapsed(.flags.AttackedTime, GlobalFrameTime))) / 1000) & "-"
         Else
             extraStrings = extraStrings & "-"
         End If

--- a/Codigo/MODULO_NPCs.bas
+++ b/Codigo/MODULO_NPCs.bas
@@ -2416,7 +2416,7 @@ End Function
 
 Public Function CanPerformAttackAction(ByVal NpcIndex As Integer, ByVal AttackInterval As Long)
     With NpcList(NpcIndex)
-        CanPerformAttackAction = GlobalFrameTime - .Contadores.IntervaloLanzarHechizo > AttackInterval And GlobalFrameTime - .Contadores.IntervaloAtaque > AttackInterval
+        CanPerformAttackAction = TicksElapsed(.Contadores.IntervaloLanzarHechizo, GlobalFrameTime) > AttackInterval And TicksElapsed(.Contadores.IntervaloAtaque, GlobalFrameTime) > AttackInterval
     End With
 End Function
 
@@ -2447,7 +2447,7 @@ Public Function GetOwnedBy(ByVal NpcIndex As Integer) As Integer
     GetOwnedBy = 0
     With NpcList(NpcIndex).flags
         If .AttackedBy = vbNullString Then Exit Function
-        If GlobalFrameTime - .AttackedTime > IntervaloNpcOwner Then Exit Function
+        If TicksElapsed(.AttackedTime, GlobalFrameTime) > IntervaloNpcOwner Then Exit Function
         Dim Attacker As t_UserReference: Attacker = NameIndex(.AttackedBy)
         If Not IsValidUserRef(Attacker) Then Exit Function
         GetOwnedBy = Attacker.ArrayIndex

--- a/Codigo/ModLobby.bas
+++ b/Codigo/ModLobby.bas
@@ -597,7 +597,7 @@ End Function
 Public Function WaitForPlayersTimeUp(ByRef instance As t_Lobby) As Boolean
     'global events waiting time is handled by game masters
     If instance.IsGlobal Then Exit Function
-    WaitForPlayersTimeUp = GlobalFrameTime - instance.MapOpenTime > WaitingForPlayersTime
+    WaitForPlayersTimeUp = TicksElapsed(instance.MapOpenTime, GlobalFrameTime) > WaitingForPlayersTime
 End Function
 
 Public Sub UpdateWaitingForPlayers(ByVal frametime As Long, ByRef instance As t_Lobby)
@@ -611,7 +611,7 @@ Public Sub UpdateWaitingForPlayers(ByVal frametime As Long, ByRef instance As t_
                     If IsValidUserRef(instance.Players(i).User) Then
                         Dim Seconds As Long
                         Dim Minutes As Long
-                        Seconds = (WaitingForPlayersTime - (GlobalFrameTime - instance.MapOpenTime)) / 1000
+                        Seconds = (WaitingForPlayersTime - (TicksElapsed(instance.MapOpenTime, GlobalFrameTime))) / 1000
                         Minutes = Seconds / 60
                         Seconds = Seconds - (Minutes * 60)
                         Call SendData(SendTarget.ToIndex, instance.Players(i).User.ArrayIndex, PrepareMessageLocaleMsg(MSG_ESPERANDO_JUGADORES_PARTIDA_INICIARA_CUANDO_LLENE_SALA, GetTimeString(Minutes, Seconds), _

--- a/Codigo/Modulo_UsUaRiOs.bas
+++ b/Codigo/Modulo_UsUaRiOs.bas
@@ -1882,7 +1882,7 @@ Public Function AlreadyKilledBy(ByVal TargetIndex As Integer, ByVal killerIndex 
         TargetPos = Min(.flags.LastKillerIndex, MaxRecentKillToStore)
         Dim i As Integer
         For i = 0 To TargetPos
-            If .flags.RecentKillers(i).UserId = UserList(killerIndex).Id And (GlobalFrameTime - .flags.RecentKillers(i).KillTime) < FactionReKillTime Then
+            If .flags.RecentKillers(i).UserId = UserList(killerIndex).Id And (TicksElapsed(.flags.RecentKillers(i).KillTime, GlobalFrameTime)) < FactionReKillTime Then
                 AlreadyKilledBy = True
                 Exit Function
             End If
@@ -1968,13 +1968,13 @@ Sub HandleFactionScoreForKill(ByVal UserIndex As Integer, ByVal TargetIndex As I
         If Score > 20 Then
             Score = 20
         End If
-        If GlobalFrameTime - .flags.LastHelpByTime < AssistHelpValidTime Then
+        If TicksElapsed(.flags.LastHelpByTime, GlobalFrameTime) < AssistHelpValidTime Then
             If IsValidUserRef(.flags.LastHelpUser) And .flags.LastHelpUser.ArrayIndex <> UserIndex Then
                 Score = Score - 1
                 Call HandleFactionScoreForAssist(.flags.LastHelpUser.ArrayIndex, TargetIndex)
             End If
         End If
-        If GlobalFrameTime - UserList(TargetIndex).flags.LastAttackedByUserTime < AssistDamageValidTime Then
+        If TicksElapsed(UserList(TargetIndex).flags.LastAttackedByUserTime, GlobalFrameTime) < AssistDamageValidTime Then
             If IsValidUserRef(UserList(TargetIndex).flags.LastAttacker) And UserList(TargetIndex).flags.LastAttacker.ArrayIndex <> UserIndex Then
                 Score = Score - 1
                 Call HandleFactionScoreForAssist(UserList(TargetIndex).flags.LastAttacker.ArrayIndex, TargetIndex)

--- a/Codigo/ScenarioDeathMatch.cls
+++ b/Codigo/ScenarioDeathMatch.cls
@@ -407,7 +407,7 @@ Public Sub IBaseScenario_PlayerKillPlayer(ByVal killerIndex As Integer, ByVal de
             Call SendData(SendTarget.toMap, MapNumber, PrepareMessageLocaleMsg(MSG_TENEMOS_GANADOR_1889, vbNullString, e_FontTypeNames.FONTTYPE_GUILD)) 'Msg1889=¡Tenemos un ganador!
             Call MatchCompleted
         End If
-        If GlobalFrameTime - UserList(deadIndex).flags.LastAttackedByUserTime < AssistDamageValidTime Then
+        If TicksElapsed(UserList(deadIndex).flags.LastAttackedByUserTime, GlobalFrameTime) < AssistDamageValidTime Then
             If IsValidUserRef(UserList(deadIndex).flags.LastAttacker) And UserList(deadIndex).flags.LastAttacker.ArrayIndex <> killerIndex Then
                 If Board.UpdatePlayerScore(UserList(deadIndex).flags.LastAttacker.ArrayIndex, 1) >= TargetScore Then
                     Call SendData(SendTarget.toMap, MapNumber, PrepareMessageLocaleMsg(MSG_TENEMOS_GANADOR_1889, vbNullString, e_FontTypeNames.FONTTYPE_GUILD)) 'Msg1889=¡Tenemos un ganador!


### PR DESCRIPTION
Replace the remaining direct elapsed-time arithmetic that subtracts raw GlobalFrameTime tick values from stored gameplay timestamps.

GlobalFrameTime intentionally stores the raw timeGetTime bit pattern in a signed VB6 Long. Direct expressions such as GlobalFrameTime - previousTick can overflow when the signed representation crosses &H7FFFFFFF -> &H80000000, even though only a small amount of modulo-2^32 time has elapsed.

Use the already merged TicksElapsed helper at each audited gameplay call site so elapsed-time comparisons remain wrap-safe while preserving existing timing semantics exactly:

- keep GlobalFrameTime as Long
- keep raw timestamp assignments unchanged
- preserve every comparison operator and timeout value
- preserve lobby, spell cooldown, assist, kill-window, attack cooldown, and NPC ownership behavior

Fixed call sites include:

- NPC spell cooldown checks
- lobby wait timeout and countdown display
- recent faction kill suppression
- help and damage assist validity windows
- deathmatch assist validity
- NPC attack action cooldown checks
- NPC ownership timeout and remaining-time display

Validation:

- built VB6 server with UNIT_TEST=1
- ran unit tests: 279 / 279 passed
- built normal server configuration
- verified no remaining direct GlobalFrameTime +/- arithmetic