### PR TITLE
Log safe trade transfers and skin usage

### DIFF
--- a/Codigo/InvUsuario.bas
+++ b/Codigo/InvUsuario.bas
@@ -1810,6 +1810,7 @@ Sub UseInvItem(ByVal UserIndex As Integer, ByVal Slot As Byte, ByVal ByClick As 
                         If AddSkin(UserIndex, .invent.Object(Slot).ObjIndex) Then
                             Call QuitarUserInvItem(UserIndex, Slot, 1)
                             Call UpdateSingleItemInv(UserIndex, Slot, False)
+                            Call LogSkinConsumption(.Id, .name, ObjIndex, 1)
                         End If
                     Else
                         Call WriteLocaleMsg(UserIndex, MSG_TIENES_SKIN, e_FontTypeNames.FONTTYPE_INFO) 'Msg2101=Ya tienes este skin.

--- a/Codigo/Logging.bas
+++ b/Codigo/Logging.bas
@@ -60,6 +60,8 @@ Private Enum eType_Log
     DatabaseError = 18
     Security = 19
     BankTransfer = 20
+    SafeCommerceTransfer = 21
+    SkinConsumption = 22
 End Enum
 
 Private Type t_CircularBuffer
@@ -270,6 +272,22 @@ Public Sub LogBankTransfer(ByVal originUser As String, ByVal targetUser As Strin
         transferContext = "destinatario fuera de línea"
     End If
     Call LogThis(eType_Log.BankTransfer, "[BankTransfers.log] " & originUser & " transfirió " & amount & " monedas a " & targetUser & " (" & transferContext & ")", vbLogEventTypeInformation)
+    Exit Sub
+ErrHandler:
+End Sub
+
+Public Sub LogSafeCommerceTransfer(ByVal originUser As String, ByVal targetUser As String, ByVal itemIndex As Integer, ByVal amount As Long, ByVal elementalTags As Long)
+    On Error GoTo ErrHandler
+    If itemIndex <= 0 Or amount <= 0 Then Exit Sub
+    Call LogThis(eType_Log.SafeCommerceTransfer, "[SafeCommerceTransfers.log] Sender: " & originUser & " | Receiver: " & targetUser & " | Item: " & ObjData(itemIndex).name & " (" & itemIndex & ") | Amount: " & amount & " | ElementalTags: " & elementalTags, vbLogEventTypeInformation)
+    Exit Sub
+ErrHandler:
+End Sub
+
+Public Sub LogSkinConsumption(ByVal characterId As Long, ByVal characterName As String, ByVal itemIndex As Integer, ByVal amount As Long)
+    On Error GoTo ErrHandler
+    If itemIndex <= 0 Or amount <= 0 Then Exit Sub
+    Call LogThis(eType_Log.SkinConsumption, "[SkinConsumptions.log] Character ID: " & characterId & " | Nick: " & characterName & " | Item: " & ObjData(itemIndex).name & " (" & itemIndex & ") | Amount: " & amount, vbLogEventTypeInformation)
     Exit Sub
 ErrHandler:
 End Sub

--- a/Codigo/mdlCOmercioConUsuario.bas
+++ b/Codigo/mdlCOmercioConUsuario.bas
@@ -240,19 +240,23 @@ Public Sub AceptarComercioUsu(ByVal UserIndex As Integer)
     End If
     ' Confirmamos que SI tienen los objetos a comerciar, procedemos con el cambio.
     For i = 1 To UBound(UserList(OtroUserIndex).ComUsu.itemsAenviar)
-        If Not MeterItemEnInventario(UserIndex, UserList(OtroUserIndex).ComUsu.itemsAenviar(i)) Then
-            Call TirarItemAlPiso(UserList(UserIndex).pos, UserList(OtroUserIndex).ComUsu.itemsAenviar(i))
+        objOfrecido = UserList(OtroUserIndex).ComUsu.itemsAenviar(i)
+        If Not MeterItemEnInventario(UserIndex, objOfrecido) Then
+            Call TirarItemAlPiso(UserList(UserIndex).pos, objOfrecido)
         End If
-        Call QuitarObjetos(UserList(OtroUserIndex).ComUsu.itemsAenviar(i).ObjIndex, UserList(OtroUserIndex).ComUsu.itemsAenviar(i).amount, OtroUserIndex, UserList( _
-                OtroUserIndex).ComUsu.itemsAenviar(i).ElementalTags)
+        If QuitarObjetos(objOfrecido.ObjIndex, objOfrecido.amount, OtroUserIndex, objOfrecido.ElementalTags) Then
+            Call LogSafeCommerceTransfer(GetUserRealName(OtroUserIndex), GetUserRealName(UserIndex), objOfrecido.ObjIndex, objOfrecido.amount, objOfrecido.ElementalTags)
+        End If
     Next i
     Dim j As Long
     For j = 1 To UBound(UserList(UserIndex).ComUsu.itemsAenviar)
-        If MeterItemEnInventario(OtroUserIndex, UserList(UserIndex).ComUsu.itemsAenviar(j)) = False Then
-            Call TirarItemAlPiso(UserList(OtroUserIndex).pos, UserList(UserIndex).ComUsu.itemsAenviar(j))
+        objOfrecido = UserList(UserIndex).ComUsu.itemsAenviar(j)
+        If MeterItemEnInventario(OtroUserIndex, objOfrecido) = False Then
+            Call TirarItemAlPiso(UserList(OtroUserIndex).pos, objOfrecido)
         End If
-        Call QuitarObjetos(UserList(UserIndex).ComUsu.itemsAenviar(j).ObjIndex, UserList(UserIndex).ComUsu.itemsAenviar(j).amount, UserIndex, UserList( _
-                UserIndex).ComUsu.itemsAenviar(j).ElementalTags)
+        If QuitarObjetos(objOfrecido.ObjIndex, objOfrecido.amount, UserIndex, objOfrecido.ElementalTags) Then
+            Call LogSafeCommerceTransfer(GetUserRealName(UserIndex), GetUserRealName(OtroUserIndex), objOfrecido.ObjIndex, objOfrecido.amount, objOfrecido.ElementalTags)
+        End If
     Next j
     Call UpdateUserInv(True, UserIndex, 0)
     Call UpdateUserInv(True, OtroUserIndex, 0)


### PR DESCRIPTION
Adds two new logging categories for auditability: safe user-to-user commerce transfers and skin consumptions. Safe trade now captures sender/receiver, item, amount, and elemental tags when item removal succeeds, and skin use now logs character identity plus consumed item data after successful application.