### PR TITLE
Preserve newbie items after graduation

### DIFF
--- a/Codigo/InvUsuario.bas
+++ b/Codigo/InvUsuario.bas
@@ -167,40 +167,6 @@ RazaPuedeUsarItem_Err:
     LogError ("Error en RazaPuedeUsarItem")
 End Function
 
-Sub QuitarNewbieObj(ByVal UserIndex As Integer)
-    On Error GoTo QuitarNewbieObj_Err
-    Dim j As Integer
-    If UserList(UserIndex).CurrentInventorySlots > 0 Then
-        For j = 1 To UserList(UserIndex).CurrentInventorySlots
-            If UserList(UserIndex).invent.Object(j).ObjIndex > 0 Then
-                If ObjData(UserList(UserIndex).invent.Object(j).ObjIndex).Newbie = 1 Then
-                    Call QuitarUserInvItem(UserIndex, j, GetMaxInvOBJ())
-                    Call UpdateUserInv(False, UserIndex, j)
-                End If
-            End If
-        Next j
-    End If
-    ' Eliminar items newbie de la boveda
-    For j = 1 To MAX_BANCOINVENTORY_SLOTS
-        If UserList(UserIndex).BancoInvent.Object(j).ObjIndex > 0 Then
-            If ObjData(UserList(UserIndex).BancoInvent.Object(j).ObjIndex).Newbie = 1 Then
-                UserList(UserIndex).BancoInvent.Object(j).ObjIndex = 0
-                UserList(UserIndex).BancoInvent.Object(j).amount = 0
-                UserList(UserIndex).BancoInvent.Object(j).ElementalTags = 0
-                Call UpdateBanUserInv(False, UserIndex, j, "QuitarNewbieObj")
-            End If
-        End If
-    Next j
-    'Si el usuario dejó de ser Newbie, y estaba en el Newbie Dungeon
-    'Mandamos a la Isla de la Fortuna
-    Call WarpUserChar(UserIndex, Renacimiento.Map, Renacimiento.x, Renacimiento.y, True)
-    ' Msg671=Has dejado de ser Newbie.
-    Call WriteLocaleMsg(UserIndex, MSG_DEJADO_NEWBIE, e_TextChannel.TEXTCHANNEL_SYSTEM, e_FontTypeNames.FONTTYPE_INFO)
-    Exit Sub
-QuitarNewbieObj_Err:
-    Call TraceError(Err.Number, Err.Description, "InvUsuario.QuitarNewbieObj", Erl)
-End Sub
-
 Sub LimpiarInventario(ByVal UserIndex As Integer)
     On Error GoTo LimpiarInventario_Err
     Dim j As Integer
@@ -1784,11 +1750,6 @@ Sub UseInvItem(ByVal UserIndex As Integer, ByVal Slot As Byte, ByVal ByClick As 
             Call SendData(SendTarget.ToPCAliveArea, UserIndex, PrepareMessageMeditateToggle(.Char.charindex, 0))
         End If
 
-        If obj.Newbie = 1 And Not EsNewbie(UserIndex) And Not EsGM(UserIndex) Then
-            ' Msg679=Solo los newbies pueden usar estos objetos.
-            Call WriteLocaleMsg(UserIndex, MSG_SOLO_NEWBIES_PUEDEN_USAR_OBJETOS, e_TextChannel.TEXTCHANNEL_SYSTEM, e_FontTypeNames.FONTTYPE_New_Naranja)
-            Exit Sub
-        End If
         If .Stats.ELV < obj.MinELV Then
             Call WriteLocaleMsg(UserIndex, MSG_ITEM_MIN_LEVEL_REQUIRED, e_TextChannel.TEXTCHANNEL_SYSTEM, e_FontTypeNames.FONTTYPE_INFO, obj.MinELV)    ' Msg1926=Necesitas ser nivel ¬1 para usar este item.
             Exit Sub

--- a/Codigo/Modulo_UsUaRiOs.bas
+++ b/Codigo/Modulo_UsUaRiOs.bas
@@ -1178,7 +1178,8 @@ Sub CheckUserLevel(ByVal UserIndex As Integer)
                 Call WriteLocaleMsg(UserIndex, MSG_GANADO_SKILLPOINTS_DISPONES_PUNTOS_LIBRES_CUIDADOSO_MOMENTO_USARLOS, e_TextChannel.TEXTCHANNEL_SYSTEM, e_FontTypeNames.FONTTYPE_PROMEDIO_MAYOR, Pts & "¬" & .Stats.SkillPts)
             End If
             If Not EsNewbie(UserIndex) And WasNewbie Then
-                Call QuitarNewbieObj(UserIndex)
+                ' Msg671=Has dejado de ser Newbie.
+                Call WriteLocaleMsg(UserIndex, MSG_DEJADO_NEWBIE, e_TextChannel.TEXTCHANNEL_SYSTEM, e_FontTypeNames.FONTTYPE_INFO)
             ElseIf .Stats.ELV >= MapInfo(.pos.Map).MaxLevel And Not EsGM(UserIndex) Then
                 If MapInfo(.pos.Map).Salida.Map <> 0 Then
                     ' Msg523=Tu nivel no te permite seguir en el mapa.

--- a/Codigo/Tests/Unit_GameStatus.bas
+++ b/Codigo/Tests/Unit_GameStatus.bas
@@ -25,6 +25,7 @@ Public Function test_suite_gamestatus() As Boolean
     Call UnitTesting.RunTest("test_esgm_no_privs", test_esgm_no_privs())
     Call UnitTesting.RunTest("test_esgm_zero_index", test_esgm_zero_index())
     Call UnitTesting.RunTest("test_esnewbie_threshold_property", test_esnewbie_threshold_property())
+    Call UnitTesting.RunTest("test_non_newbie_can_use_newbie_item", test_non_newbie_can_use_newbie_item())
     test_suite_gamestatus = True
 End Function
 
@@ -440,6 +441,44 @@ Private Function test_esnewbie_threshold_property() As Boolean
 Err_Handler:
     UserList(1).Stats.ELV = origELV
     test_esnewbie_threshold_property = False
+End Function
+
+Private Function test_non_newbie_can_use_newbie_item() As Boolean
+    On Error GoTo Err_Handler
+
+    Dim OriginalLevel  As Byte
+    Dim OriginalClass  As e_Class
+    Dim OriginalRace   As e_Raza
+    Dim OriginalGender As e_Genero
+    Dim OriginalObject As t_ObjData
+    Dim TestObject     As t_ObjData
+
+    OriginalLevel = UserList(1).Stats.ELV
+    OriginalClass = UserList(1).clase
+    OriginalRace = UserList(1).raza
+    OriginalGender = UserList(1).genero
+    OriginalObject = ObjData(1)
+    UserList(1).Stats.ELV = LimiteNewbie + 1
+    UserList(1).clase = e_Class.Warrior
+    UserList(1).raza = e_Raza.Humano
+    UserList(1).genero = e_Genero.Hombre
+    TestObject.Newbie = 1
+    ObjData(1) = TestObject
+
+    test_non_newbie_can_use_newbie_item = ObjData(1).Newbie = 1 _
+            And Not EsNewbie(1) _
+            And CanUseObject(1, 1) = 0
+
+Clean_Up:
+    UserList(1).Stats.ELV = OriginalLevel
+    UserList(1).clase = OriginalClass
+    UserList(1).raza = OriginalRace
+    UserList(1).genero = OriginalGender
+    ObjData(1) = OriginalObject
+    Exit Function
+Err_Handler:
+    test_non_newbie_can_use_newbie_item = False
+    Resume Clean_Up
 End Function
 
 #End If

--- a/Codigo/WorldActions.bas
+++ b/Codigo/WorldActions.bas
@@ -49,10 +49,7 @@ Public Function CanUseObject(ByVal UserIndex As Integer, ByVal ObjIndex As Integ
             Exit Function
         End If
         ' Keep the original priority: first match wins
-        If Objeto.Newbie = 1 And Not EsNewbie(UserIndex) Then
-            CanUseObject = 7
-            msg = "679" ' Only newbies can use this item.
-        ElseIf .Stats.ELV < Objeto.MinELV Then
+        If .Stats.ELV < Objeto.MinELV Then
             CanUseObject = 6
             msg = "1926" ' Need level {0}
             Extra = CStr(Objeto.MinELV)


### PR DESCRIPTION
## Summary

- remove the destructive newbie-item cleanup when a character leaves Newbie status
- remove the graduation warp to Renacimiento so the character remains at the same map and position
- allow non-newbie characters to continue using and equipping items marked `Newbie = 1`
- retain the existing localized graduation message

## Behavior

Newbie items keep their original object IDs, quantities, slots, equipped state, graphics, and combat properties after graduation. The server no longer deletes inventory or bank items and does not need a newbie-to-normal object mapping.

The Newbie use restriction was removed from both authoritative use checks: `CanUseObject` and `UseInvItem`. All normal level, class, race, gender, faction, skill, and equipment requirements remain active. Any character possessing a newbie item can therefore use it. Existing trade, NPC-sale, and death-drop protections remain unchanged.

## Validation

- VB6 unit-test build: passed
- full server suite: 318/318 passed
- production-style `PYMMO=1` VB6 build: passed
- `git diff --check`: passed

## Scope

Server-only change. No object data, client, protocol, packet, schema, or bank-flow changes.