### PR TITLE
Ignorar trampas de paralisis para NPCs marcados con AfectaParalisis

### DIFF
--- a/Codigo/clsTrap.cls
+++ b/Codigo/clsTrap.cls
@@ -229,6 +229,13 @@ End Function
 
 Public Function trigger(ByVal TargetIndex, ByVal TargetType As e_ReferenceType)
     trigger = False
+    If TargetType = eNpc Then
+        If EffectOverTime(mDotInfo.EotId).SubType = e_TrapTypes.eParalice Then
+            If NpcList(TargetIndex).flags.AfectaParalisis = 1 Then
+                Exit Function
+            End If
+        End If
+    End If
     Call modSendData.SendToAreaByPos(mWorldPosition.map, mWorldPosition.x, mWorldPosition.y, PrepareMessagePlayWave(ACTIVATE_TRAP_WAW_FILE, mWorldPosition.x, mWorldPosition.y, _
             False))
     If EffectOverTime(mDotInfo.EotId).OnHitWav > 0 Then Call modSendData.SendToAreaByPos(mWorldPosition.Map, mWorldPosition.x, mWorldPosition.y, PrepareMessagePlayWave( _


### PR DESCRIPTION
Agrega una salida temprana en clsTrap.trigger para omitir la activacion cuando el subtipo del EffectOverTime de la trampa es eParalice y el objetivo es un NPC con NpcList(...).flags.AfectaParalisis activo. 

Esto evita que el efecto de trampas de paralisis (y su broadcast de activacion) se aplique o se reproduzca sobre NPCs marcados con ese flag.