### PR TITLE
Add authoritative HOO targeted spell casting

### DIFF
--- a/Codigo/Declares.bas
+++ b/Codigo/Declares.bas
@@ -1912,7 +1912,7 @@ Public Enum e_DamageResult
     eDead
 End Enum
 
-Public Const MAX_PACKET_COUNTERS As Long = 16
+Public Const MAX_PACKET_COUNTERS As Long = 17
 
 Public Enum PacketNames
     CastSpell = 1
@@ -1931,6 +1931,7 @@ Public Enum PacketNames
     QuestionGM
     ChangeHeading
     Hide
+    TargetedSpellCast
 End Enum
 
 Public Type t_UserOBJ
@@ -2978,8 +2979,19 @@ Public Const HotKeyCount As Integer = 10
 Public Const HOO_CAP_PROTOCOL_VERSION As Byte = 1
 Public Const HOO_CAP_ADJACENT_CHARACTERS_V1 As Long = &H1&
 Public Const HOO_CAP_REMORT_V1 As Long = &H2&
+Public Const HOO_CAP_TARGETED_SPELL_CAST_V1 As Long = &H4&
 Public Const HOO_FEATURE_ADJACENT_CHARACTERS_V1 As String = "hoo-adjacent-characters-v1"
 Public Const HOO_FEATURE_REMORT_V1 As String = "hoo-remort-v1"
+Public Const HOO_FEATURE_TARGETED_SPELL_CAST_V1 As String = "hoo-targeted-spell-cast-v1"
+
+Public Enum e_HooTargetedSpellCastResult
+    eHooTargetedSpellCastResult_Success = 0
+    eHooTargetedSpellCastResult_RateLimited = 1
+    eHooTargetedSpellCastResult_OutOfRange = 2
+    eHooTargetedSpellCastResult_InvalidTarget = 3
+    eHooTargetedSpellCastResult_InvalidSpell = 4
+    eHooTargetedSpellCastResult_Rejected = 5
+End Enum
 
 Public Enum e_RemortEligibilityReason
     eRemortEligibility_Eligible = 0

--- a/Codigo/PacketId.bas
+++ b/Codigo/PacketId.bas
@@ -227,6 +227,7 @@ Public Enum ServerPacketID
     eShowPickUpObj
     eRemortState
     eRemortResult
+    eHooTargetedSpellCastResult
     eMaxPacket
     [PacketCount]
 End Enum
@@ -551,6 +552,7 @@ Public Enum ClientPacketID
     eModifyCastleWhiteList
     eHooClientCapabilities
     eRequestRemort
+    eHooTargetedSpellCast
     eMaxPacket
     [PacketCount]
 End Enum

--- a/Codigo/Protocol.bas
+++ b/Codigo/Protocol.bas
@@ -933,6 +933,8 @@ Public Function HandleIncomingData(ByVal ConnectionID As Long, ByVal Message As 
             Call HandleHooClientCapabilities(UserIndex)
         Case ClientPacketID.eRequestRemort
             Call HandleRequestRemort(UserIndex)
+        Case ClientPacketID.eHooTargetedSpellCast
+            Call HandleHooTargetedSpellCast(UserIndex)
             #If PYMMO = 0 Then
             Case ClientPacketID.eCreateAccount
                 Call HandleCreateAccount(ConnectionID)
@@ -991,6 +993,118 @@ End Function
 Public Function UserSupportsRemortState(ByVal UserIndex As Integer) As Boolean
     UserSupportsRemortState = IsFeatureEnabled(HOO_FEATURE_REMORT_V1) And _
         UserSupportsHooCapability(UserIndex, HOO_CAP_REMORT_V1)
+End Function
+
+Public Function UserSupportsHooTargetedSpellCast(ByVal UserIndex As Integer) As Boolean
+    UserSupportsHooTargetedSpellCast = IsFeatureEnabled(HOO_FEATURE_TARGETED_SPELL_CAST_V1) And _
+        UserSupportsHooCapability(UserIndex, HOO_CAP_TARGETED_SPELL_CAST_V1)
+End Function
+
+Public Function ResolveHooTargetedSpellNpc(ByVal TargetCharacterIndex As Integer) As Integer
+    If TargetCharacterIndex < LBound(CharList) Or TargetCharacterIndex > UBound(CharList) Then Exit Function
+    Dim NpcIndex As Integer
+    NpcIndex = CharList(TargetCharacterIndex)
+    If NpcIndex < LBound(NpcList) Or NpcIndex > UBound(NpcList) Then Exit Function
+    With NpcList(NpcIndex)
+        If Not .flags.NPCActive Then Exit Function
+        If .Stats.MinHp <= 0 Then Exit Function
+        If .Char.charindex <> TargetCharacterIndex Then Exit Function
+    End With
+    ResolveHooTargetedSpellNpc = NpcIndex
+End Function
+
+Public Function IsHooTargetedSpellEligible(ByVal UserIndex As Integer, ByVal SpellSlot As Integer) As Boolean
+    If UserIndex < LBound(UserList) Or UserIndex > UBound(UserList) Then Exit Function
+    If SpellSlot < 1 Or SpellSlot > MAXUSERHECHIZOS Then Exit Function
+    Dim SpellIndex As Integer
+    SpellIndex = UserList(UserIndex).Stats.UserHechizos(SpellSlot)
+    If SpellIndex < LBound(Hechizos) Or SpellIndex > UBound(Hechizos) Then Exit Function
+    With Hechizos(SpellIndex)
+        If .AutoLanzar <> 0 Then Exit Function
+        If .AreaRadio <> 0 Or .AreaAfecta <> 0 Then Exit Function
+        If .Target <> e_TargetType.uNPC And .Target <> e_TargetType.uUsuariosYnpc Then Exit Function
+        If .TargetEffectType <> e_TargetEffectType.eNegative Then Exit Function
+        If .Tipo <> e_TipoHechizo.uEstado And .Tipo <> e_TipoHechizo.uPropiedades And _
+                .Tipo <> e_TipoHechizo.uPhysicalSkill Then Exit Function
+    End With
+    IsHooTargetedSpellEligible = True
+End Function
+
+Public Function IsHooTargetedSpellTargetInRange(ByVal UserIndex As Integer, ByVal NpcIndex As Integer) As Boolean
+    With NpcList(NpcIndex).pos
+        If Not InRangoVision(UserIndex, .x, .y) Then Exit Function
+        If Abs(.x - UserList(UserIndex).pos.x) > RANGO_VISION_X Or _
+                Abs(.y - UserList(UserIndex).pos.y) > RANGO_VISION_Y Then Exit Function
+    End With
+    IsHooTargetedSpellTargetInRange = True
+End Function
+
+Private Sub RestoreHooTargetedSpellState(ByVal UserIndex As Integer, ByVal OldSpell As Integer, ByRef OldTargetNpc As t_NpcReference, ByRef OldTargetUser As t_UserReference)
+    With UserList(UserIndex).flags
+        .Hechizo = OldSpell
+        Call ClearNpcRef(.TargetNPC)
+        Call ClearUserRef(.TargetUser)
+        If IsValidNpcRef(OldTargetNpc) Then Call SetNpcRef(.TargetNPC, OldTargetNpc.ArrayIndex)
+        If IsValidUserRef(OldTargetUser) Then Call SetUserRef(.TargetUser, OldTargetUser.ArrayIndex)
+    End With
+End Sub
+
+Public Function ExecuteHooTargetedSpellCast(ByVal UserIndex As Integer, ByVal SpellSlot As Integer, ByVal TargetCharacterIndex As Integer, ByRef RetryAfterMs As Long) As e_HooTargetedSpellCastResult
+    On Error GoTo ExecuteHooTargetedSpellCast_Err
+    ExecuteHooTargetedSpellCast = eHooTargetedSpellCastResult_InvalidTarget
+    Dim NpcIndex As Integer
+    NpcIndex = ResolveHooTargetedSpellNpc(TargetCharacterIndex)
+    If NpcIndex = 0 Then Exit Function
+    If NpcList(NpcIndex).pos.Map <> UserList(UserIndex).pos.Map Then Exit Function
+    If Not IsHooTargetedSpellEligible(UserIndex, SpellSlot) Then
+        ExecuteHooTargetedSpellCast = eHooTargetedSpellCastResult_InvalidSpell
+        Exit Function
+    End If
+    If Not IsHooTargetedSpellTargetInRange(UserIndex, NpcIndex) Then
+        ExecuteHooTargetedSpellCast = eHooTargetedSpellCastResult_OutOfRange
+        Exit Function
+    End If
+    RetryAfterMs = HooTargetedSpellCastRetryAfterMs(UserIndex)
+    If RetryAfterMs > 0 Then
+        ExecuteHooTargetedSpellCast = eHooTargetedSpellCastResult_RateLimited
+        Exit Function
+    End If
+    If Not IntervaloPermiteUsarArcos(UserIndex, False) Then GoTo RateLimited
+    If Not IntervaloPermiteGolpeMagia(UserIndex, False) Then GoTo RateLimited
+    If Not IntervaloPermiteLanzarSpell(UserIndex) Then GoTo RateLimited
+
+    Dim OldSpell As Integer
+    Dim OldTargetNpc As t_NpcReference
+    Dim OldTargetUser As t_UserReference
+    Dim SnapshotTaken As Boolean
+    OldSpell = UserList(UserIndex).flags.Hechizo
+    OldTargetNpc = UserList(UserIndex).flags.TargetNPC
+    OldTargetUser = UserList(UserIndex).flags.TargetUser
+    SnapshotTaken = True
+    UserList(UserIndex).flags.Hechizo = SpellSlot
+    Call ClearUserRef(UserList(UserIndex).flags.TargetUser)
+    If Not SetNpcRef(UserList(UserIndex).flags.TargetNPC, NpcIndex) Then GoTo RestoreRejected
+    UserList(UserIndex).Counters.controlHechizos.HechizosTotales = UserList(UserIndex).Counters.controlHechizos.HechizosTotales + 1
+    If LanzarHechizo(SpellSlot, UserIndex) Then
+        ExecuteHooTargetedSpellCast = eHooTargetedSpellCastResult_Success
+    Else
+RestoreRejected:
+        ExecuteHooTargetedSpellCast = eHooTargetedSpellCastResult_Rejected
+    End If
+    Call RestoreHooTargetedSpellState(UserIndex, OldSpell, OldTargetNpc, OldTargetUser)
+    Exit Function
+
+RateLimited:
+    RetryAfterMs = HooTargetedSpellCastRetryAfterMs(UserIndex)
+    If RetryAfterMs < 1 Then RetryAfterMs = 1
+    ExecuteHooTargetedSpellCast = eHooTargetedSpellCastResult_RateLimited
+    Exit Function
+ExecuteHooTargetedSpellCast_Err:
+    If SnapshotTaken Then
+        Call RestoreHooTargetedSpellState(UserIndex, OldSpell, OldTargetNpc, OldTargetUser)
+    End If
+    ExecuteHooTargetedSpellCast = eHooTargetedSpellCastResult_Rejected
+    Call TraceError(Err.Number, Err.Description, "Protocol.ExecuteHooTargetedSpellCast", Erl)
 End Function
 
 Public Function UserHasActiveRemortQuest(ByVal UserIndex As Integer) As Boolean
@@ -1113,6 +1227,9 @@ Public Function AcceptedHooCapabilityMask(ByVal ProtocolVersion As Byte, ByVal R
     If IsFeatureEnabled(HOO_FEATURE_REMORT_V1) Then
         SupportedMask = SupportedMask Or HOO_CAP_REMORT_V1
     End If
+    If IsFeatureEnabled(HOO_FEATURE_TARGETED_SPELL_CAST_V1) Then
+        SupportedMask = SupportedMask Or HOO_CAP_TARGETED_SPELL_CAST_V1
+    End If
     AcceptedHooCapabilityMask = RequestedMask And SupportedMask
 End Function
 
@@ -1141,6 +1258,29 @@ Private Sub HandleHooClientCapabilities(ByVal UserIndex As Integer)
 HandleHooClientCapabilities_Err:
     Call ResetHooClientCapabilities(UserIndex)
     Call TraceError(Err.Number, Err.Description, "Protocol.HandleHooClientCapabilities", Erl)
+End Sub
+
+Private Sub HandleHooTargetedSpellCast(ByVal UserIndex As Integer)
+    On Error GoTo HandleHooTargetedSpellCast_Err
+    Dim SpellSlot As Byte
+    Dim TargetCharacterIndex As Integer
+    Dim RequestId As Long
+    SpellSlot = reader.ReadInt8
+    TargetCharacterIndex = reader.ReadInt16
+    RequestId = reader.ReadInt32
+    If Not UserSupportsHooTargetedSpellCast(UserIndex) Then
+        Call LogSecurity("Rejected HOO targeted spell cast without negotiated capability; user=" & CStr(UserIndex))
+        Exit Sub
+    End If
+    If Not VerifyPacketSequence(RequestId, UserList(UserIndex).PacketCounters(PacketNames.TargetedSpellCast), UserIndex, "HooTargetedSpellCast") Then Exit Sub
+
+    Dim RetryAfterMs As Long
+    Dim Result As e_HooTargetedSpellCastResult
+    Result = ExecuteHooTargetedSpellCast(UserIndex, CInt(SpellSlot), TargetCharacterIndex, RetryAfterMs)
+    Call WriteHooTargetedSpellCastResult(UserIndex, RequestId, Result, RetryAfterMs)
+    Exit Sub
+HandleHooTargetedSpellCast_Err:
+    Call TraceError(Err.Number, Err.Description, "Protocol.HandleHooTargetedSpellCast", Erl)
 End Sub
 
 Private Sub HandleRequestRemort(ByVal UserIndex As Integer)

--- a/Codigo/Protocol_Writes.bas
+++ b/Codigo/Protocol_Writes.bas
@@ -134,6 +134,19 @@ WriteRemortResult_Err:
     Call TraceError(Err.Number, Err.Description, "Argentum20Server.Protocol_Writes.WriteRemortResult", Erl)
 End Sub
 
+Public Sub WriteHooTargetedSpellCastResult(ByVal UserIndex As Integer, ByVal RequestId As Long, ByVal Result As e_HooTargetedSpellCastResult, ByVal RetryAfterMs As Long)
+    On Error GoTo WriteHooTargetedSpellCastResult_Err
+    Call Writer.WriteInt16(ServerPacketID.eHooTargetedSpellCastResult)
+    Call Writer.WriteInt32(RequestId)
+    Call Writer.WriteInt8(CByte(Result))
+    Call Writer.WriteInt32(RetryAfterMs)
+    Call modSendData.SendData(ToIndex, UserIndex)
+    Exit Sub
+WriteHooTargetedSpellCastResult_Err:
+    Call Writer.Clear
+    Call TraceError(Err.Number, Err.Description, "Argentum20Server.Protocol_Writes.WriteHooTargetedSpellCastResult", Erl)
+End Sub
+
 Public Sub WriteHora(ByVal UserIndex As Integer)
     On Error GoTo WriteHora_Err
     Call modSendData.SendData(ToIndex, UserIndex, PrepareMessageHora())

--- a/Codigo/UnitTesting.bas
+++ b/Codigo/UnitTesting.bas
@@ -394,9 +394,283 @@ Private Function test_suite_remort_capability_state() As Boolean
     Call RunTest("remort capability bit and reset", test_remort_capability_bit_and_reset())
     Call RunTest("remort packet is appended", CInt(ServerPacketID.eRemortState) = CInt(ServerPacketID.eShowPickUpObj) + 1)
     Call RunTest("remort operation packet IDs are appended", CInt(ServerPacketID.eRemortResult) = CInt(ServerPacketID.eRemortState) + 1 And CInt(ClientPacketID.eRequestRemort) = CInt(ClientPacketID.eHooClientCapabilities) + 1)
+    Call RunTest("targeted spell packet IDs are appended", CInt(ServerPacketID.eHooTargetedSpellCastResult) = CInt(ServerPacketID.eRemortResult) + 1 And CInt(ClientPacketID.eHooTargetedSpellCast) = CInt(ClientPacketID.eRequestRemort) + 1)
+    Call RunTest("targeted spell capability and feature gate", test_targeted_spell_capability())
+    Call RunTest("targeted spell retry interval is wrap safe", test_targeted_spell_retry_interval())
+    Call RunTest("targeted spell NPC resolution rejects stale mappings", test_targeted_spell_target_resolution())
+    Call RunTest("targeted spell eligibility rejects unsupported spells", test_targeted_spell_eligibility())
+    Call RunTest("targeted spell range matches legacy vision boundaries", test_targeted_spell_range_boundaries())
+    Call RunTest("targeted spell early rejections are read-only", test_targeted_spell_early_rejections())
     Call RunTest("remort equipment and count eligibility", test_remort_equipment_and_count_eligibility())
     Call RunTest("remort live reset and preservation", test_remort_live_reset_and_preservation())
     test_suite_remort_capability_state = True
+End Function
+
+Private Function test_targeted_spell_range_boundaries() As Boolean
+    On Error GoTo TestError
+    Dim OriginalUserX As Byte
+    Dim OriginalUserY As Byte
+    Dim OriginalNpcX As Byte
+    Dim OriginalNpcY As Byte
+    OriginalUserX = UserList(1).pos.x
+    OriginalUserY = UserList(1).pos.y
+    OriginalNpcX = NpcList(1).pos.x
+    OriginalNpcY = NpcList(1).pos.y
+
+    UserList(1).pos.x = 50
+    UserList(1).pos.y = 50
+
+    NpcList(1).pos.x = 61: NpcList(1).pos.y = 50
+    If Not IsHooTargetedSpellTargetInRange(1, 1) Then GoTo TestDone
+    NpcList(1).pos.x = 39
+    If Not IsHooTargetedSpellTargetInRange(1, 1) Then GoTo TestDone
+    NpcList(1).pos.x = 62
+    If IsHooTargetedSpellTargetInRange(1, 1) Then GoTo TestDone
+    NpcList(1).pos.x = 38
+    If IsHooTargetedSpellTargetInRange(1, 1) Then GoTo TestDone
+
+    NpcList(1).pos.x = 50: NpcList(1).pos.y = 59
+    If Not IsHooTargetedSpellTargetInRange(1, 1) Then GoTo TestDone
+    NpcList(1).pos.y = 41
+    If Not IsHooTargetedSpellTargetInRange(1, 1) Then GoTo TestDone
+    NpcList(1).pos.y = 60
+    If IsHooTargetedSpellTargetInRange(1, 1) Then GoTo TestDone
+    NpcList(1).pos.y = 40
+    If IsHooTargetedSpellTargetInRange(1, 1) Then GoTo TestDone
+
+    NpcList(1).pos.x = 61: NpcList(1).pos.y = 59
+    If Not IsHooTargetedSpellTargetInRange(1, 1) Then GoTo TestDone
+    NpcList(1).pos.x = 62
+    If IsHooTargetedSpellTargetInRange(1, 1) Then GoTo TestDone
+    NpcList(1).pos.x = 61: NpcList(1).pos.y = 60
+    If IsHooTargetedSpellTargetInRange(1, 1) Then GoTo TestDone
+
+    test_targeted_spell_range_boundaries = True
+TestDone:
+    UserList(1).pos.x = OriginalUserX
+    UserList(1).pos.y = OriginalUserY
+    NpcList(1).pos.x = OriginalNpcX
+    NpcList(1).pos.y = OriginalNpcY
+    Exit Function
+TestError:
+    test_targeted_spell_range_boundaries = False
+    Resume TestDone
+End Function
+
+Private Function test_targeted_spell_early_rejections() As Boolean
+    On Error GoTo TestError
+    Dim OriginalMapping As Integer
+    Dim OriginalActive As Boolean
+    Dim OriginalHp As Integer
+    Dim OriginalCharIndex As Integer
+    Dim OriginalNpcMap As Integer
+    Dim OriginalNpcX As Byte
+    Dim OriginalNpcY As Byte
+    Dim OriginalUserMap As Integer
+    Dim OriginalUserX As Byte
+    Dim OriginalUserY As Byte
+    Dim OriginalSpellIndex As Integer
+    Dim OriginalAuto As Byte
+    Dim OriginalAreaRadio As Long
+    Dim OriginalAreaAfecta As Integer
+    Dim OriginalTarget As e_TargetType
+    Dim OriginalEffect As e_TargetEffectType
+    Dim OriginalType As e_TipoHechizo
+    Dim OriginalBowTimer As Long
+    Dim OriginalHitMagicTimer As Long
+    Dim OriginalMagicTimer As Long
+    OriginalMapping = CharList(1)
+    OriginalActive = NpcList(1).flags.NPCActive
+    OriginalHp = NpcList(1).Stats.MinHp
+    OriginalCharIndex = NpcList(1).Char.charindex
+    OriginalNpcMap = NpcList(1).pos.Map
+    OriginalNpcX = NpcList(1).pos.x
+    OriginalNpcY = NpcList(1).pos.y
+    OriginalUserMap = UserList(1).pos.Map
+    OriginalUserX = UserList(1).pos.x
+    OriginalUserY = UserList(1).pos.y
+    OriginalSpellIndex = UserList(1).Stats.UserHechizos(1)
+    OriginalAuto = Hechizos(1).AutoLanzar
+    OriginalAreaRadio = Hechizos(1).AreaRadio
+    OriginalAreaAfecta = Hechizos(1).AreaAfecta
+    OriginalTarget = Hechizos(1).Target
+    OriginalEffect = Hechizos(1).TargetEffectType
+    OriginalType = Hechizos(1).Tipo
+    OriginalBowTimer = UserList(1).Counters.TimerPuedeUsarArco
+    OriginalHitMagicTimer = UserList(1).Counters.TimerGolpeMagia
+    OriginalMagicTimer = UserList(1).Counters.TimerLanzarSpell
+
+    CharList(1) = 1
+    NpcList(1).flags.NPCActive = True
+    NpcList(1).Stats.MinHp = 10
+    NpcList(1).Char.charindex = 1
+    NpcList(1).pos.Map = 1
+    NpcList(1).pos.x = 20
+    NpcList(1).pos.y = 20
+    UserList(1).pos.Map = 1
+    UserList(1).pos.x = 20
+    UserList(1).pos.y = 20
+    UserList(1).Stats.UserHechizos(1) = 1
+    Hechizos(1).AutoLanzar = 0
+    Hechizos(1).AreaRadio = 0
+    Hechizos(1).AreaAfecta = 0
+    Hechizos(1).Target = e_TargetType.uNPC
+    Hechizos(1).TargetEffectType = e_TargetEffectType.eNegative
+    Hechizos(1).Tipo = e_TipoHechizo.uPropiedades
+
+    Dim RetryAfterMs As Long
+    If ExecuteHooTargetedSpellCast(1, 1, 2, RetryAfterMs) <> eHooTargetedSpellCastResult_InvalidTarget Then GoTo TestDone
+    If ExecuteHooTargetedSpellCast(1, 0, 1, RetryAfterMs) <> eHooTargetedSpellCastResult_InvalidSpell Then GoTo TestDone
+    NpcList(1).pos.Map = 2
+    If ExecuteHooTargetedSpellCast(1, 1, 1, RetryAfterMs) <> eHooTargetedSpellCastResult_InvalidTarget Then GoTo TestDone
+    NpcList(1).pos.Map = 1
+    NpcList(1).pos.x = 100
+    If ExecuteHooTargetedSpellCast(1, 1, 1, RetryAfterMs) <> eHooTargetedSpellCastResult_OutOfRange Then GoTo TestDone
+    NpcList(1).pos.x = 20
+    Dim NowRaw As Long
+    NowRaw = GetTickCountRaw()
+    UserList(1).Counters.TimerPuedeUsarArco = NowRaw
+    UserList(1).Counters.TimerGolpeMagia = NowRaw
+    UserList(1).Counters.TimerLanzarSpell = NowRaw
+    If ExecuteHooTargetedSpellCast(1, 1, 1, RetryAfterMs) <> eHooTargetedSpellCastResult_RateLimited Then GoTo TestDone
+    If RetryAfterMs <= 0 Then GoTo TestDone
+    If UserList(1).Counters.TimerPuedeUsarArco <> NowRaw Then GoTo TestDone
+    If UserList(1).Counters.TimerGolpeMagia <> NowRaw Then GoTo TestDone
+    If UserList(1).Counters.TimerLanzarSpell <> NowRaw Then GoTo TestDone
+    test_targeted_spell_early_rejections = True
+TestDone:
+    CharList(1) = OriginalMapping
+    NpcList(1).flags.NPCActive = OriginalActive
+    NpcList(1).Stats.MinHp = OriginalHp
+    NpcList(1).Char.charindex = OriginalCharIndex
+    NpcList(1).pos.Map = OriginalNpcMap
+    NpcList(1).pos.x = OriginalNpcX
+    NpcList(1).pos.y = OriginalNpcY
+    UserList(1).pos.Map = OriginalUserMap
+    UserList(1).pos.x = OriginalUserX
+    UserList(1).pos.y = OriginalUserY
+    UserList(1).Stats.UserHechizos(1) = OriginalSpellIndex
+    Hechizos(1).AutoLanzar = OriginalAuto
+    Hechizos(1).AreaRadio = OriginalAreaRadio
+    Hechizos(1).AreaAfecta = OriginalAreaAfecta
+    Hechizos(1).Target = OriginalTarget
+    Hechizos(1).TargetEffectType = OriginalEffect
+    Hechizos(1).Tipo = OriginalType
+    UserList(1).Counters.TimerPuedeUsarArco = OriginalBowTimer
+    UserList(1).Counters.TimerGolpeMagia = OriginalHitMagicTimer
+    UserList(1).Counters.TimerLanzarSpell = OriginalMagicTimer
+    Exit Function
+TestError:
+    test_targeted_spell_early_rejections = False
+    Resume TestDone
+End Function
+
+Private Function test_targeted_spell_target_resolution() As Boolean
+    On Error GoTo TestError
+    Dim OriginalMapping As Integer
+    Dim OriginalActive As Boolean
+    Dim OriginalHp As Integer
+    Dim OriginalCharIndex As Integer
+    OriginalMapping = CharList(1)
+    OriginalActive = NpcList(1).flags.NPCActive
+    OriginalHp = NpcList(1).Stats.MinHp
+    OriginalCharIndex = NpcList(1).Char.charindex
+
+    CharList(1) = 1
+    NpcList(1).flags.NPCActive = True
+    NpcList(1).Stats.MinHp = 10
+    NpcList(1).Char.charindex = 1
+    If ResolveHooTargetedSpellNpc(1) <> 1 Then GoTo TestDone
+    NpcList(1).Char.charindex = 2
+    If ResolveHooTargetedSpellNpc(1) <> 0 Then GoTo TestDone
+    NpcList(1).Char.charindex = 1
+    NpcList(1).Stats.MinHp = 0
+    If ResolveHooTargetedSpellNpc(1) <> 0 Then GoTo TestDone
+    test_targeted_spell_target_resolution = True
+TestDone:
+    CharList(1) = OriginalMapping
+    NpcList(1).flags.NPCActive = OriginalActive
+    NpcList(1).Stats.MinHp = OriginalHp
+    NpcList(1).Char.charindex = OriginalCharIndex
+    Exit Function
+TestError:
+    test_targeted_spell_target_resolution = False
+    Resume TestDone
+End Function
+
+Private Function test_targeted_spell_eligibility() As Boolean
+    On Error GoTo TestError
+    Dim OriginalSpellIndex As Integer
+    Dim OriginalAuto As Byte
+    Dim OriginalAreaRadio As Long
+    Dim OriginalAreaAfecta As Integer
+    Dim OriginalTarget As e_TargetType
+    Dim OriginalEffect As e_TargetEffectType
+    Dim OriginalType As e_TipoHechizo
+    OriginalSpellIndex = UserList(1).Stats.UserHechizos(1)
+    OriginalAuto = Hechizos(1).AutoLanzar
+    OriginalAreaRadio = Hechizos(1).AreaRadio
+    OriginalAreaAfecta = Hechizos(1).AreaAfecta
+    OriginalTarget = Hechizos(1).Target
+    OriginalEffect = Hechizos(1).TargetEffectType
+    OriginalType = Hechizos(1).Tipo
+
+    UserList(1).Stats.UserHechizos(1) = 1
+    Hechizos(1).AutoLanzar = 0
+    Hechizos(1).AreaRadio = 0
+    Hechizos(1).AreaAfecta = 0
+    Hechizos(1).Target = e_TargetType.uNPC
+    Hechizos(1).TargetEffectType = e_TargetEffectType.eNegative
+    Hechizos(1).Tipo = e_TipoHechizo.uPropiedades
+    If Not IsHooTargetedSpellEligible(1, 1) Then GoTo TestDone
+    Hechizos(1).AutoLanzar = 1
+    If IsHooTargetedSpellEligible(1, 1) Then GoTo TestDone
+    Hechizos(1).AutoLanzar = 0
+    Hechizos(1).AreaRadio = 1
+    If IsHooTargetedSpellEligible(1, 1) Then GoTo TestDone
+    Hechizos(1).AreaRadio = 0
+    Hechizos(1).Target = e_TargetType.uUsuarios
+    If IsHooTargetedSpellEligible(1, 1) Then GoTo TestDone
+    Hechizos(1).Target = e_TargetType.uNPC
+    Hechizos(1).TargetEffectType = e_TargetEffectType.ePositive
+    If IsHooTargetedSpellEligible(1, 1) Then GoTo TestDone
+    test_targeted_spell_eligibility = True
+TestDone:
+    UserList(1).Stats.UserHechizos(1) = OriginalSpellIndex
+    Hechizos(1).AutoLanzar = OriginalAuto
+    Hechizos(1).AreaRadio = OriginalAreaRadio
+    Hechizos(1).AreaAfecta = OriginalAreaAfecta
+    Hechizos(1).Target = OriginalTarget
+    Hechizos(1).TargetEffectType = OriginalEffect
+    Hechizos(1).Tipo = OriginalType
+    Exit Function
+TestError:
+    test_targeted_spell_eligibility = False
+    Resume TestDone
+End Function
+
+Private Function test_targeted_spell_capability() As Boolean
+    On Error GoTo TestError
+    Dim OriginalFeatureEnabled As Boolean
+    OriginalFeatureEnabled = IsFeatureEnabled(HOO_FEATURE_TARGETED_SPELL_CAST_V1)
+    Call SetFeatureToggle(HOO_FEATURE_TARGETED_SPELL_CAST_V1, True)
+    If AcceptedHooCapabilityMask(HOO_CAP_PROTOCOL_VERSION, HOO_CAP_TARGETED_SPELL_CAST_V1) <> HOO_CAP_TARGETED_SPELL_CAST_V1 Then GoTo TestDone
+    Call SetFeatureToggle(HOO_FEATURE_TARGETED_SPELL_CAST_V1, False)
+    If AcceptedHooCapabilityMask(HOO_CAP_PROTOCOL_VERSION, HOO_CAP_TARGETED_SPELL_CAST_V1) <> 0 Then GoTo TestDone
+    test_targeted_spell_capability = (HOO_CAP_TARGETED_SPELL_CAST_V1 = &H4&)
+TestDone:
+    Call SetFeatureToggle(HOO_FEATURE_TARGETED_SPELL_CAST_V1, OriginalFeatureEnabled)
+    Exit Function
+TestError:
+    test_targeted_spell_capability = False
+    Resume TestDone
+End Function
+
+Private Function test_targeted_spell_retry_interval() As Boolean
+    test_targeted_spell_retry_interval = _
+        IntervalRemainingMs(1000, 500, 1250) = 250 And _
+        IntervalRemainingMs(1000, 500, 1500) = 0 And _
+        IntervalRemainingMs(2147483600, 200, -2147483596) = 100
 End Function
 
 Private Function test_remort_eligibility_and_priority() As Boolean

--- a/Codigo/UnitTesting.bas
+++ b/Codigo/UnitTesting.bas
@@ -519,7 +519,7 @@ Private Function test_targeted_spell_early_rejections() As Boolean
     Hechizos(1).Tipo = e_TipoHechizo.uPropiedades
 
     Dim RetryAfterMs As Long
-    If ExecuteHooTargetedSpellCast(1, 1, 2, RetryAfterMs) <> eHooTargetedSpellCastResult_InvalidTarget Then GoTo TestDone
+    If ExecuteHooTargetedSpellCast(1, 1, 0, RetryAfterMs) <> eHooTargetedSpellCastResult_InvalidTarget Then GoTo TestDone
     If ExecuteHooTargetedSpellCast(1, 0, 1, RetryAfterMs) <> eHooTargetedSpellCastResult_InvalidSpell Then GoTo TestDone
     NpcList(1).pos.Map = 2
     If ExecuteHooTargetedSpellCast(1, 1, 1, RetryAfterMs) <> eHooTargetedSpellCastResult_InvalidTarget Then GoTo TestDone

--- a/Codigo/modHechizos.bas
+++ b/Codigo/modHechizos.bas
@@ -1326,7 +1326,7 @@ HandleHechizoNPC_Err:
     Call TraceError(Err.Number, Err.Description, "modHechizos.HandleHechizoNPC", Erl)
 End Sub
 
-Sub LanzarHechizo(ByVal Index As Integer, ByVal UserIndex As Integer)
+Function LanzarHechizo(ByVal Index As Integer, ByVal UserIndex As Integer) As Boolean
     On Error GoTo LanzarHechizo_Err
     Dim uh               As Integer
     Dim SpellCastSuccess As Boolean
@@ -1411,10 +1411,11 @@ Sub LanzarHechizo(ByVal Index As Integer, ByVal UserIndex As Integer)
         Call WriteMacroTrabajoToggle(UserIndex, False)
     End If
     If UserList(UserIndex).Counters.Ocultando Then UserList(UserIndex).Counters.Ocultando = UserList(UserIndex).Counters.Ocultando - 1
-    Exit Sub
+    LanzarHechizo = SpellCastSuccess
+    Exit Function
 LanzarHechizo_Err:
     Call TraceError(Err.Number, Err.Description, "modHechizos.LanzarHechizo", Erl)
-End Sub
+End Function
 
 Sub HechizoEstadoUsuario(ByVal UserIndex As Integer, ByRef b As Boolean)
     '***************************************************

--- a/Codigo/modNuevoTimer.bas
+++ b/Codigo/modNuevoTimer.bas
@@ -34,6 +34,27 @@ Option Explicit
 '       If Actualizar Then lastTick = nowRaw
 '       result = True
 '   End If
+Public Function IntervalRemainingMs(ByVal LastTick As Long, ByVal IntervalMs As Long, ByVal NowRaw As Long) As Long
+    Dim Elapsed As Double
+    Elapsed = TicksElapsed(LastTick, NowRaw)
+    If Elapsed < CDbl(IntervalMs) Then
+        IntervalRemainingMs = CLng(CDbl(IntervalMs) - Elapsed)
+    End If
+End Function
+
+Public Function HooTargetedSpellCastRetryAfterMs(ByVal UserIndex As Integer) As Long
+    Dim NowRaw As Long
+    Dim Remaining As Long
+    NowRaw = GetTickCountRaw()
+    With UserList(UserIndex).Counters
+        HooTargetedSpellCastRetryAfterMs = IntervalRemainingMs(.TimerPuedeUsarArco, IntervaloFlechasCazadores, NowRaw)
+        Remaining = IntervalRemainingMs(.TimerGolpeMagia, IntervaloGolpeMagia, NowRaw)
+        If Remaining > HooTargetedSpellCastRetryAfterMs Then HooTargetedSpellCastRetryAfterMs = Remaining
+        Remaining = IntervalRemainingMs(.TimerLanzarSpell, IntervaloUserPuedeCastear, NowRaw)
+        If Remaining > HooTargetedSpellCastRetryAfterMs Then HooTargetedSpellCastRetryAfterMs = Remaining
+    End With
+End Function
+
 Public Function IntervaloPermiteLanzarSpell(ByVal UserIndex As Integer, Optional ByVal Actualizar As Boolean = True) As Boolean
     On Error GoTo IntervaloPermiteLanzarSpell_Err
     Dim nowRaw As Long: nowRaw = GetTickCountRaw()

--- a/Example.feature_toggle.ini
+++ b/Example.feature_toggle.ini
@@ -1,5 +1,5 @@
 [INIT]
-TOGGLECOUNT=27
+TOGGLECOUNT=28
 [TOGGLE1]
 name=bandit_unequip_bonus
 value=1
@@ -80,4 +80,7 @@ name=hoo-remort-v1
 value=1
 [TOGGLE27]
 name=npc-cross-map-pursuit
+value=0
+[TOGGLE28]
+name=hoo-targeted-spell-cast-v1
 value=0


### PR DESCRIPTION
## Summary
- add `HOO_CAP_TARGETED_SPELL_CAST_V1` behind `hoo-targeted-spell-cast-v1`
- resolve the requested NPC authoritatively from server-visible character identity
- execute one atomic offensive NPC spell through the existing spell engine
- return typed results and wrap-safe authoritative retry timing

## Correctness
- requires negotiated HOO capability
- accepts only supported negative, single-NPC spell semantics
- never calls `LookatTile` and never trusts client coordinates
- applies both legacy `InRangoVision` and `RANGO_VISION_X/Y` checks
- snapshots and safely restores temporary spell and target state
- `LanzarHechizo` returns its pre-existing `SpellCastSuccess` semantic
- `HandleHechizoNPC` remains behaviorally unchanged

## Compatibility
- no database changes or direct persistence
- no existing packet ordinal changes
- no legacy-client gameplay changes
- legacy manual casting remains unchanged

## Validation
- Windows VB6 `PYMMO=1 UNIT_TEST=1` build passed
- 317/317 tests passed
- Windows VB6 `PYMMO=1 UNIT_TEST=0` production build passed
- `git diff --check` passed