### PR TITLE
Keep NPC respawns on their original map

### DIFF
--- a/Codigo/MODULO_NPCs.bas
+++ b/Codigo/MODULO_NPCs.bas
@@ -252,7 +252,7 @@ Sub MuereNpc(ByVal NpcIndex As Integer, ByVal UserIndex As Integer)
             .RespawnFlag = MiNPC.flags.Respawn
             .NpcNumber = MiNPC.Numero
             .SndRespawn = MiNPC.flags.SndRespawn
-            .SpawnMap = MiNPC.pos.Map
+            .SpawnMap = NpcRespawnMap(MiNPC)
             .Orig = MiNPC.Orig
             .IntervaloRespawn = MiNPC.Contadores.IntervaloRespawn
         End With
@@ -893,9 +893,13 @@ SpawnNpc_Err:
     Call TraceError(Err.Number, Err.Description, "NPCs.SpawnNpc", Erl)
 End Function
 
+Public Function NpcRespawnMap(ByRef npc As t_Npc) As Integer
+    NpcRespawnMap = npc.Orig.Map
+End Function
+
 Sub ReSpawnNpc(MiNPC As t_Npc)
     On Error GoTo ReSpawnNpc_Err
-    If (MiNPC.flags.Respawn = 0) Then Call CrearNPC(MiNPC.Numero, MiNPC.pos.Map, MiNPC.Orig)
+    If (MiNPC.flags.Respawn = 0) Then Call CrearNPC(MiNPC.Numero, NpcRespawnMap(MiNPC), MiNPC.Orig)
     Exit Sub
 ReSpawnNpc_Err:
     Call TraceError(Err.Number, Err.Description, "NPCs.ReSpawnNpc", Erl)

--- a/Codigo/Tests/Unit_NpcCrossMapPursuit.bas
+++ b/Codigo/Tests/Unit_NpcCrossMapPursuit.bas
@@ -18,6 +18,7 @@ Public Function test_suite_npc_cross_map_pursuit() As Boolean
     Call UnitTesting.RunTest("npc spatial transition retains existing target only", test_target_retention())
     Call UnitTesting.RunTest("npc combat rejects targets on another map", test_cross_map_combat_guard())
     Call UnitTesting.RunTest("npc cross-map route keeps AI active on empty map", test_route_keeps_ai_active())
+    Call UnitTesting.RunTest("npc respawn keeps original spawn map", test_respawn_uses_original_map())
     Call LoadAdjacentTopology
     test_suite_npc_cross_map_pursuit = True
 End Function
@@ -37,6 +38,13 @@ Private Function test_safe_destination_allowed() As Boolean
 
 Cleanup:
     Call SetFeatureToggle(NPC_CROSS_MAP_PURSUIT_FEATURE, originalToggle)
+End Function
+
+Private Function test_respawn_uses_original_map() As Boolean
+    Dim npc As t_Npc
+    npc.Orig.Map = 34
+    npc.pos.Map = 35
+    test_respawn_uses_original_map = (NpcRespawnMap(npc) = 34)
 End Function
 
 Private Function test_safe_destination_blocked() As Boolean


### PR DESCRIPTION
## Summary

Ensures NPCs that cross maps while pursuing a player always respawn on the map where they originally spawned.

## Root cause

Cross-map pursuit updates `NpcList(...).pos.Map` while correctly preserving `NpcList(...).Orig.Map`. Both NPC respawn paths were nevertheless using the current position map:

- immediate respawn passed `MiNPC.pos.Map` to `CrearNPC`
- delayed respawn stored `MiNPC.pos.Map` in the respawn queue

If an NPC died on a map reached during pursuit, that chase map became its respawn map.

## Implementation

- Added `NpcRespawnMap`, which derives the respawn map exclusively from `Npc.Orig.Map`.
- Immediate respawn now creates the NPC on that original map.
- Delayed respawn queue now records that same original map.
- Existing `OrigPos` behavior is preserved: NPCs configured for exact-position respawn return to the original tile; other NPCs select a legal position on the original map.
- Cross-map pursuit and return-home behavior are otherwise unchanged.

## Validation

- Windows VB6 unit build: passed
- Full server suite: **310/310 passed**
- Production-style `PYMMO=1` VB6 build: passed
- `git diff --check`: passed

## Compatibility

No protocol, client, database, map, or configuration changes.