### PR TITLE
Implement HOO Remort operation

### DIFF
--- a/Codigo/Declares.bas
+++ b/Codigo/Declares.bas
@@ -2987,6 +2987,8 @@ Public Enum e_RemortEligibilityReason
     eRemortEligibility_Dead = 2
     eRemortEligibility_ActiveQuest = 3
     eRemortEligibility_InParty = 4
+    eRemortEligibility_InvalidEquipment = 5
+    eRemortEligibility_RemortLimitReached = 6
 End Enum
 
 Public Type t_HooClientCapabilities

--- a/Codigo/PacketId.bas
+++ b/Codigo/PacketId.bas
@@ -226,6 +226,7 @@ Public Enum ServerPacketID
     eGuildConfig
     eShowPickUpObj
     eRemortState
+    eRemortResult
     eMaxPacket
     [PacketCount]
 End Enum
@@ -549,6 +550,7 @@ Public Enum ClientPacketID
     eAntiMacroMessage
     eModifyCastleWhiteList
     eHooClientCapabilities
+    eRequestRemort
     eMaxPacket
     [PacketCount]
 End Enum

--- a/Codigo/Protocol.bas
+++ b/Codigo/Protocol.bas
@@ -911,6 +911,8 @@ Public Function HandleIncomingData(ByVal ConnectionID As Long, ByVal Message As 
             Call HandleModifyCastleWhiteList(UserIndex)
         Case ClientPacketID.eHooClientCapabilities
             Call HandleHooClientCapabilities(UserIndex)
+        Case ClientPacketID.eRequestRemort
+            Call HandleRequestRemort(UserIndex)
             #If PYMMO = 0 Then
             Case ClientPacketID.eCreateAccount
                 Call HandleCreateAccount(ConnectionID)
@@ -981,6 +983,30 @@ Public Function UserHasActiveRemortQuest(ByVal UserIndex As Integer) As Boolean
     Next QuestSlot
 End Function
 
+Public Function IsRemortCompatibleEquipment(ByVal ObjIndex As Integer) As Boolean
+    If ObjIndex < 1 Or ObjIndex > UBound(ObjData) Then Exit Function
+
+    With ObjData(ObjIndex)
+        If .MinELV > 1 Then Exit Function
+        If .MaxLEV > 0 And 1 > .MaxLEV Then Exit Function
+        If .SkillIndex > 0 And .SkillRequerido > 0 Then Exit Function
+    End With
+
+    IsRemortCompatibleEquipment = True
+End Function
+
+Public Function UserHasInvalidRemortEquipment(ByVal UserIndex As Integer) As Boolean
+    Dim Slot As Integer
+    For Slot = 1 To MAX_INVENTORY_SLOTS
+        With UserList(UserIndex).invent.Object(Slot)
+            If .Equipped <> 0 And Not IsRemortCompatibleEquipment(.ObjIndex) Then
+                UserHasInvalidRemortEquipment = True
+                Exit Function
+            End If
+        End With
+    Next Slot
+End Function
+
 Public Function GetRemortEligibility(ByVal UserIndex As Integer) As e_RemortEligibilityReason
     GetRemortEligibility = eRemortEligibility_BelowRequiredLevel
     If UserIndex < 1 Or UserIndex > UBound(UserList) Then Exit Function
@@ -998,8 +1024,57 @@ Public Function GetRemortEligibility(ByVal UserIndex As Integer) As e_RemortElig
             GetRemortEligibility = eRemortEligibility_InParty
             Exit Function
         End If
+        If UserHasInvalidRemortEquipment(UserIndex) Then
+            GetRemortEligibility = eRemortEligibility_InvalidEquipment
+            Exit Function
+        End If
+        If .Stats.RemortCount = 2147483647 Then
+            GetRemortEligibility = eRemortEligibility_RemortLimitReached
+            Exit Function
+        End If
     End With
     GetRemortEligibility = eRemortEligibility_Eligible
+End Function
+
+Public Function ApplyRemortProgression(ByVal UserIndex As Integer) As Boolean
+    If GetRemortEligibility(UserIndex) <> eRemortEligibility_Eligible Then Exit Function
+
+    Dim TargetMaxHp As Integer
+    Dim TargetMaxMana As Integer
+    Dim TargetMaxStamina As Integer
+    Dim SkillIndex As Integer
+
+    With UserList(UserIndex)
+        TargetMaxHp = .Stats.UserAtributos(e_Atributos.Constitucion)
+        TargetMaxMana = .Stats.UserAtributos(e_Atributos.Inteligencia) * ModClase(.clase).ManaInicial
+        TargetMaxStamina = 60
+
+        .Stats.ELV = 1
+        .Stats.Exp = 0
+        For SkillIndex = 1 To NUMSKILLS
+            .Stats.UserSkills(SkillIndex) = 0
+            .Stats.SkillDirty(SkillIndex) = True
+        Next SkillIndex
+        .Stats.SkillPts = 10
+        .flags.ModificoSkills = True
+
+        .Stats.MaxHp = TargetMaxHp
+        .Stats.MinHp = TargetMaxHp
+        .Stats.shield = 0
+        .Stats.MaxMAN = TargetMaxMana
+        .Stats.MinMAN = TargetMaxMana
+        .Stats.MaxSta = TargetMaxStamina
+        .Stats.MinSta = TargetMaxStamina
+        .Stats.MinHIT = 1
+        .Stats.MaxHit = 2
+        .Stats.MaxAGU = 100
+        .Stats.MinAGU = 100
+        .Stats.MaxHam = 100
+        .Stats.MinHam = 100
+        .Stats.RemortCount = .Stats.RemortCount + 1
+    End With
+
+    ApplyRemortProgression = True
 End Function
 
 Public Sub MaybeSendRemortState(ByVal UserIndex As Integer)
@@ -1046,6 +1121,47 @@ Private Sub HandleHooClientCapabilities(ByVal UserIndex As Integer)
 HandleHooClientCapabilities_Err:
     Call ResetHooClientCapabilities(UserIndex)
     Call TraceError(Err.Number, Err.Description, "Protocol.HandleHooClientCapabilities", Erl)
+End Sub
+
+Private Sub HandleRequestRemort(ByVal UserIndex As Integer)
+    On Error GoTo HandleRequestRemort_Err
+
+    If Not UserSupportsRemortState(UserIndex) Then Exit Sub
+
+    Dim Reason As e_RemortEligibilityReason
+    Reason = GetRemortEligibility(UserIndex)
+    If Reason <> eRemortEligibility_Eligible Then
+        Call WriteRemortResult(UserIndex, False, Reason)
+        Call MaybeSendRemortState(UserIndex)
+        Exit Sub
+    End If
+
+    Dim OldLevel As Byte
+    Dim OldRemortCount As Long
+    OldLevel = UserList(UserIndex).Stats.ELV
+    OldRemortCount = UserList(UserIndex).Stats.RemortCount
+
+    If Not ApplyRemortProgression(UserIndex) Then
+        Reason = GetRemortEligibility(UserIndex)
+        Call WriteRemortResult(UserIndex, False, Reason)
+        Call MaybeSendRemortState(UserIndex)
+        Exit Sub
+    End If
+
+    Call WriteUpdateUserStats(UserIndex)
+    Call WriteUpdateHungerAndThirst(UserIndex)
+    Call WriteSendSkills(UserIndex)
+    Call WriteLevelUp(UserIndex, UserList(UserIndex).Stats.SkillPts)
+    Call WriteRemortResult(UserIndex, True, eRemortEligibility_Eligible)
+    Call MaybeSendRemortState(UserIndex)
+    Call LogInfoServidor("Remort: character=" & GetUserRealName(UserIndex) & _
+        " old_level=" & CStr(OldLevel) & _
+        " old_count=" & CStr(OldRemortCount) & _
+        " new_count=" & CStr(UserList(UserIndex).Stats.RemortCount))
+    Exit Sub
+
+HandleRequestRemort_Err:
+    Call TraceError(Err.Number, Err.Description, "Protocol.HandleRequestRemort", Erl)
 End Sub
 
 #If PYMMO = 0 Then

--- a/Codigo/Protocol_Writes.bas
+++ b/Codigo/Protocol_Writes.bas
@@ -121,6 +121,19 @@ WriteRemortState_Err:
     Call TraceError(Err.Number, Err.Description, "Argentum20Server.Protocol_Writes.WriteRemortState", Erl)
 End Sub
 
+Public Sub WriteRemortResult(ByVal UserIndex As Integer, ByVal Success As Boolean, ByVal Reason As e_RemortEligibilityReason)
+    On Error GoTo WriteRemortResult_Err
+    Call Writer.WriteInt16(ServerPacketID.eRemortResult)
+    Call Writer.WriteBool(Success)
+    Call Writer.WriteInt8(CByte(Reason))
+    Call Writer.WriteInt32(UserList(UserIndex).Stats.RemortCount)
+    Call modSendData.SendData(ToIndex, UserIndex)
+    Exit Sub
+WriteRemortResult_Err:
+    Call Writer.Clear
+    Call TraceError(Err.Number, Err.Description, "Argentum20Server.Protocol_Writes.WriteRemortResult", Erl)
+End Sub
+
 Public Sub WriteHora(ByVal UserIndex As Integer)
     On Error GoTo WriteHora_Err
     Call modSendData.SendData(ToIndex, UserIndex, PrepareMessageHora())

--- a/Codigo/UnitTesting.bas
+++ b/Codigo/UnitTesting.bas
@@ -392,6 +392,9 @@ Private Function test_suite_remort_capability_state() As Boolean
     Call RunTest("remort eligibility is read-only", test_remort_eligibility_is_read_only())
     Call RunTest("remort capability bit and reset", test_remort_capability_bit_and_reset())
     Call RunTest("remort packet is appended", CInt(ServerPacketID.eRemortState) = CInt(ServerPacketID.eShowPickUpObj) + 1)
+    Call RunTest("remort operation packet IDs are appended", CInt(ServerPacketID.eRemortResult) = CInt(ServerPacketID.eRemortState) + 1 And CInt(ClientPacketID.eRequestRemort) = CInt(ClientPacketID.eHooClientCapabilities) + 1)
+    Call RunTest("remort equipment and count eligibility", test_remort_equipment_and_count_eligibility())
+    Call RunTest("remort live reset and preservation", test_remort_live_reset_and_preservation())
     test_suite_remort_capability_state = True
 End Function
 
@@ -402,9 +405,18 @@ Private Function test_remort_eligibility_and_priority() As Boolean
     Dim OriginalInParty As Boolean
     Dim OriginalQuests(1 To MAXUSERQUESTS) As Integer
     Dim QuestSlot As Integer
+    Dim OriginalRemortCount As Long
+    Dim OriginalEquipped(1 To MAX_INVENTORY_SLOTS) As Byte
+    Dim InventorySlot As Integer
     OriginalLevel = UserList(1).Stats.ELV
     OriginalDead = UserList(1).flags.Muerto
     OriginalInParty = UserList(1).Grupo.EnGrupo
+    OriginalRemortCount = UserList(1).Stats.RemortCount
+    UserList(1).Stats.RemortCount = 0
+    For InventorySlot = 1 To MAX_INVENTORY_SLOTS
+        OriginalEquipped(InventorySlot) = UserList(1).invent.Object(InventorySlot).Equipped
+        UserList(1).invent.Object(InventorySlot).Equipped = 0
+    Next InventorySlot
     For QuestSlot = 1 To MAXUSERQUESTS
         OriginalQuests(QuestSlot) = UserList(1).QuestStats.Quests(QuestSlot).QuestIndex
         UserList(1).QuestStats.Quests(QuestSlot).QuestIndex = 0
@@ -433,6 +445,10 @@ TestDone:
     UserList(1).Stats.ELV = OriginalLevel
     UserList(1).flags.Muerto = OriginalDead
     UserList(1).Grupo.EnGrupo = OriginalInParty
+    UserList(1).Stats.RemortCount = OriginalRemortCount
+    For InventorySlot = 1 To MAX_INVENTORY_SLOTS
+        UserList(1).invent.Object(InventorySlot).Equipped = OriginalEquipped(InventorySlot)
+    Next InventorySlot
     For QuestSlot = 1 To MAXUSERQUESTS
         UserList(1).QuestStats.Quests(QuestSlot).QuestIndex = OriginalQuests(QuestSlot)
     Next QuestSlot
@@ -507,6 +523,208 @@ TestDone:
     Exit Function
 TestError:
     test_remort_capability_bit_and_reset = False
+    Resume TestDone
+End Function
+
+Private Function test_remort_equipment_and_count_eligibility() As Boolean
+    On Error GoTo TestError
+
+    Dim OriginalLevel As Byte
+    Dim OriginalDead As Byte
+    Dim OriginalInParty As Boolean
+    Dim OriginalCount As Long
+    Dim OriginalEquipped As Byte
+    Dim OriginalObjIndex As Integer
+    Dim OriginalMinLevel As Byte
+    Dim OriginalMaxLevel As Byte
+    Dim OriginalSkillIndex As Byte
+    Dim OriginalSkillRequired As Byte
+    Dim OriginalQuests(1 To MAXUSERQUESTS) As Integer
+    Dim QuestSlot As Integer
+
+    OriginalLevel = UserList(1).Stats.ELV
+    OriginalDead = UserList(1).flags.Muerto
+    OriginalInParty = UserList(1).Grupo.EnGrupo
+    OriginalCount = UserList(1).Stats.RemortCount
+    OriginalEquipped = UserList(1).invent.Object(1).Equipped
+    OriginalObjIndex = UserList(1).invent.Object(1).ObjIndex
+    For QuestSlot = 1 To MAXUSERQUESTS
+        OriginalQuests(QuestSlot) = UserList(1).QuestStats.Quests(QuestSlot).QuestIndex
+        UserList(1).QuestStats.Quests(QuestSlot).QuestIndex = 0
+    Next QuestSlot
+    OriginalMinLevel = ObjData(1).MinELV
+    OriginalMaxLevel = ObjData(1).MaxLEV
+    OriginalSkillIndex = ObjData(1).SkillIndex
+    OriginalSkillRequired = ObjData(1).SkillRequerido
+
+    UserList(1).Stats.ELV = STAT_MAXELV
+    UserList(1).flags.Muerto = 0
+    UserList(1).Grupo.EnGrupo = False
+    UserList(1).QuestStats.Quests(1).QuestIndex = 0
+    UserList(1).Stats.RemortCount = 0
+    UserList(1).invent.Object(1).Equipped = 1
+    UserList(1).invent.Object(1).ObjIndex = 1
+    ObjData(1).MinELV = 2
+    ObjData(1).MaxLEV = 0
+    ObjData(1).SkillIndex = 0
+    ObjData(1).SkillRequerido = 0
+    If GetRemortEligibility(1) <> eRemortEligibility_InvalidEquipment Then GoTo TestDone
+
+    ObjData(1).MinELV = 0
+    ObjData(1).SkillIndex = 1
+    ObjData(1).SkillRequerido = 1
+    If GetRemortEligibility(1) <> eRemortEligibility_InvalidEquipment Then GoTo TestDone
+
+    UserList(1).invent.Object(1).Equipped = 0
+    UserList(1).Stats.RemortCount = 2147483647
+    If GetRemortEligibility(1) <> eRemortEligibility_RemortLimitReached Then GoTo TestDone
+    test_remort_equipment_and_count_eligibility = True
+
+TestDone:
+    UserList(1).Stats.ELV = OriginalLevel
+    UserList(1).flags.Muerto = OriginalDead
+    UserList(1).Grupo.EnGrupo = OriginalInParty
+    UserList(1).Stats.RemortCount = OriginalCount
+    UserList(1).invent.Object(1).Equipped = OriginalEquipped
+    UserList(1).invent.Object(1).ObjIndex = OriginalObjIndex
+    For QuestSlot = 1 To MAXUSERQUESTS
+        UserList(1).QuestStats.Quests(QuestSlot).QuestIndex = OriginalQuests(QuestSlot)
+    Next QuestSlot
+    ObjData(1).MinELV = OriginalMinLevel
+    ObjData(1).MaxLEV = OriginalMaxLevel
+    ObjData(1).SkillIndex = OriginalSkillIndex
+    ObjData(1).SkillRequerido = OriginalSkillRequired
+    Exit Function
+TestError:
+    test_remort_equipment_and_count_eligibility = False
+    Resume TestDone
+End Function
+
+Private Function test_remort_live_reset_and_preservation() As Boolean
+    On Error GoTo TestError
+
+    Dim OriginalLevel As Byte, OriginalDead As Byte, OriginalExp As Long
+    Dim OriginalCount As Long, OriginalSkillPts As Integer, OriginalModified As Boolean
+    Dim OriginalMaxHp As Integer, OriginalMinHp As Integer, OriginalShield As Long
+    Dim OriginalMaxMana As Integer, OriginalMinMana As Integer
+    Dim OriginalMaxSta As Integer, OriginalMinSta As Integer
+    Dim OriginalMaxHit As Integer, OriginalMinHit As Integer
+    Dim OriginalMaxWater As Integer, OriginalMinWater As Integer
+    Dim OriginalMaxHunger As Integer, OriginalMinHunger As Integer
+    Dim OriginalGold As Long, OriginalBankGold As Long, OriginalSpell As Integer
+    Dim OriginalGuild As Integer, OriginalClass As e_Class
+    Dim OriginalConstitution As Byte, OriginalIntelligence As Byte
+    Dim OriginalParty As Boolean
+    Dim OriginalQuests(1 To MAXUSERQUESTS) As Integer
+    Dim QuestSlot As Integer
+    Dim OriginalSkills(1 To NUMSKILLS) As Byte
+    Dim OriginalDirty(1 To NUMSKILLS) As Boolean
+    Dim OriginalEquipped(1 To MAX_INVENTORY_SLOTS) As Byte
+    Dim SkillIndex As Integer, Slot As Integer
+
+    With UserList(1)
+        OriginalLevel = .Stats.ELV
+        OriginalDead = .flags.Muerto
+        OriginalExp = .Stats.Exp
+        OriginalCount = .Stats.RemortCount
+        OriginalSkillPts = .Stats.SkillPts
+        OriginalModified = .flags.ModificoSkills
+        OriginalMaxHp = .Stats.MaxHp: OriginalMinHp = .Stats.MinHp: OriginalShield = .Stats.shield
+        OriginalMaxMana = .Stats.MaxMAN: OriginalMinMana = .Stats.MinMAN
+        OriginalMaxSta = .Stats.MaxSta: OriginalMinSta = .Stats.MinSta
+        OriginalMaxHit = .Stats.MaxHit: OriginalMinHit = .Stats.MinHIT
+        OriginalMaxWater = .Stats.MaxAGU: OriginalMinWater = .Stats.MinAGU
+        OriginalMaxHunger = .Stats.MaxHam: OriginalMinHunger = .Stats.MinHam
+        OriginalGold = .Stats.GLD: OriginalBankGold = .Stats.Banco
+        OriginalSpell = .Stats.UserHechizos(1): OriginalGuild = .GuildIndex
+        OriginalClass = .clase
+        OriginalConstitution = .Stats.UserAtributos(e_Atributos.Constitucion)
+        OriginalIntelligence = .Stats.UserAtributos(e_Atributos.Inteligencia)
+        OriginalParty = .Grupo.EnGrupo
+        For QuestSlot = 1 To MAXUSERQUESTS
+            OriginalQuests(QuestSlot) = .QuestStats.Quests(QuestSlot).QuestIndex
+            .QuestStats.Quests(QuestSlot).QuestIndex = 0
+        Next QuestSlot
+        For SkillIndex = 1 To NUMSKILLS
+            OriginalSkills(SkillIndex) = .Stats.UserSkills(SkillIndex)
+            OriginalDirty(SkillIndex) = .Stats.SkillDirty(SkillIndex)
+            .Stats.UserSkills(SkillIndex) = 75
+            .Stats.SkillDirty(SkillIndex) = False
+        Next SkillIndex
+        For Slot = 1 To MAX_INVENTORY_SLOTS
+            OriginalEquipped(Slot) = .invent.Object(Slot).Equipped
+            .invent.Object(Slot).Equipped = 0
+        Next Slot
+        .clase = e_Class.Mage
+        .Stats.UserAtributos(e_Atributos.Constitucion) = 18
+        .Stats.UserAtributos(e_Atributos.Inteligencia) = 18
+        .Stats.ELV = STAT_MAXELV
+        .flags.Muerto = 0
+        .Grupo.EnGrupo = False
+        .Stats.Exp = 123456
+        .Stats.SkillPts = 99
+        .Stats.MaxHp = 500: .Stats.MinHp = 250: .Stats.shield = 50
+        .Stats.MaxMAN = 500: .Stats.MinMAN = 250
+        .Stats.MaxSta = 500: .Stats.MinSta = 250
+        .Stats.MaxHit = 100: .Stats.MinHIT = 90
+        .Stats.MaxAGU = 25: .Stats.MinAGU = 10
+        .Stats.MaxHam = 25: .Stats.MinHam = 10
+        .Stats.RemortCount = 3
+        .Stats.GLD = 12345: .Stats.Banco = 23456
+        .Stats.UserHechizos(1) = 42
+        .GuildIndex = 7
+    End With
+
+    If Not ApplyRemortProgression(1) Then GoTo TestDone
+    With UserList(1)
+        If .Stats.ELV <> 1 Or .Stats.Exp <> 0 Or .Stats.RemortCount <> 4 Then GoTo TestDone
+        If .Stats.SkillPts <> 10 Then GoTo TestDone
+        If .Stats.MaxHp <> 18 Or .Stats.MinHp <> 18 Or .Stats.shield <> 0 Then GoTo TestDone
+        If .Stats.MaxMAN <> CInt(18 * ModClase(.clase).ManaInicial) Or .Stats.MinMAN <> .Stats.MaxMAN Then GoTo TestDone
+        If .Stats.MaxSta <> 60 Or .Stats.MinSta <> 60 Then GoTo TestDone
+        If .Stats.MinHIT <> 1 Or .Stats.MaxHit <> 2 Then GoTo TestDone
+        If .Stats.MinAGU <> 100 Or .Stats.MinHam <> 100 Then GoTo TestDone
+        For SkillIndex = 1 To NUMSKILLS
+            If .Stats.UserSkills(SkillIndex) <> 0 Or Not .Stats.SkillDirty(SkillIndex) Then GoTo TestDone
+        Next SkillIndex
+        If .Stats.GLD <> 12345 Or .Stats.Banco <> 23456 Then GoTo TestDone
+        If .Stats.UserHechizos(1) <> 42 Or .GuildIndex <> 7 Then GoTo TestDone
+    End With
+    If ApplyRemortProgression(1) Then GoTo TestDone
+    If UserList(1).Stats.RemortCount <> 4 Then GoTo TestDone
+    test_remort_live_reset_and_preservation = True
+
+TestDone:
+    With UserList(1)
+        .Stats.ELV = OriginalLevel: .flags.Muerto = OriginalDead: .Stats.Exp = OriginalExp
+        .Stats.RemortCount = OriginalCount: .Stats.SkillPts = OriginalSkillPts
+        .flags.ModificoSkills = OriginalModified
+        .Stats.MaxHp = OriginalMaxHp: .Stats.MinHp = OriginalMinHp: .Stats.shield = OriginalShield
+        .Stats.MaxMAN = OriginalMaxMana: .Stats.MinMAN = OriginalMinMana
+        .Stats.MaxSta = OriginalMaxSta: .Stats.MinSta = OriginalMinSta
+        .Stats.MaxHit = OriginalMaxHit: .Stats.MinHIT = OriginalMinHit
+        .Stats.MaxAGU = OriginalMaxWater: .Stats.MinAGU = OriginalMinWater
+        .Stats.MaxHam = OriginalMaxHunger: .Stats.MinHam = OriginalMinHunger
+        .Stats.GLD = OriginalGold: .Stats.Banco = OriginalBankGold
+        .Stats.UserHechizos(1) = OriginalSpell: .GuildIndex = OriginalGuild
+        .clase = OriginalClass
+        .Stats.UserAtributos(e_Atributos.Constitucion) = OriginalConstitution
+        .Stats.UserAtributos(e_Atributos.Inteligencia) = OriginalIntelligence
+        .Grupo.EnGrupo = OriginalParty
+        For QuestSlot = 1 To MAXUSERQUESTS
+            .QuestStats.Quests(QuestSlot).QuestIndex = OriginalQuests(QuestSlot)
+        Next QuestSlot
+        For SkillIndex = 1 To NUMSKILLS
+            .Stats.UserSkills(SkillIndex) = OriginalSkills(SkillIndex)
+            .Stats.SkillDirty(SkillIndex) = OriginalDirty(SkillIndex)
+        Next SkillIndex
+        For Slot = 1 To MAX_INVENTORY_SLOTS
+            .invent.Object(Slot).Equipped = OriginalEquipped(Slot)
+        Next Slot
+    End With
+    Exit Function
+TestError:
+    test_remort_live_reset_and_preservation = False
     Resume TestDone
 End Function
 


### PR DESCRIPTION
## Summary
- Handle the payload-free RequestRemort packet behind HOO_CAP_REMORT_V1.
- Re-evaluate authoritative eligibility when each request arrives.
- Reject incompatible equipped items and Remort-count overflow.
- Reset progression live in server memory and increment RemortCount.
- Send normal character-state packets, RemortResult, and refreshed RemortState.

## Reset policy
The operation resets level, XP, skills, free skill points, vitals, hit modifiers, hunger, and thirst to canonical level-1 state. It preserves identity, inventory, bank, gold, learned spells, completed quests, guild, faction, and unrelated long-term progression.

## Persistence
The request handler performs no SQL and triggers no special save. Existing autosave and logout persistence store the resulting authoritative runtime state.

## Safety
- Capability and server feature toggle are required.
- Current eligibility is revalidated.
- Active quests and party membership remain blockers.
- Incompatible equipment must be removed first.
- Duplicate sequential requests cannot increment twice because the first request lowers the character to level 1.

## Validation
- VB6 unit build passed.
- 294 / 294 tests passed.
- Production-style PYMMO=1 build passed.
- git diff --check passed.

## Coordination
Requires matching ProtocolGenerator, legacy-client packet-definition, and HOO Phase 3 PRs.