### PR TITLE
Prevent banking newbie items

### DIFF
--- a/Codigo/InvUsuario.bas
+++ b/Codigo/InvUsuario.bas
@@ -2930,7 +2930,7 @@ Sub TirarTodosLosItems(ByVal UserIndex As Integer)
         For i = 1 To .CurrentInventorySlots
             ItemIndex = .invent.Object(i).ObjIndex
             If ItemIndex > 0 Then
-                If ItemSeCae(ItemIndex) And PirataCaeItem(UserIndex, i) And (Not EsNewbie(UserIndex) Or Not ItemNewbie(ItemIndex)) Then
+                If ItemSeCae(ItemIndex) And PirataCaeItem(UserIndex, i) And Not ItemNewbieProtegidoAlMorir(UserIndex, ItemIndex) Then
                     NuevaPos.x = 0
                     NuevaPos.y = 0
                     MiObj.amount = DropAmmount(.invent, i)
@@ -2996,6 +2996,10 @@ Function ItemNewbie(ByVal ItemIndex As Integer) As Boolean
     Exit Function
 ItemNewbie_Err:
     Call TraceError(Err.Number, Err.Description, "InvUsuario.ItemNewbie", Erl)
+End Function
+
+Function ItemNewbieProtegidoAlMorir(ByVal UserIndex As Integer, ByVal ItemIndex As Integer) As Boolean
+    ItemNewbieProtegidoAlMorir = EsNewbie(UserIndex) And ItemNewbie(ItemIndex)
 End Function
 
 Public Function IsItemInCooldown(ByRef User As t_User, ByRef obj As t_UserOBJ) As Boolean

--- a/Codigo/ModRetos.bas
+++ b/Codigo/ModRetos.bas
@@ -629,7 +629,7 @@ Public Sub TirarItemsEnPos(ByVal UserIndex As Integer, ByVal x As Byte, ByVal y 
         For i = 1 To .CurrentInventorySlots
             ItemIndex = .invent.Object(i).ObjIndex
             If ItemIndex > 0 Then
-                If ItemSeCae(ItemIndex) And PirataCaeItem(UserIndex, i) And (Not EsNewbie(UserIndex) Or Not ItemNewbie(ItemIndex)) Then
+                If ItemSeCae(ItemIndex) And PirataCaeItem(UserIndex, i) And Not ItemNewbieProtegidoAlMorir(UserIndex, ItemIndex) Then
                     NuevaPos.x = 0
                     NuevaPos.y = 0
                     MiObj.amount = .invent.Object(i).amount

--- a/Codigo/Tests/Unit_GameStatus.bas
+++ b/Codigo/Tests/Unit_GameStatus.bas
@@ -26,7 +26,182 @@ Public Function test_suite_gamestatus() As Boolean
     Call UnitTesting.RunTest("test_esgm_zero_index", test_esgm_zero_index())
     Call UnitTesting.RunTest("test_esnewbie_threshold_property", test_esnewbie_threshold_property())
     Call UnitTesting.RunTest("test_non_newbie_can_use_newbie_item", test_non_newbie_can_use_newbie_item())
+    Call UnitTesting.RunTest("test_newbie_graduation_preserves_character_state", test_newbie_graduation_preserves_character_state())
+    Call UnitTesting.RunTest("test_newbie_item_normal_requirements_still_apply", test_newbie_item_normal_requirements_still_apply())
+    Call UnitTesting.RunTest("test_newbie_bank_deposit_is_rejected", test_newbie_bank_deposit_is_rejected())
+    Call UnitTesting.RunTest("test_normal_bank_deposit_succeeds", test_normal_bank_deposit_succeeds())
+    Call UnitTesting.RunTest("test_newbie_death_drop_protection", test_newbie_death_drop_protection())
     test_suite_gamestatus = True
+End Function
+
+Private Function test_newbie_bank_deposit_is_rejected() As Boolean
+    On Error GoTo Err_Handler
+
+    Dim OriginalObject            As t_ObjData
+    Dim OriginalInventory         As t_UserOBJ
+    Dim OriginalBank              As t_UserOBJ
+    Dim OriginalInventorySlots    As Byte
+    Dim OriginalInventoryCount    As Byte
+    Dim OriginalBankCount         As Byte
+    Dim OriginalInventoryModified As Boolean
+    Dim OriginalBankModified      As Boolean
+    Dim DepositedSlot             As Long
+
+    OriginalObject = ObjData(1)
+    With UserList(1)
+        OriginalInventory = .invent.Object(1)
+        OriginalBank = .BancoInvent.Object(1)
+        OriginalInventorySlots = .CurrentInventorySlots
+        OriginalInventoryCount = .invent.NroItems
+        OriginalBankCount = .BancoInvent.NroItems
+        OriginalInventoryModified = .flags.ModificoInventario
+        OriginalBankModified = .flags.ModificoInventarioBanco
+
+        .CurrentInventorySlots = 1
+        .invent.Object(1).ObjIndex = 1
+        .invent.Object(1).amount = 3
+        .invent.Object(1).Equipped = 1
+        .invent.Object(1).ElementalTags = e_ElementalTags.Fire
+        .invent.NroItems = 1
+        .BancoInvent.Object(1).ObjIndex = 0
+        .BancoInvent.Object(1).amount = 0
+        .BancoInvent.Object(1).Equipped = 0
+        .BancoInvent.Object(1).ElementalTags = 0
+        .BancoInvent.NroItems = 0
+        .flags.ModificoInventario = False
+        .flags.ModificoInventarioBanco = False
+    End With
+    ObjData(1).Newbie = 1
+
+    DepositedSlot = UserDejaObj(1, 1, 2, 1)
+
+    With UserList(1)
+        test_newbie_bank_deposit_is_rejected = DepositedSlot = 0 _
+                And .invent.Object(1).ObjIndex = 1 _
+                And .invent.Object(1).amount = 3 _
+                And .invent.Object(1).Equipped = 1 _
+                And .invent.Object(1).ElementalTags = e_ElementalTags.Fire _
+                And .invent.NroItems = 1 _
+                And .BancoInvent.Object(1).ObjIndex = 0 _
+                And .BancoInvent.Object(1).amount = 0 _
+                And .BancoInvent.NroItems = 0 _
+                And Not .flags.ModificoInventario _
+                And Not .flags.ModificoInventarioBanco
+    End With
+
+Clean_Up:
+    ObjData(1) = OriginalObject
+    With UserList(1)
+        .invent.Object(1) = OriginalInventory
+        .BancoInvent.Object(1) = OriginalBank
+        .CurrentInventorySlots = OriginalInventorySlots
+        .invent.NroItems = OriginalInventoryCount
+        .BancoInvent.NroItems = OriginalBankCount
+        .flags.ModificoInventario = OriginalInventoryModified
+        .flags.ModificoInventarioBanco = OriginalBankModified
+    End With
+    Exit Function
+Err_Handler:
+    test_newbie_bank_deposit_is_rejected = False
+    Resume Clean_Up
+End Function
+
+Private Function test_normal_bank_deposit_succeeds() As Boolean
+    On Error GoTo Err_Handler
+
+    Dim OriginalObject         As t_ObjData
+    Dim OriginalInventory      As t_UserOBJ
+    Dim OriginalBank           As t_UserOBJ
+    Dim OriginalInventorySlots As Byte
+    Dim OriginalInventoryCount As Byte
+    Dim OriginalBankCount      As Byte
+    Dim OriginalInventoryModified As Boolean
+    Dim OriginalBankModified      As Boolean
+    Dim DepositedSlot          As Long
+
+    OriginalObject = ObjData(1)
+    With UserList(1)
+        OriginalInventory = .invent.Object(1)
+        OriginalBank = .BancoInvent.Object(1)
+        OriginalInventorySlots = .CurrentInventorySlots
+        OriginalInventoryCount = .invent.NroItems
+        OriginalBankCount = .BancoInvent.NroItems
+        OriginalInventoryModified = .flags.ModificoInventario
+        OriginalBankModified = .flags.ModificoInventarioBanco
+
+        .CurrentInventorySlots = 1
+        .invent.Object(1).ObjIndex = 1
+        .invent.Object(1).amount = 3
+        .invent.Object(1).Equipped = 0
+        .invent.Object(1).ElementalTags = e_ElementalTags.Water
+        .invent.NroItems = 1
+        .BancoInvent.Object(1).ObjIndex = 0
+        .BancoInvent.Object(1).amount = 0
+        .BancoInvent.Object(1).Equipped = 0
+        .BancoInvent.Object(1).ElementalTags = 0
+        .BancoInvent.NroItems = 0
+        .flags.ModificoInventario = False
+        .flags.ModificoInventarioBanco = False
+    End With
+    ObjData(1).Newbie = 0
+
+    DepositedSlot = UserDejaObj(1, 1, 2, 1)
+
+    With UserList(1)
+        test_normal_bank_deposit_succeeds = DepositedSlot = 1 _
+                And .invent.Object(1).ObjIndex = 1 _
+                And .invent.Object(1).amount = 1 _
+                And .BancoInvent.Object(1).ObjIndex = 1 _
+                And .BancoInvent.Object(1).amount = 2 _
+                And .BancoInvent.Object(1).ElementalTags = e_ElementalTags.Water _
+                And .BancoInvent.NroItems = 1
+    End With
+
+Clean_Up:
+    ObjData(1) = OriginalObject
+    With UserList(1)
+        .invent.Object(1) = OriginalInventory
+        .BancoInvent.Object(1) = OriginalBank
+        .CurrentInventorySlots = OriginalInventorySlots
+        .invent.NroItems = OriginalInventoryCount
+        .BancoInvent.NroItems = OriginalBankCount
+        .flags.ModificoInventario = OriginalInventoryModified
+        .flags.ModificoInventarioBanco = OriginalBankModified
+    End With
+    Exit Function
+Err_Handler:
+    test_normal_bank_deposit_succeeds = False
+    Resume Clean_Up
+End Function
+
+Private Function test_newbie_death_drop_protection() As Boolean
+    On Error GoTo Err_Handler
+
+    Dim OriginalLevel  As Byte
+    Dim OriginalObject As t_ObjData
+
+    OriginalLevel = UserList(1).Stats.ELV
+    OriginalObject = ObjData(1)
+    ObjData(1).Newbie = 1
+
+    UserList(1).Stats.ELV = LimiteNewbie
+    If Not ItemNewbieProtegidoAlMorir(1, 1) Then GoTo Clean_Up
+
+    UserList(1).Stats.ELV = LimiteNewbie + 1
+    If ItemNewbieProtegidoAlMorir(1, 1) Then GoTo Clean_Up
+
+    ObjData(1).Newbie = 0
+    If ItemNewbieProtegidoAlMorir(1, 1) Then GoTo Clean_Up
+
+    test_newbie_death_drop_protection = True
+
+Clean_Up:
+    UserList(1).Stats.ELV = OriginalLevel
+    ObjData(1) = OriginalObject
+    Exit Function
+Err_Handler:
+    test_newbie_death_drop_protection = False
+    Resume Clean_Up
 End Function
 
 ' ============================================================
@@ -479,6 +654,156 @@ Clean_Up:
 Err_Handler:
     test_non_newbie_can_use_newbie_item = False
     Resume Clean_Up
+End Function
+
+Private Function test_newbie_graduation_preserves_character_state() As Boolean
+    On Error GoTo Err_Handler
+
+    Dim OriginalStats            As t_UserStats
+    Dim OriginalCounters         As t_UserCounters
+    Dim OriginalPosition         As t_WorldPos
+    Dim OriginalInventory        As t_UserOBJ
+    Dim OriginalBank             As t_UserOBJ
+    Dim OriginalClass            As e_Class
+    Dim OriginalRace             As e_Raza
+    Dim OriginalGender           As e_Genero
+    Dim OriginalInventorySlots   As Byte
+    Dim OriginalWeaponObjIndex   As Integer
+    Dim OriginalWeaponSlot       As Byte
+    Dim OriginalNaked            As Byte
+
+    With UserList(1)
+        OriginalStats = .Stats
+        OriginalCounters = .Counters
+        OriginalPosition = .pos
+        OriginalInventory = .invent.Object(1)
+        OriginalBank = .BancoInvent.Object(1)
+        OriginalClass = .clase
+        OriginalRace = .raza
+        OriginalGender = .genero
+        OriginalInventorySlots = .CurrentInventorySlots
+        OriginalWeaponObjIndex = .invent.EquippedWeaponObjIndex
+        OriginalWeaponSlot = .invent.EquippedWeaponSlot
+        OriginalNaked = .flags.Desnudo
+
+        .Stats.ELV = LimiteNewbie
+        .Stats.Exp = ExpLevelUp(LimiteNewbie)
+        .Stats.MaxHp = 100
+        .Stats.MinHp = 100
+        .Stats.UserAtributos(e_Atributos.Constitucion) = 18
+        .clase = e_Class.Warrior
+        .raza = e_Raza.Humano
+        .genero = e_Genero.Hombre
+        .pos.Map = 34
+        .pos.x = 50
+        .pos.y = 60
+        .CurrentInventorySlots = 1
+        .invent.Object(1).ObjIndex = 3487
+        .invent.Object(1).amount = 1
+        .invent.Object(1).Equipped = 1
+        .invent.Object(1).ElementalTags = e_ElementalTags.Fire
+        .invent.EquippedWeaponObjIndex = 3487
+        .invent.EquippedWeaponSlot = 1
+        .BancoInvent.Object(1).ObjIndex = 4335
+        .BancoInvent.Object(1).amount = 4
+        .BancoInvent.Object(1).ElementalTags = e_ElementalTags.Water
+        .flags.Desnudo = 0
+
+        Call CheckUserLevel(1)
+
+        test_newbie_graduation_preserves_character_state = .Stats.ELV = LimiteNewbie + 1 _
+                And .pos.Map = 34 And .pos.x = 50 And .pos.y = 60 _
+                And .invent.Object(1).ObjIndex = 3487 _
+                And .invent.Object(1).amount = 1 _
+                And .invent.Object(1).Equipped = 1 _
+                And .invent.Object(1).ElementalTags = e_ElementalTags.Fire _
+                And .invent.EquippedWeaponObjIndex = 3487 _
+                And .invent.EquippedWeaponSlot = 1 _
+                And .BancoInvent.Object(1).ObjIndex = 4335 _
+                And .BancoInvent.Object(1).amount = 4 _
+                And .BancoInvent.Object(1).ElementalTags = e_ElementalTags.Water _
+                And .flags.Desnudo = 0
+    End With
+
+Clean_Up:
+    With UserList(1)
+        .Stats = OriginalStats
+        .Counters = OriginalCounters
+        .pos = OriginalPosition
+        .invent.Object(1) = OriginalInventory
+        .BancoInvent.Object(1) = OriginalBank
+        .clase = OriginalClass
+        .raza = OriginalRace
+        .genero = OriginalGender
+        .CurrentInventorySlots = OriginalInventorySlots
+        .invent.EquippedWeaponObjIndex = OriginalWeaponObjIndex
+        .invent.EquippedWeaponSlot = OriginalWeaponSlot
+        .flags.Desnudo = OriginalNaked
+    End With
+    Exit Function
+Err_Handler:
+    test_newbie_graduation_preserves_character_state = False
+    Resume Clean_Up
+End Function
+
+Private Function test_newbie_item_normal_requirements_still_apply() As Boolean
+    On Error GoTo Err_Handler
+
+    Dim OriginalStats  As t_UserStats
+    Dim OriginalObject As t_ObjData
+    Dim OriginalClass  As e_Class
+    Dim OriginalRace   As e_Raza
+    Dim OriginalGender As e_Genero
+    Dim TestObject     As t_ObjData
+
+    With UserList(1)
+        OriginalStats = .Stats
+        OriginalObject = ObjData(1)
+        OriginalClass = .clase
+        OriginalRace = .raza
+        OriginalGender = .genero
+        .Stats.ELV = LimiteNewbie + 1
+        .clase = e_Class.Warrior
+        .raza = e_Raza.Humano
+        .genero = e_Genero.Hombre
+
+        TestObject.Newbie = 1
+        TestObject.ClaseProhibida(1) = e_Class.Warrior
+        ObjData(1) = TestObject
+        If CanUseObject(1, 1) <> 2 Then GoTo TestDone
+
+        TestObject.ClaseProhibida(1) = 0
+        TestObject.RazaProhibida(1) = e_Raza.Humano
+        ObjData(1) = TestObject
+        If CanUseObject(1, 1) <> 5 Then GoTo TestDone
+
+        TestObject.RazaProhibida(1) = 0
+        TestObject.MinELV = LimiteNewbie + 2
+        ObjData(1) = TestObject
+        If CanUseObject(1, 1) <> 6 Then GoTo TestDone
+
+        TestObject.MinELV = 0
+        TestObject.SkillIndex = 1
+        TestObject.SkillRequerido = 10
+        .Stats.UserSkills(1) = 0
+        ObjData(1) = TestObject
+        If CanUseObject(1, 1) <> 4 Then GoTo TestDone
+
+        test_newbie_item_normal_requirements_still_apply = True
+    End With
+
+TestDone:
+    With UserList(1)
+        .Stats = OriginalStats
+        .clase = OriginalClass
+        .raza = OriginalRace
+        .genero = OriginalGender
+    End With
+    ObjData(1) = OriginalObject
+    Exit Function
+Err_Handler:
+    test_newbie_item_normal_requirements_still_apply = False
+    Resume TestDone
 End Function
 
 #End If

--- a/Codigo/modBanco.bas
+++ b/Codigo/modBanco.bas
@@ -217,7 +217,14 @@ Function UserDejaObj(ByVal UserIndex As Integer, ByVal ObjIndex As Integer, ByVa
     Dim Slot As Integer
     Dim obji As Integer
     If Cantidad < 1 Then Exit Function
+    If ObjIndex < 1 Or ObjIndex > UserList(UserIndex).CurrentInventorySlots Then Exit Function
     obji = UserList(UserIndex).invent.Object(ObjIndex).ObjIndex
+    If obji < 1 Or obji > UBound(ObjData) Then Exit Function
+    If ObjData(obji).Newbie = 1 Then
+        ' Msg1141=No puedes comerciar objetos newbie.
+        Call WriteLocaleMsg(UserIndex, MSG_NO_PUEDES_COMERCIAR_OBJETOS_NEWBIE, e_TextChannel.TEXTCHANNEL_ECONOMY, e_FontTypeNames.FONTTYPE_New_Naranja)
+        Exit Function
+    End If
     Dim slotvalido As Boolean
     slotvalido = False
     If slotdestino <> 0 Then


### PR DESCRIPTION
## Resumen

Impide de forma autoritativa que los objetos marcados con `Newbie = 1` se depositen en el banco, sin modificar ni eliminar el objeto del inventario. También deja explícita y cubierta por tests la política de pérdida al morir: estos objetos están protegidos mientras el personaje es Newbie, pero siguen las reglas normales de caída cuando el personaje deja de serlo.

## Comportamiento

- La validación vive en `UserDejaObj`, antes de modificar inventario, banco, cantidades o flags de persistencia.
- Un intento de depósito de un objeto Newbie se rechaza con el mensaje localizado existente `MSG_NO_PUEDES_COMERCIAR_OBJETOS_NEWBIE`.
- El slot, cantidad, estado equipado y etiquetas elementales del inventario permanecen intactos.
- El banco y sus contadores permanecen intactos.
- Los objetos normales continúan depositándose sin cambios.
- No se agrega migración, conversión de `ObjIndex` ni procesamiento del banco durante la graduación.

## Caída al morir

Se centraliza la condición en `ItemNewbieProtegidoAlMorir` y se usa tanto en la muerte normal como en retos:

- Víctima Newbie + objeto Newbie: protegido.
- Víctima no-Newbie + objeto Newbie: puede caer según las reglas normales (`ItemSeCae`, reglas de pirata, mapas y demás condiciones existentes).
- No se alteran las restricciones de comercio, venta a NPC, drop manual ni otros mecanismos económicos.

## Graduación

La graduación sigue siendo no destructiva:

- No elimina ni convierte objetos.
- No procesa inventario o banco.
- No cambia `ObjIndex`.
- No desequipa objetos.
- No teletransporta al personaje.
- Los objetos Newbie siguen siendo utilizables por personajes no-Newbie si cumplen las restricciones normales de clase, raza, nivel y skill.

## Tests

Se agregó cobertura para:

- rechazo atómico del depósito de objetos Newbie;
- depósito normal sin regresiones;
- protección al morir para Newbies y caída normal para no-Newbies;
- graduación sin pérdida de inventario, banco, equipo o posición;
- uso de objetos Newbie por no-Newbies respetando requisitos normales.

Resultados:

- Suite VB6: `323 / 323` tests aprobados.
- Build VB6 unitario: aprobado.
- Build VB6 producción `PYMMO=1`: aprobado.
- `git diff --check`: aprobado.

El cambio local preexistente en `Server.VBP` no está incluido en el commit.