### PR TITLE
Add HOO Remort capability state

### DIFF
--- a/Codigo/Declares.bas
+++ b/Codigo/Declares.bas
@@ -2977,7 +2977,17 @@ Public Const HotKeyCount As Integer = 10
 
 Public Const HOO_CAP_PROTOCOL_VERSION As Byte = 1
 Public Const HOO_CAP_ADJACENT_CHARACTERS_V1 As Long = &H1&
+Public Const HOO_CAP_REMORT_V1 As Long = &H2&
 Public Const HOO_FEATURE_ADJACENT_CHARACTERS_V1 As String = "hoo-adjacent-characters-v1"
+Public Const HOO_FEATURE_REMORT_V1 As String = "hoo-remort-v1"
+
+Public Enum e_RemortEligibilityReason
+    eRemortEligibility_Eligible = 0
+    eRemortEligibility_BelowRequiredLevel = 1
+    eRemortEligibility_Dead = 2
+    eRemortEligibility_ActiveQuest = 3
+    eRemortEligibility_InParty = 4
+End Enum
 
 Public Type t_HooClientCapabilities
     Negotiated As Boolean

--- a/Codigo/Modulo_UsUaRiOs.bas
+++ b/Codigo/Modulo_UsUaRiOs.bas
@@ -720,6 +720,7 @@ Dim tStr                        As String
         End If
         Call WriteCurrentWeatherState(UserIndex)
         Call WriteLoggedMessage(UserIndex, newUser)
+        Call MaybeSendRemortState(UserIndex)
         If .Stats.ELV = 1 Then
             Call WriteLocaleMsg(UserIndex, MSG_BIENVENIDO_TIERRAS_ARGENTUM_ONLINE_NOMBRE_TENGAS_BUEN_VIAJE, e_FontTypeNames.FONTTYPE_GUILD, GetUserDisplayName(UserIndex)) ' Msg522=¡Bienvenido a las tierras de Argentum Online! ¡<nombre> que tengas buen viaje y mucha suerte!
         Else

--- a/Codigo/PacketId.bas
+++ b/Codigo/PacketId.bas
@@ -225,6 +225,7 @@ Public Enum ServerPacketID
     eChangeSkinSlot
     eGuildConfig
     eShowPickUpObj
+    eRemortState
     eMaxPacket
     [PacketCount]
 End Enum

--- a/Codigo/Protocol.bas
+++ b/Codigo/Protocol.bas
@@ -966,11 +966,59 @@ Public Function UserSupportsAdjacentCharacters(ByVal UserIndex As Integer) As Bo
         UserSupportsHooCapability(UserIndex, HOO_CAP_ADJACENT_CHARACTERS_V1)
 End Function
 
+Public Function UserSupportsRemortState(ByVal UserIndex As Integer) As Boolean
+    UserSupportsRemortState = IsFeatureEnabled(HOO_FEATURE_REMORT_V1) And _
+        UserSupportsHooCapability(UserIndex, HOO_CAP_REMORT_V1)
+End Function
+
+Public Function UserHasActiveRemortQuest(ByVal UserIndex As Integer) As Boolean
+    Dim QuestSlot As Integer
+    For QuestSlot = 1 To MAXUSERQUESTS
+        If UserList(UserIndex).QuestStats.Quests(QuestSlot).QuestIndex <> 0 Then
+            UserHasActiveRemortQuest = True
+            Exit Function
+        End If
+    Next QuestSlot
+End Function
+
+Public Function GetRemortEligibility(ByVal UserIndex As Integer) As e_RemortEligibilityReason
+    GetRemortEligibility = eRemortEligibility_BelowRequiredLevel
+    If UserIndex < 1 Or UserIndex > UBound(UserList) Then Exit Function
+    With UserList(UserIndex)
+        If .Stats.ELV <> STAT_MAXELV Then Exit Function
+        If .flags.Muerto <> 0 Then
+            GetRemortEligibility = eRemortEligibility_Dead
+            Exit Function
+        End If
+        If UserHasActiveRemortQuest(UserIndex) Then
+            GetRemortEligibility = eRemortEligibility_ActiveQuest
+            Exit Function
+        End If
+        If .Grupo.EnGrupo Then
+            GetRemortEligibility = eRemortEligibility_InParty
+            Exit Function
+        End If
+    End With
+    GetRemortEligibility = eRemortEligibility_Eligible
+End Function
+
+Public Sub MaybeSendRemortState(ByVal UserIndex As Integer)
+    If UserIndex < 1 Or UserIndex > UBound(UserList) Then Exit Sub
+    If Not UserList(UserIndex).flags.UserLogged Then Exit Sub
+    If Not UserSupportsRemortState(UserIndex) Then Exit Sub
+    Call WriteRemortState(UserIndex, GetRemortEligibility(UserIndex))
+End Sub
+
 Public Function AcceptedHooCapabilityMask(ByVal ProtocolVersion As Byte, ByVal RequestedMask As Long) As Long
     If ProtocolVersion <> HOO_CAP_PROTOCOL_VERSION Then Exit Function
+    Dim SupportedMask As Long
     If IsFeatureEnabled(HOO_FEATURE_ADJACENT_CHARACTERS_V1) Then
-        AcceptedHooCapabilityMask = RequestedMask And HOO_CAP_ADJACENT_CHARACTERS_V1
+        SupportedMask = SupportedMask Or HOO_CAP_ADJACENT_CHARACTERS_V1
     End If
+    If IsFeatureEnabled(HOO_FEATURE_REMORT_V1) Then
+        SupportedMask = SupportedMask Or HOO_CAP_REMORT_V1
+    End If
+    AcceptedHooCapabilityMask = RequestedMask And SupportedMask
 End Function
 
 Private Sub HandleHooClientCapabilities(ByVal UserIndex As Integer)
@@ -993,6 +1041,7 @@ Private Sub HandleHooClientCapabilities(ByVal UserIndex As Integer)
         " protocol=" & CStr(ProtocolVersion) & _
         " requested=" & CStr(RequestedMask) & _
         " accepted=" & CStr(AcceptedMask))
+    Call MaybeSendRemortState(UserIndex)
     Exit Sub
 HandleHooClientCapabilities_Err:
     Call ResetHooClientCapabilities(UserIndex)

--- a/Codigo/Protocol_Writes.bas
+++ b/Codigo/Protocol_Writes.bas
@@ -107,6 +107,20 @@ WriteLoggedMessage_Err:
     Call TraceError(Err.Number, Err.Description, "Argentum20Server.Protocol_Writes.WriteLoggedMessage", Erl)
 End Sub
 
+Public Sub WriteRemortState(ByVal UserIndex As Integer, ByVal Reason As e_RemortEligibilityReason)
+    On Error GoTo WriteRemortState_Err
+    Call Writer.WriteInt16(ServerPacketID.eRemortState)
+    Call Writer.WriteInt32(UserList(UserIndex).Stats.RemortCount)
+    Call Writer.WriteInt16(STAT_MAXELV)
+    Call Writer.WriteBool(Reason = eRemortEligibility_Eligible)
+    Call Writer.WriteInt8(CByte(Reason))
+    Call modSendData.SendData(ToIndex, UserIndex)
+    Exit Sub
+WriteRemortState_Err:
+    Call Writer.Clear
+    Call TraceError(Err.Number, Err.Description, "Argentum20Server.Protocol_Writes.WriteRemortState", Erl)
+End Sub
+
 Public Sub WriteHora(ByVal UserIndex As Integer)
     On Error GoTo WriteHora_Err
     Call modSendData.SendData(ToIndex, UserIndex, PrepareMessageHora())

--- a/Codigo/UnitTesting.bas
+++ b/Codigo/UnitTesting.bas
@@ -41,7 +41,7 @@ Option Explicit
     Private FailedTestCount As Integer
     Private TotalElapsed   As Double
 
-    Private Const SUITE_COUNT As Integer = 37
+    Private Const SUITE_COUNT As Integer = 38
 
 Public Sub Init()
     On Error GoTo Init_Err
@@ -279,6 +279,7 @@ Private Function RunSuite(ByVal suiteIndex As Integer) As Boolean
 #End If
         Case 36: RunSuite = Unit_Weather.test_suite_weather()
         Case 37: RunSuite = test_suite_remort_persistence()
+        Case 38: RunSuite = test_suite_remort_capability_state()
         Case Else
             RunSuite = False
     End Select
@@ -384,6 +385,129 @@ Private Function test_remort_count_normal_save_sql() As Boolean
     test_remort_count_normal_save_sql = _
             InStr(1, QUERY_LOAD_MAINPJ, "remort_count", vbTextCompare) > 0 And _
             InStr(1, QUERY_UPDATE_MAINPJ, "remort_count = ?", vbTextCompare) > 0
+End Function
+
+Private Function test_suite_remort_capability_state() As Boolean
+    Call RunTest("remort eligibility and priority", test_remort_eligibility_and_priority())
+    Call RunTest("remort eligibility is read-only", test_remort_eligibility_is_read_only())
+    Call RunTest("remort capability bit and reset", test_remort_capability_bit_and_reset())
+    Call RunTest("remort packet is appended", CInt(ServerPacketID.eRemortState) = CInt(ServerPacketID.eShowPickUpObj) + 1)
+    test_suite_remort_capability_state = True
+End Function
+
+Private Function test_remort_eligibility_and_priority() As Boolean
+    On Error GoTo TestError
+    Dim OriginalLevel As Byte
+    Dim OriginalDead As Byte
+    Dim OriginalInParty As Boolean
+    Dim OriginalQuests(1 To MAXUSERQUESTS) As Integer
+    Dim QuestSlot As Integer
+    OriginalLevel = UserList(1).Stats.ELV
+    OriginalDead = UserList(1).flags.Muerto
+    OriginalInParty = UserList(1).Grupo.EnGrupo
+    For QuestSlot = 1 To MAXUSERQUESTS
+        OriginalQuests(QuestSlot) = UserList(1).QuestStats.Quests(QuestSlot).QuestIndex
+        UserList(1).QuestStats.Quests(QuestSlot).QuestIndex = 0
+    Next QuestSlot
+
+    UserList(1).Stats.ELV = STAT_MAXELV - 1
+    UserList(1).flags.Muerto = 1
+    If GetRemortEligibility(1) <> eRemortEligibility_BelowRequiredLevel Then GoTo TestDone
+
+    UserList(1).Stats.ELV = STAT_MAXELV
+    If GetRemortEligibility(1) <> eRemortEligibility_Dead Then GoTo TestDone
+
+    UserList(1).flags.Muerto = 0
+    UserList(1).QuestStats.Quests(1).QuestIndex = 1
+    UserList(1).Grupo.EnGrupo = True
+    If GetRemortEligibility(1) <> eRemortEligibility_ActiveQuest Then GoTo TestDone
+
+    UserList(1).QuestStats.Quests(1).QuestIndex = 0
+    If GetRemortEligibility(1) <> eRemortEligibility_InParty Then GoTo TestDone
+
+    UserList(1).Grupo.EnGrupo = False
+    If GetRemortEligibility(1) <> eRemortEligibility_Eligible Then GoTo TestDone
+    test_remort_eligibility_and_priority = True
+
+TestDone:
+    UserList(1).Stats.ELV = OriginalLevel
+    UserList(1).flags.Muerto = OriginalDead
+    UserList(1).Grupo.EnGrupo = OriginalInParty
+    For QuestSlot = 1 To MAXUSERQUESTS
+        UserList(1).QuestStats.Quests(QuestSlot).QuestIndex = OriginalQuests(QuestSlot)
+    Next QuestSlot
+    Exit Function
+TestError:
+    test_remort_eligibility_and_priority = False
+    Resume TestDone
+End Function
+
+Private Function test_remort_eligibility_is_read_only() As Boolean
+    On Error GoTo TestError
+    Dim OriginalRemortCount As Long
+    Dim OriginalLevel As Byte
+    Dim OriginalExp As Long
+    Dim OriginalSkillPts As Integer
+    Dim OriginalHp As Integer
+    Dim OriginalSkill As Byte
+    OriginalRemortCount = UserList(1).Stats.RemortCount
+    OriginalLevel = UserList(1).Stats.ELV
+    OriginalExp = UserList(1).Stats.Exp
+    OriginalSkillPts = UserList(1).Stats.SkillPts
+    OriginalHp = UserList(1).Stats.MinHp
+    OriginalSkill = UserList(1).Stats.UserSkills(1)
+
+    Call GetRemortEligibility(1)
+    test_remort_eligibility_is_read_only = _
+        UserList(1).Stats.RemortCount = OriginalRemortCount And _
+        UserList(1).Stats.ELV = OriginalLevel And _
+        UserList(1).Stats.Exp = OriginalExp And _
+        UserList(1).Stats.SkillPts = OriginalSkillPts And _
+        UserList(1).Stats.MinHp = OriginalHp And _
+        UserList(1).Stats.UserSkills(1) = OriginalSkill
+    Exit Function
+TestError:
+    test_remort_eligibility_is_read_only = False
+End Function
+
+Private Function test_remort_capability_bit_and_reset() As Boolean
+    On Error GoTo TestError
+    Dim OriginalNegotiated As Boolean
+    Dim OriginalVersion As Byte
+    Dim OriginalMask As Long
+    Dim OriginalFeatureEnabled As Boolean
+    OriginalNegotiated = UserList(1).HooCapabilities.Negotiated
+    OriginalVersion = UserList(1).HooCapabilities.ProtocolVersion
+    OriginalMask = UserList(1).HooCapabilities.CapabilityMask
+    OriginalFeatureEnabled = IsFeatureEnabled(HOO_FEATURE_REMORT_V1)
+
+    Call SetFeatureToggle(HOO_FEATURE_REMORT_V1, True)
+    If AcceptedHooCapabilityMask(HOO_CAP_PROTOCOL_VERSION, HOO_CAP_REMORT_V1) <> HOO_CAP_REMORT_V1 Then GoTo TestDone
+    Call SetFeatureToggle(HOO_FEATURE_REMORT_V1, False)
+    If AcceptedHooCapabilityMask(HOO_CAP_PROTOCOL_VERSION, HOO_CAP_REMORT_V1) <> 0 Then GoTo TestDone
+    Call SetFeatureToggle(HOO_FEATURE_REMORT_V1, True)
+    If AcceptedHooCapabilityMask(HOO_CAP_PROTOCOL_VERSION + 1, HOO_CAP_REMORT_V1) <> 0 Then GoTo TestDone
+    Call ResetHooClientCapabilities(1)
+    If UserSupportsHooCapability(1, HOO_CAP_REMORT_V1) Then GoTo TestDone
+    UserList(1).HooCapabilities.Negotiated = True
+    UserList(1).HooCapabilities.ProtocolVersion = HOO_CAP_PROTOCOL_VERSION
+    UserList(1).HooCapabilities.CapabilityMask = HOO_CAP_ADJACENT_CHARACTERS_V1 Or HOO_CAP_REMORT_V1
+    If Not UserSupportsHooCapability(1, HOO_CAP_REMORT_V1) Then GoTo TestDone
+    If Not UserSupportsHooCapability(1, HOO_CAP_ADJACENT_CHARACTERS_V1) Then GoTo TestDone
+    Call ResetHooClientCapabilities(1)
+    If UserList(1).HooCapabilities.Negotiated Then GoTo TestDone
+    If UserList(1).HooCapabilities.CapabilityMask <> 0 Then GoTo TestDone
+    test_remort_capability_bit_and_reset = (HOO_CAP_REMORT_V1 = &H2&)
+
+TestDone:
+    Call SetFeatureToggle(HOO_FEATURE_REMORT_V1, OriginalFeatureEnabled)
+    UserList(1).HooCapabilities.Negotiated = OriginalNegotiated
+    UserList(1).HooCapabilities.ProtocolVersion = OriginalVersion
+    UserList(1).HooCapabilities.CapabilityMask = OriginalMask
+    Exit Function
+TestError:
+    test_remort_capability_bit_and_reset = False
+    Resume TestDone
 End Function
 
 #End If

--- a/Example.feature_toggle.ini
+++ b/Example.feature_toggle.ini
@@ -1,5 +1,5 @@
 [INIT]
-TOGGLECOUNT=25
+TOGGLECOUNT=26
 [TOGGLE1]
 name=bandit_unequip_bonus
 value=1
@@ -74,4 +74,7 @@ name=collectible_cards
 value=0
 [TOGGLE25]
 name=hoo-adjacent-characters-v1
+value=1
+[TOGGLE26]
+name=hoo-remort-v1
 value=1


### PR DESCRIPTION
## Summary
- add `HOO_CAP_REMORT_V1` as capability bit `0x2`
- append server packet `RemortState` at ordinal `202`
- evaluate read-only Remort eligibility from authoritative runtime state
- push state after capability negotiation/login in either ordering
- gate all sends on the negotiated HOO capability and feature toggle
- add focused capability, priority, read-only, and ordinal tests

## Wire format
`RemortState` writes, in order:
1. `Int32 remortCount`
2. `Int16 requiredLevel` from `STAT_MAXELV`
3. `Boolean eligible`
4. `Int8 reason`

Implemented reasons and priority:
`BelowRequiredLevel > Dead > ActiveQuest > InParty > Eligible`.

## Read-only guarantees
This does not increment Remort count, reset progression, mutate quests/party/equipment, execute SQL, or trigger a save. There is no `RequestRemortInfo`, `RequestRemort`, or `RemortResult`.

## Validation
- native VB6 production `PYMMO=1` build passed
- native VB6 unit build passed
- full suite: `291/291`
- protocol ordinal audit passed
- `git diff --check` passed

The pre-existing local `Server.VBP` changes are not part of this PR.