### PR TITLE
Agregar sistema configurable de equipamiento inicial

### DIFF
--- a/Codigo/General.bas
+++ b/Codigo/General.bas
@@ -557,6 +557,8 @@ Sub Main()
     '*************************************************
     frmCargando.Label1(2).Caption = "Cargando Obj.Dat"
     Call LoadOBJData
+    frmCargando.Label1(2).Caption = "Cargando Equipamiento Inicial"
+    Call CargarEquipamientoInicial
     frmCargando.Label1(2).Caption = "Cargando Hechizos.Dat"
     Call CargarHechizos
     frmCargando.Label1(2).Caption = "Cargando EffectsOverTime.Dat"

--- a/Codigo/TCP.bas
+++ b/Codigo/TCP.bas
@@ -27,6 +27,22 @@ Attribute VB_Name = "TCP"
 '
 Option Explicit
 
+Private Type t_InitialEquipItem
+    ObjIndex As Integer
+    Amount As Long
+    Equip As Byte
+End Type
+
+Private Type t_InitialEquipSet
+    Items() As t_InitialEquipItem
+    NumItems As Integer
+    Spells() As Integer
+    NumSpells As Integer
+End Type
+
+Private EquipoInicialComun As t_InitialEquipSet
+Private EquipoInicialClase() As t_InitialEquipSet
+
 Sub DarCuerpo(ByVal UserIndex As Integer)
     On Error GoTo DarCuerpo_Err
     '*************************************************
@@ -81,271 +97,16 @@ Sub RellenarInventario(ByVal UserIndex As String)
     On Error GoTo RellenarInventario_Err
     With UserList(UserIndex)
         Dim NumItems As Integer
+        Dim i As Integer
         NumItems = 1
-        ' Todos reciben pociones rojas
-        .invent.Object(NumItems).ObjIndex = 4335 'Pocion Roja
-        .invent.Object(NumItems).amount = 500
-        NumItems = NumItems + 1
-        ' Magicas puras reciben más azules
-        Select Case .clase
-            Case e_Class.Mage, e_Class.Druid
-                .invent.Object(NumItems).ObjIndex = 4336 ' Pocion Azul
-                .invent.Object(NumItems).amount = 850
-                NumItems = NumItems + 1
-            Case e_Class.Bard, e_Class.Cleric
-                .invent.Object(NumItems).ObjIndex = 4336 ' Pocion Azul
-                .invent.Object(NumItems).amount = 650
-                NumItems = NumItems + 1
-            Case e_Class.Paladin, e_Class.Assasin, e_Class.Bandit
-                .invent.Object(NumItems).ObjIndex = 4336 ' Pocion Azul
-                .invent.Object(NumItems).amount = 450
-                NumItems = NumItems + 1
-        End Select
-        ' Hechizos
-        Select Case .clase
-            Case e_Class.Mage, e_Class.Cleric, e_Class.Druid, e_Class.Bard
-                .Stats.UserHechizos(1) = 1 ' Dardo mágico
-                .Stats.UserHechizos(2) = 7 ' Invocar lobo
-            Case e_Class.Paladin, e_Class.Bandit, e_Class.Assasin
-                .Stats.UserHechizos(1) = 291 ' Onda mágica
-                .Stats.UserHechizos(2) = 12 ' Curar heridas leves
-        End Select
-        ' Pociones amarillas y verdes
-        Select Case .clase
-            Case e_Class.Assasin, e_Class.Bard, e_Class.Cleric, e_Class.Hunter, e_Class.Paladin, e_Class.Trabajador, e_Class.Warrior, e_Class.Bandit, e_Class.Pirat, e_Class.Thief
-                .invent.Object(NumItems).ObjIndex = 4337 ' Pocion Amarilla
-                .invent.Object(NumItems).amount = 100
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 4338 ' Pocion Verde
-                .invent.Object(NumItems).amount = 120
-                NumItems = NumItems + 1
-            Case e_Class.Mage, e_Class.Druid
-                .invent.Object(NumItems).ObjIndex = 4337 ' Pocion Amarilla
-                .invent.Object(NumItems).amount = 80
-                NumItems = NumItems + 1
-        End Select
-        ' Poción violeta
-        .invent.Object(NumItems).ObjIndex = 4334 ' Pocion violeta
-        .invent.Object(NumItems).amount = 35
-        NumItems = NumItems + 1
-        .invent.Object(NumItems).ObjIndex = 3791 ' Pasaje a Jourmut
-        .invent.Object(NumItems).amount = 4
-        NumItems = NumItems + 1
-        ' Armas
-        Select Case .clase
-            Case e_Class.Cleric
-                .invent.Object(NumItems).ObjIndex = 3686 ' Daga del Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 3487 ' Espada del Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 3488 ' Escudo de Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 3489 ' Casco de Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 3490 ' Anillo del Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-            Case e_Class.Paladin
-                .invent.Object(NumItems).ObjIndex = 3487 ' Espada del Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 3686 ' Daga del Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 3488 ' Escudo de Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 3489 ' Casco de Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 3490 ' Anillo del Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-            Case e_Class.Hunter
-                .invent.Object(NumItems).ObjIndex = 3686 ' Daga del principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 3491 ' Arco del principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 3492 ' Flecha del Principiante
-                .invent.Object(NumItems).amount = 1050
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 3489  ' Casco de Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 3490 ' Anillo del Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 3488 ' Escudo de Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-            Case e_Class.Trabajador
-                .invent.Object(NumItems).ObjIndex = 3487 ' Espada del Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 3488 ' Escudo de Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 3489 ' Casco de Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 3491 ' Arco del Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 3492 ' Flecha del Principiante
-                .invent.Object(NumItems).amount = 850
-                NumItems = NumItems + 1
-            Case e_Class.Pirat
-                .invent.Object(NumItems).ObjIndex = 3487 ' Espada del Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 3488 ' Escudo de Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 3489 ' Casco de Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 3490 ' Anillo del Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 3497 ' Pistola del Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 3498 ' Balas del Principiante
-                .invent.Object(NumItems).amount = 350
-                NumItems = NumItems + 1
-            Case e_Class.Warrior
-                .invent.Object(NumItems).ObjIndex = 3487 ' Espada del Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 3488 ' Escudo de Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 3489 ' Casco de Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 3490 ' Anillo del Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 3491 ' Arco del Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 3492 ' Flecha del Principiante
-                .invent.Object(NumItems).amount = 650
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 3686 ' Daga del Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-            Case e_Class.Thief
-                .invent.Object(NumItems).ObjIndex = 3686 ' Daga del Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 1353 ' Nudillos del Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 3488 ' Escudo de Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 3489  ' Casco de Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-            Case e_Class.Bandit
-                .invent.Object(NumItems).ObjIndex = 1353 ' Nudillos del Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 3487 ' Espada del Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 3488 ' Escudo de Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 3489 ' Casco de Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 3490 ' Anillo del Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-            Case e_Class.Mage
-                .invent.Object(NumItems).ObjIndex = 3495 ' Bastón del Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 3493 ' Sombrero del Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-            Case e_Class.Assasin
-                .invent.Object(NumItems).ObjIndex = 3686 ' Daga del Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 3488 ' Escudo de Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 3489 ' Casco de Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 3490 ' Anillo del Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 3487 ' Espada del Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-            Case e_Class.Druid
-                .invent.Object(NumItems).ObjIndex = 3487 ' Espada del Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 3494 ' Flauta del Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 1778  'Casco de Lobo (Resistencia Magica 1)
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-            Case e_Class.Bard
-                .invent.Object(NumItems).ObjIndex = 3686 ' Daga del Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 3488 ' Escudo de Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 3489 ' Casco de Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 3490 ' Anillo del Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-                .invent.Object(NumItems).ObjIndex = 3496 ' Laúd del Principiante
-                .invent.Object(NumItems).amount = 1
-                NumItems = NumItems + 1
-        End Select
-        ' Armadura o túnica de principiante
-        Select Case .clase
-                ' Todas menos mago, druida y bardo:
-            Case e_Class.Trabajador, e_Class.Thief, e_Class.Paladin, e_Class.Cleric, e_Class.Assasin, e_Class.Bandit, e_Class.Pirat, e_Class.Warrior, e_Class.Hunter
-                .invent.Object(NumItems).ObjIndex = 3500 ' Armadura de Principiante
-                ' Mago, druida y bardo:
-            Case e_Class.Mage, e_Class.Druid, e_Class.Bard
-                .invent.Object(NumItems).ObjIndex = 3502 ' Túnica del Principiante
-        End Select
-        .invent.Object(NumItems).Equipped = 0
-        Call EquiparInvItem(UserIndex, NumItems)
-        .invent.Object(NumItems).amount = 1
-        .invent.Object(NumItems).Equipped = 1
-        .invent.EquippedArmorSlot = NumItems
-        .invent.EquippedArmorObjIndex = .invent.Object(NumItems).ObjIndex
-        NumItems = NumItems + 1
-        ' Animación según raza
-        .Char.body = ObtenerRopaje(UserIndex, ObjData(.invent.EquippedArmorObjIndex))
-        ' Comida y bebida
-        .invent.Object(NumItems).ObjIndex = 3684 ' Manzana
-        .invent.Object(NumItems).amount = 100
-        NumItems = NumItems + 1
-        .invent.Object(NumItems).ObjIndex = 3685 ' Agua
-        .invent.Object(NumItems).amount = 50
-        NumItems = NumItems + 1
-        ' Seteo la cantidad de items
+        For i = 1 To EquipoInicialComun.NumItems
+            Call AsignarItemInicial(UserIndex, NumItems, EquipoInicialComun.Items(i))
+        Next i
+        For i = 1 To EquipoInicialClase(.clase).NumItems
+            Call AsignarItemInicial(UserIndex, NumItems, EquipoInicialClase(.clase).Items(i))
+        Next i
+        Call AplicarHechizosIniciales(UserIndex, EquipoInicialComun)
+        Call AplicarHechizosIniciales(UserIndex, EquipoInicialClase(.clase))
         .invent.NroItems = NumItems
         .flags.ModificoInventario = True
         .flags.ModificoHechizos = True
@@ -353,6 +114,89 @@ Sub RellenarInventario(ByVal UserIndex As String)
     Exit Sub
 RellenarInventario_Err:
     Call TraceError(Err.Number, Err.Description, "TCP.RellenarInventario", Erl)
+End Sub
+
+Public Sub CargarEquipamientoInicial()
+    On Error GoTo CargarEquipamientoInicial_Err
+    Dim Ini As clsIniManager
+    Set Ini = New clsIniManager
+    Call Ini.Initialize(DatPath & "EquipamientoInicial.dat")
+    Call LoadEquipSet(Ini, "COMMON", EquipoInicialComun)
+    ReDim EquipoInicialClase(1 To NUMCLASES)
+    Dim ClaseId As Integer
+    For ClaseId = 1 To NUMCLASES
+        Call LoadEquipSet(Ini, "CLASS" & CStr(ClaseId), EquipoInicialClase(ClaseId))
+    Next ClaseId
+    Set Ini = Nothing
+    AgregarAConsola "Se carg? el equipamiento inicial (EquipamientoInicial.dat)"
+    Exit Sub
+CargarEquipamientoInicial_Err:
+    Call TraceError(Err.Number, Err.Description, "TCP.CargarEquipamientoInicial", Erl)
+End Sub
+
+Private Sub LoadEquipSet(ByVal Ini As clsIniManager, ByVal SectionName As String, ByRef OutSet As t_InitialEquipSet)
+    On Error GoTo LoadEquipSet_Err
+    Dim NumObjs As Integer
+    Dim NumSpells As Integer
+    Dim i As Integer
+    Dim RawValue As String
+    Dim Parts() As String
+    NumObjs = CInt(Ini.GetValue(SectionName, "NumObjs", "0"))
+    OutSet.NumItems = NumObjs
+    If NumObjs > 0 Then
+        ReDim OutSet.Items(1 To NumObjs)
+        For i = 1 To NumObjs
+            RawValue = Ini.GetValue(SectionName, "Obj" & CStr(i), vbNullString)
+            If LenB(RawValue) = 0 Then
+                Call LogError("EquipamientoInicial.dat: falta Obj" & CStr(i) & " en seccion " & SectionName)
+            Else
+                Parts = Split(RawValue, ",")
+                If UBound(Parts) <> 2 Then
+                    Call LogError("EquipamientoInicial.dat: formato invalido en " & SectionName & ".Obj" & CStr(i))
+                Else
+                    OutSet.Items(i).ObjIndex = CInt(Trim$(Parts(0)))
+                    OutSet.Items(i).Amount = CLng(Trim$(Parts(1)))
+                    OutSet.Items(i).Equip = CByte(Trim$(Parts(2)))
+                End If
+            End If
+        Next i
+    End If
+    NumSpells = CInt(Ini.GetValue(SectionName, "NumSpells", "0"))
+    OutSet.NumSpells = NumSpells
+    If NumSpells > 0 Then
+        ReDim OutSet.Spells(1 To NumSpells)
+        For i = 1 To NumSpells
+            OutSet.Spells(i) = CInt(Ini.GetValue(SectionName, "Spell" & CStr(i), "0"))
+        Next i
+    End If
+    Exit Sub
+LoadEquipSet_Err:
+    Call TraceError(Err.Number, Err.Description & ". Seccion: " & SectionName, "TCP.LoadEquipSet", Erl)
+End Sub
+
+Private Sub AsignarItemInicial(ByVal UserIndex As Integer, ByRef NumItems As Integer, ByRef Item As t_InitialEquipItem)
+    With UserList(UserIndex)
+        .invent.Object(NumItems).ObjIndex = Item.ObjIndex
+        If Item.Equip = 1 Then
+            .invent.Object(NumItems).Equipped = 0
+            Call EquiparInvItem(UserIndex, NumItems)
+            .invent.Object(NumItems).Amount = 1
+            .invent.Object(NumItems).Equipped = 1
+            .invent.EquippedArmorSlot = NumItems
+            .invent.EquippedArmorObjIndex = .invent.Object(NumItems).ObjIndex
+            .Char.body = ObtenerRopaje(UserIndex, ObjData(.invent.EquippedArmorObjIndex))
+        Else
+            .invent.Object(NumItems).Amount = Item.Amount
+        End If
+    End With
+    NumItems = NumItems + 1
+End Sub
+
+Private Sub AplicarHechizosIniciales(ByVal UserIndex As Integer, ByRef EquipSet As t_InitialEquipSet)
+    Dim i As Integer
+    For i = 1 To EquipSet.NumSpells
+        UserList(UserIndex).Stats.UserHechizos(i) = EquipSet.Spells(i)
+    Next i
 End Sub
 
 Function AsciiValidos(ByVal cad As String) As Boolean


### PR DESCRIPTION
## Resumen
Reemplaza el inventario inicial hardcodeado en `RellenarInventario` (TCP.bas) por un sistema data-driven basado en INI (`EquipamientoInicial.dat`), leído con `clsIniManager`.

## Contexto (antes)
`RellenarInventario` tenía toda la asignación de objetos y hechizos iniciales hardcodeada en `Select Case .clase`, con bloques `Case` separados para pociones, armas/accesorios y armadura por cada una de las 12 clases, más otro `Select Case` aparte para los dos hechizos iniciales (`Stats.UserHechizos`). Cualquier cambio de equipo inicial requería tocar código y recompilar.

## Cambios

**TCP.bas**
- Nuevos tipos a nivel de módulo: `t_InitialEquipItem` (ObjIndex, Amount, Equip) y `t_InitialEquipSet` (array de items + array de hechizos).
- Nuevas variables privadas: `EquipoInicialComun` (set común a todas las clases) y `EquipoInicialClase()` (array indexado 1 To NUMCLASES con el set de cada clase).
- Nueva `Public Sub CargarEquipamientoInicial()`: inicializa `clsIniManager` sobre `EquipamientoInicial.dat`, carga la sección `[COMMON]` y las 12 secciones `[CLASSN]` (N = valor numérico de `e_Class`) en memoria una sola vez al boot.
- Nueva `Private Sub LoadEquipSet(...)`: parsea una sección del `.dat` (claves `NumObjs`/`ObjN=ObjIndex,Amount,Equip` y `NumSpells`/`SpellN=HechizoIndex`) hacia un `t_InitialEquipSet`. Loguea con `LogError` si falta una clave esperada o el formato de un `ObjN` no tiene 3 campos.
- Nueva `Private Sub AsignarItemInicial(...)`: agrega un ítem al inventario del usuario; si `Equip=1`, además llama `EquiparInvItem`, fija `EquippedArmorSlot`/`EquippedArmorObjIndex` y actualiza `Char.body` vía `ObtenerRopaje` (reemplaza la lógica que antes asumía que el último ítem agregado era siempre la armadura).
- Nueva `Private Sub AplicarHechizosIniciales(...)`: carga `Stats.UserHechizos` desde `EquipSet.Spells`.
- `RellenarInventario` reescrita: ahora recorre `EquipoInicialComun` y `EquipoInicialClase(.clase)` llamando `AsignarItemInicial` y `AplicarHechizosIniciales`, en vez de los `Select Case` por clase. Mantiene el mismo `On Error GoTo` / `TraceError` que tenía antes.

**General.bas**
- `Sub Main`: agregado `Call CargarEquipamientoInicial` inmediatamente después de `Call LoadOBJData` (el loader depende de `ObjData` ya cargado, porque `AsignarItemInicial` llama `EquiparInvItem`/`ObtenerRopaje`) y antes de `Call CargarHechizos`.

**EquipamientoInicial.dat (nuevo, en DatPath)**
- Sección `[COMMON]`: ítems comunes a todas las clases (poción roja, poción violeta, pasaje a Jourmut, manzana, agua).
- Secciones `[CLASS1]` a `[CLASS12]`, una por cada valor de `e_Class`: objetos (pociones, arma/escudo/casco/anillo según corresponda, armadura o túnica marcada con `Equip=1`) y hechizos iniciales donde aplica (Mage/Cleric/Druid/Bard reciben Dardo Mágico + Invocar Lobo; Paladin/Bandit/Assasin reciben Onda Mágica + Curar Heridas Leves).

## Notas / riesgos conocidos
- `NumObjs`/`NumSpells` deben coincidir exactamente con la cantidad de entradas `ObjN=`/`SpellN=` presentes en cada sección — el loader no cuenta entradas, confía en ese valor. Un desfasaje trunca silenciosamente el resto de la sección sin error visible en el server (bug real detectado y corregido para Hunter en `fix/equipamiento-inicial-hunter-numobjs`, que debe mergear junto con o después de este PR).
- Los hechizos iniciales (`Stats.UserHechizos`) quedaron migrados al `.dat` junto con los objetos, a pedido explícito, aunque conceptualmente son un sistema separado del inventario.