### PR TITLE
Fix remaining wrap-unsafe server timers

### DIFF
--- a/Codigo/Scenearios/ScenarioNavalBoarding.cls
+++ b/Codigo/Scenearios/ScenarioNavalBoarding.cls
@@ -649,7 +649,7 @@ Private Sub RespawnPlayers()
     Keys = PlayerRespawn.Keys
     For Each key In Keys
         Set RespawnInfo = PlayerRespawn.Item(key)
-        If currentTime - RespawnInfo.RespawnTime > PlayerMinRespawnTime Then
+        If TicksElapsed(RespawnInfo.RespawnTime, currentTime) > PlayerMinRespawnTime Then
             Call Respawn(key)
             For i = 0 To RespawnInfo.EquipedElementCount - 1
                 Call EquiparInvItem(key, RespawnInfo.GetActiveSlot(i))

--- a/Codigo/Tests/Unit_ElapsedTime.bas
+++ b/Codigo/Tests/Unit_ElapsedTime.bas
@@ -21,6 +21,7 @@ Public Function test_suite_elapsed_time() As Boolean
     Call UnitTesting.RunTest("test_add_mod32_simple", test_add_mod32_simple())
     Call UnitTesting.RunTest("test_add_mod32_signed_boundary", test_add_mod32_signed_boundary())
     Call UnitTesting.RunTest("test_add_mod32_true_wrap", test_add_mod32_true_wrap())
+    Call UnitTesting.RunTest("test_add_mod32_modular_subtraction", test_add_mod32_modular_subtraction())
     Call UnitTesting.RunTest("test_deadline_passed_zero", test_deadline_passed_zero())
     Call UnitTesting.RunTest("test_deadline_passed_normal", test_deadline_passed_normal())
     Call UnitTesting.RunTest("test_deadline_passed_signed_boundary", test_deadline_passed_signed_boundary())
@@ -171,6 +172,18 @@ Private Function test_add_mod32_true_wrap() As Boolean
     Exit Function
 Err_Handler:
     test_add_mod32_true_wrap = False
+End Function
+
+' Verifies callers can create an earlier raw timestamp without signed Long
+' subtraction overflowing at either the sign boundary or the true wrap.
+Private Function test_add_mod32_modular_subtraction() As Boolean
+    On Error GoTo Err_Handler
+    test_add_mod32_modular_subtraction = True
+    If AddMod32(&H80000010, -32) <> &H7FFFFFF0 Then test_add_mod32_modular_subtraction = False: Exit Function
+    If AddMod32(&H10, -32) <> &HFFFFFFF0 Then test_add_mod32_modular_subtraction = False: Exit Function
+    Exit Function
+Err_Handler:
+    test_add_mod32_modular_subtraction = False
 End Function
 
 ' Verifies DeadlinePassed() treats deadline=0 as "always passed" regardless

--- a/Codigo/WorldTime.bas
+++ b/Codigo/WorldTime.bas
@@ -37,7 +37,7 @@ Private WT_Inited   As Boolean
 Public Sub WorldTime_Init(ByVal dayLenMs As Long, Optional ByVal startElapsedMs As Long = 0)
     If dayLenMs <= 0 Then dayLenMs = 1
     WT_DayLenMs = dayLenMs
-    WT_BaseTick = WorldTime_NowRaw() - (startElapsedMs And &H7FFFFFFF) ' store raw base; differences via TicksElapsed()
+    WT_BaseTick = AddMod32(WorldTime_NowRaw(), -(startElapsedMs And &H7FFFFFFF)) ' store raw base; differences via TicksElapsed()
     WT_Inited = True
 End Sub
 
@@ -49,7 +49,7 @@ Public Sub WorldTime_HandleHora(ByVal elapsedFromServerMs As Long, ByVal dayLenM
     WT_DayLenMs = dayLenMs
     Dim elapsedNorm As Long
     elapsedNorm = PosMod(CDbl(elapsedFromServerMs), WT_DayLenMs)
-    WT_BaseTick = WorldTime_NowRaw() - elapsedNorm   ' base is raw; only compare via TicksElapsed()
+    WT_BaseTick = AddMod32(WorldTime_NowRaw(), -elapsedNorm)   ' base is raw; only compare via TicksElapsed()
     WT_Inited = True
 End Sub
 
@@ -80,7 +80,7 @@ Public Sub WorldTime_Resync(ByVal serverElapsedMs As Long)
     If WT_DayLenMs <= 0 Then WT_DayLenMs = 1
     Dim elapsedNorm As Long
     elapsedNorm = PosMod(CDbl(serverElapsedMs), WT_DayLenMs)
-    WT_BaseTick = WorldTime_NowRaw() - elapsedNorm
+    WT_BaseTick = AddMod32(WorldTime_NowRaw(), -elapsedNorm)
     WT_Inited = True
 End Sub
 


### PR DESCRIPTION
## Summary

Completes a focused whole-server audit of timer and tick arithmetic after the earlier `GlobalFrameTime` wrap-safety work.

The audit classifies timer values by provenance before changing them and fixes only expressions proven to operate on raw modulo-2^32 Windows tick values.

## What changed

- Replaced direct signed subtraction of Naval Boarding player-respawn timestamps with `TicksElapsed`.
- Replaced three signed raw-tick subtractions used to anchor `WorldTime` with modular subtraction through `AddMod32`.
- Added focused regression coverage proving modular subtraction across:
  - the signed `Long` boundary (`&H7FFFFFFF -> &H80000000`);
  - the true modulo-2^32 wrap (`&HFFFFFFFF -> &H00000000`).

## Audit conclusions

Reviewed and deliberately left unchanged:

- `modTime.t_Timer.ElapsedTime - Interval`: accumulated duration arithmetic, not raw timestamps.
- Scenario and effect-over-time `ElapsedTime`/`DeltaTime` calculations: accumulated durations.
- `QueryPerformanceCounter` calculations: separate high-resolution counter representation.
- Calendar and world-schedule calculations using `DateTime.Now`, system time, or explicit hour values.
- Existing raw-tick users already using `TicksElapsed`, `TickAfter`, `AddMod32`, or `DeadlinePassed`.
- The isolated string-builder benchmark's private `GetTickCount`/`TickDiff` implementation; it is not a production gameplay timer.

No remaining unsafe direct `GlobalFrameTime` arithmetic was found.

## Semantics preserved

- Existing comparison operators remain unchanged.
- Respawn, cooldown, event, and world-time duration values remain unchanged.
- No gameplay balancing, scheduler, protocol, networking, or client behavior changed.
- Zero remains a valid `WorldTime` raw tick; initialization remains controlled by `WT_Inited`.

## Validation performed

- Full VB6 unit-test build succeeded.
- Full test suite: **284 passed / 284 total / 0 failed**.
- Production-style `PYMMO=1` VB6 build succeeded.
- Final whole-server timer-source/arithmetic search completed.
- `git diff --check` passed.

The normal `Server.VBP` was already open in the user's VB6 IDE, so validation used a temporary same-directory project copy with a separate executable name. Those temporary build artifacts were removed afterward.

## Intentionally deferred

- No broad timer-system redesign.
- No migration of the isolated string-builder benchmark.
- No change to legacy timestamp sentinel representations.
- No unrelated `Server.VBP` changes included.
