### PR TITLE
Fix authoritative weather state synchronization

### DIFF
--- a/Codigo/ModClimas.bas
+++ b/Codigo/ModClimas.bas
@@ -35,14 +35,43 @@ Public ServidorNublado     As Boolean
 Public ProbabilidadNublar  As Byte
 Public ProbabilidadLLuvia  As Byte
 
-Public Sub ResetMeteo()
+Public Function IsAtmosphericFogActive() As Boolean
+    IsAtmosphericFogActive = ServidorNublado Or Nieblando
+End Function
+
+Public Sub DetermineInitialWeatherSynchronization(ByRef SendRain As Boolean, ByRef SendSnow As Boolean, ByRef ToggleFog As Boolean)
+    SendRain = Lloviendo
+    SendSnow = Nebando
+    ToggleFog = IsAtmosphericFogActive()
+End Sub
+
+Public Sub DetermineWeatherResetNotifications(ByVal WasRaining As Boolean, ByVal WasSnowing As Boolean, ByVal WasFogActive As Boolean, ByRef NotifyRain As Boolean, ByRef NotifySnow As Boolean, ByRef NotifyFog As Boolean)
+    NotifyRain = WasRaining
+    NotifySnow = WasSnowing
+    NotifyFog = WasFogActive
+End Sub
+
+Public Sub ResetMeteo(Optional ByVal NotifyClients As Boolean = False)
     On Error GoTo ResetMeteo_Err
+    Dim NotifyRain As Boolean
+    Dim NotifySnow As Boolean
+    Dim NotifyFog As Boolean
+    Call DetermineWeatherResetNotifications(Lloviendo, Nebando, IsAtmosphericFogActive(), NotifyRain, NotifySnow, NotifyFog)
     Call AgregarAConsola("Servidor > Meteorologia reseteada")
     frmMain.TimerMeteorologia.Enabled = True
     frmMain.Truenos.Enabled = False
     TimerMeteorologico = 30
     ServidorNublado = False
+    Nieblando = False
     Lloviendo = False
+    Nebando = False
+    If NotifyClients Then
+        ' Fog has no explicit state in its packet: only toggle clients that
+        ' were known to have atmospheric fog active before this reset.
+        If NotifyFog Then Call SendData(SendTarget.ToAll, 0, PrepareMessageNieblandoToggle(IntensidadDeNubes))
+        If NotifyRain Then Call SendData(SendTarget.ToAll, 0, PrepareMessageRainToggle())
+        If NotifySnow Then Call SendData(SendTarget.ToAll, 0, PrepareMessageNevarToggle())
+    End If
     Exit Sub
 ResetMeteo_Err:
     Call TraceError(Err.Number, Err.Description, "ModClimas.ResetMeteo", Erl)

--- a/Codigo/Modulo_UsUaRiOs.bas
+++ b/Codigo/Modulo_UsUaRiOs.bas
@@ -718,8 +718,7 @@ Dim tStr                        As String
             .LastGuildRejection = vbNullString
             Call SaveUserGuildRejectionReason(.name, vbNullString)
         End If
-        If Lloviendo Then Call WriteRainToggle(UserIndex)
-        If ServidorNublado Then Call WriteNubesToggle(UserIndex)
+        Call WriteCurrentWeatherState(UserIndex)
         Call WriteLoggedMessage(UserIndex, newUser)
         If .Stats.ELV = 1 Then
             Call WriteLocaleMsg(UserIndex, MSG_BIENVENIDO_TIERRAS_ARGENTUM_ONLINE_NOMBRE_TENGAS_BUEN_VIAJE, e_FontTypeNames.FONTTYPE_GUILD, GetUserDisplayName(UserIndex)) ' Msg522=¡Bienvenido a las tierras de Argentum Online! ¡<nombre> que tengas buen viaje y mucha suerte!

--- a/Codigo/Protocol_GmCommands.bas
+++ b/Codigo/Protocol_GmCommands.bas
@@ -3465,7 +3465,7 @@ Public Sub HandleNieblaToggle(ByVal UserIndex As Integer)
             Exit Sub
         End If
         Call LogGM(GetUserRealName(UserIndex), "/NIEBLA")
-        Call ResetMeteo
+        Call ResetMeteo(True)
     End With
     Exit Sub
 HandleNieblaToggle_Err:

--- a/Codigo/Protocol_Writes.bas
+++ b/Codigo/Protocol_Writes.bas
@@ -1261,6 +1261,15 @@ WriteRainToggle_Err:
     Call TraceError(Err.Number, Err.Description, "Argentum20Server.Protocol_Writes.WriteRainToggle", Erl)
 End Sub
 
+Public Sub WriteNieveToggle(ByVal UserIndex As Integer)
+    On Error GoTo WriteNieveToggle_Err
+    Call modSendData.SendData(ToIndex, UserIndex, PrepareMessageNevarToggle())
+    Exit Sub
+WriteNieveToggle_Err:
+    Call Writer.Clear
+    Call TraceError(Err.Number, Err.Description, "Argentum20Server.Protocol_Writes.WriteNieveToggle", Erl)
+End Sub
+
 Public Sub WriteNubesToggle(ByVal UserIndex As Integer)
     On Error GoTo WriteNubesToggle_Err
     Call modSendData.SendData(ToIndex, UserIndex, PrepareMessageNieblandoToggle(IntensidadDeNubes))
@@ -1268,6 +1277,22 @@ Public Sub WriteNubesToggle(ByVal UserIndex As Integer)
 WriteNubesToggle_Err:
     Call Writer.Clear
     Call TraceError(Err.Number, Err.Description, "Argentum20Server.Protocol_Writes.WriteNubesToggle", Erl)
+End Sub
+
+' Initial synchronization only. A newly initialized client starts with
+' atmospheric fog disabled, so sending the fog toggle here enables it safely.
+Public Sub WriteCurrentWeatherState(ByVal UserIndex As Integer)
+    On Error GoTo WriteCurrentWeatherState_Err
+    Dim SendRain As Boolean
+    Dim SendSnow As Boolean
+    Dim ToggleFog As Boolean
+    Call DetermineInitialWeatherSynchronization(SendRain, SendSnow, ToggleFog)
+    If SendRain Then Call WriteRainToggle(UserIndex)
+    If SendSnow Then Call WriteNieveToggle(UserIndex)
+    If ToggleFog Then Call WriteNubesToggle(UserIndex)
+    Exit Sub
+WriteCurrentWeatherState_Err:
+    Call TraceError(Err.Number, Err.Description, "Argentum20Server.Protocol_Writes.WriteCurrentWeatherState", Erl)
 End Sub
 
 ''

--- a/Codigo/Tests/Unit_Weather.bas
+++ b/Codigo/Tests/Unit_Weather.bas
@@ -1,0 +1,63 @@
+Attribute VB_Name = "Unit_Weather"
+Option Explicit
+#If UNIT_TEST = 1 Then
+
+Public Function test_suite_weather() As Boolean
+    Call UnitTesting.RunTest("test_weather_fog_state", test_weather_fog_state())
+    Call UnitTesting.RunTest("test_weather_reset_decisions", test_weather_reset_decisions())
+    Call UnitTesting.RunTest("test_weather_initial_sync", test_weather_initial_sync())
+    Call UnitTesting.RunTest("test_weather_canonical_reset", test_weather_canonical_reset())
+    test_suite_weather = True
+End Function
+
+Private Function test_weather_fog_state() As Boolean
+    ServidorNublado = True
+    Nieblando = False
+    If Not IsAtmosphericFogActive() Then Exit Function
+    ServidorNublado = False
+    Nieblando = True
+    If Not IsAtmosphericFogActive() Then Exit Function
+    ServidorNublado = False
+    Nieblando = False
+    test_weather_fog_state = Not IsAtmosphericFogActive()
+End Function
+
+Private Function test_weather_reset_decisions() As Boolean
+    Dim NotifyRain As Boolean
+    Dim NotifySnow As Boolean
+    Dim NotifyFog As Boolean
+    Call DetermineWeatherResetNotifications(True, True, True, NotifyRain, NotifySnow, NotifyFog)
+    If Not NotifyRain Or Not NotifySnow Or Not NotifyFog Then Exit Function
+    Call DetermineWeatherResetNotifications(False, False, False, NotifyRain, NotifySnow, NotifyFog)
+    test_weather_reset_decisions = Not NotifyRain And Not NotifySnow And Not NotifyFog
+End Function
+
+Private Function test_weather_initial_sync() As Boolean
+    Dim SendRain As Boolean
+    Dim SendSnow As Boolean
+    Dim ToggleFog As Boolean
+    Lloviendo = False
+    Nebando = True
+    ServidorNublado = False
+    Nieblando = False
+    Call DetermineInitialWeatherSynchronization(SendRain, SendSnow, ToggleFog)
+    If SendRain Or Not SendSnow Or ToggleFog Then Exit Function
+    Lloviendo = True
+    ServidorNublado = True
+    Call DetermineInitialWeatherSynchronization(SendRain, SendSnow, ToggleFog)
+    test_weather_initial_sync = SendRain And SendSnow And ToggleFog
+End Function
+
+Private Function test_weather_canonical_reset() As Boolean
+    Lloviendo = True
+    Nebando = True
+    ServidorNublado = True
+    Nieblando = True
+    Call ResetMeteo(False)
+    test_weather_canonical_reset = Not Lloviendo And Not Nebando And _
+        Not ServidorNublado And Not Nieblando And _
+        Not frmMain.Truenos.Enabled And frmMain.TimerMeteorologia.Enabled And _
+        TimerMeteorologico = 30
+End Function
+
+#End If

--- a/Codigo/UnitTesting.bas
+++ b/Codigo/UnitTesting.bas
@@ -41,7 +41,7 @@ Option Explicit
     Private FailedTestCount As Integer
     Private TotalElapsed   As Double
 
-    Private Const SUITE_COUNT As Integer = 35
+    Private Const SUITE_COUNT As Integer = 36
 
 Public Sub Init()
     On Error GoTo Init_Err
@@ -277,6 +277,7 @@ Private Function RunSuite(ByVal suiteIndex As Integer) As Boolean
 #If DIRECT_PLAY = 0 Then
         Case 35: RunSuite = Unit_Network_Aurora.test_suite_network_aurora()
 #End If
+        Case 36: RunSuite = Unit_Weather.test_suite_weather()
         Case Else
             RunSuite = False
     End Select

--- a/Codigo/frmMain.frm
+++ b/Codigo/frmMain.frm
@@ -1421,19 +1421,17 @@ Private Sub TimerMeteorologia_Timer()
         ProbabilidadNublar = RandomNumber(1, 3)
         If ProbabilidadNublar = 1 Then
             IntensidadDeNubes = RandomNumber(10, 45)
-            ServidorNublado = True
-            'Enviar Nubes a todos
             Nieblando = True
             ServidorNublado = True
+            'Enviar Nubes a todos
             Call SendData(SendTarget.ToAll, 0, PrepareMessageNieblandoToggle(IntensidadDeNubes))
             ' Call SendData(SendTarget.ToAll, 0, PrepareMessageConsoleMsg("Servidor > Empezaron las nubes con intensidad: " & IntensidadDeNubes & "%.", e_FontTypeNames.FONTTYPE_SERVER))
             Call AgregarAConsola("Servidor » Empezaron las nubes")
             TimerMeteorologico = TimerMeteorologico - 1
         Else
-            ServidorNublado = False
             ' Call SendData(SendTarget.ToAll, 0, PrepareMessageConsoleMsg("Servidor > Tranquilo, no hay nubes ni va a llover.", e_FontTypeNames.FONTTYPE_SERVER))
             Call AgregarAConsola("Servidor » Tranquilo, no hay nubes ni va a llover.")
-            Call ResetMeteo
+            Call ResetMeteo(True)
             Exit Sub
         End If
     End If
@@ -1458,13 +1456,8 @@ Private Sub TimerMeteorologia_Timer()
             Call AgregarAConsola("Servidor » Lloviendo.")
             TimerMeteorologico = TimerMeteorologico - 1
         Else
-            Nieblando = False
-            Lloviendo = False
-            ServidorNublado = False
-            Truenos.Enabled = False
-            Call SendData(SendTarget.ToAll, 0, PrepareMessageNieblandoToggle(IntensidadDeNubes))
             Call AgregarAConsola("Servidor » Truenos y nubes desactivados.")
-            Call ResetMeteo
+            Call ResetMeteo(True)
             Exit Sub
         End If
     End If
@@ -1474,15 +1467,8 @@ Private Sub TimerMeteorologia_Timer()
     End If
     If TimerMeteorologico = 0 Then
         'dejar de llover y sacar nubes
-        Nieblando = False
-        Lloviendo = False
-        Truenos.Enabled = False
-        Nebando = False
-        Call SendData(SendTarget.ToAll, 0, PrepareMessageNieblandoToggle(IntensidadDeNubes))
-        Call SendData(SendTarget.ToAll, 0, PrepareMessageRainToggle())
-        Call SendData(SendTarget.ToAll, 0, PrepareMessageNevarToggle())
         Call AgregarAConsola("Servidor >Lluvia desactivada.")
-        Call ResetMeteo
+        Call ResetMeteo(True)
         Exit Sub
     End If
     Exit Sub

--- a/Server.VBP
+++ b/Server.VBP
@@ -108,6 +108,7 @@ Module=Unit_Crafting; Codigo\Tests\Unit_Crafting.bas
 Module=Unit_GameStatus; Codigo\Tests\Unit_GameStatus.bas
 Module=Unit_IniManager; Codigo\Tests\Unit_IniManager.bas
 Module=Unit_WorldTime; Codigo\Tests\Unit_WorldTime.bas
+Module=Unit_Weather; Codigo\Tests\Unit_Weather.bas
 Module=Unit_TimeFormat; Codigo\Tests\Unit_TimeFormat.bas
 Module=Unit_StringUtils; Codigo\Tests\Unit_StringUtils.bas
 Module=Unit_Spawn; Codigo\Tests\Unit_Spawn.bas


### PR DESCRIPTION
## Summary

Fix authoritative VB6 server weather synchronization for rain, snow, and atmospheric fog while preserving the existing protocol and meteorological behaviour.

## What changed

- Added snow to the weather state sent when a client completes login initialization.
- Added a focused initial-weather synchronization helper covering rain, snow, and fog.
- Added a per-user snow writer that reuses the existing packet 122 serializer.
- Made `ResetMeteo` clear rain, snow, both legacy fog flags, thunder state, and the existing meteorological timer state.
- Added an optional live-notification mode to `ResetMeteo`.
- Rain and snow off packets are sent only when their previous states were active.
- Fog packet 123 is sent exactly once only when atmospheric fog was previously active, preventing an already-clear reset from toggling fog on.
- Routed failed storm transitions, normal storm completion, and `/NIEBLA` through the notifying reset path.
- Removed duplicate fog state assignment at fog startup.
- Added focused tests for canonical reset state, inconsistent legacy fog flags, notification decisions, snow-only login synchronization, and full-storm login synchronization.

## Compatibility

The legacy VB6 client remains wire-compatible:

- packet 59 remains `eRainToggle` plus `Bool Lloviendo`;
- packet 122 remains `eNieveToggle` plus `Bool Nebando`;
- packet 123 remains `eNieblaToggle` plus only `Int8 IntensidadDeNubes`;
- packet 129 remains unchanged.

No packet IDs or payload layouts changed. Simultaneous global rain and snow remain supported, allowing map climate metadata to select the visible effect.

## What is intentionally unchanged

- weather probabilities and timing;
- rain/snow duration;
- fog intensity ranges;
- thunder timing and sounds;
- screen-flash parameters;
- map climate metadata;
- HOO and legacy VB6 client code.

## Validation performed

- `git diff --check` — passed.
- Audited every `ResetMeteo` caller and every production assignment to `Lloviendo`, `Nebando`, `Nieblando`, and `ServidorNublado`.
- Source-verified that packet serializers 59, 122, 123, and 129 are unchanged.
- Attempted the documented VB6 unit-test build. It could not start because this checkout’s `Server.VBP` was already open in another VB6 IDE instance (`El archivo ... Server.VBP ya está abierto`). The existing server executable remained byte-for-byte unchanged.

## Risks / follow-up validation

Once the open IDE session is closed, run the documented `UNIT_TEST=1` build and execute `Server.exe` to exercise the new `Unit_Weather` suite. Runtime verification should cover login during snow/full-storm states, failed-storm fog shutdown, normal storm end, and `/NIEBLA` while active and already clear.