### PR TITLE
Add modern HOO house door controls

### DIFF
--- a/Codigo/Declares.bas
+++ b/Codigo/Declares.bas
@@ -2980,9 +2980,31 @@ Public Const HOO_CAP_PROTOCOL_VERSION As Byte = 1
 Public Const HOO_CAP_ADJACENT_CHARACTERS_V1 As Long = &H1&
 Public Const HOO_CAP_REMORT_V1 As Long = &H2&
 Public Const HOO_CAP_TARGETED_SPELL_CAST_V1 As Long = &H4&
+Public Const HOO_CAP_HOUSE_DOOR_ACTIONS_V1 As Long = &H8&
 Public Const HOO_FEATURE_ADJACENT_CHARACTERS_V1 As String = "hoo-adjacent-characters-v1"
 Public Const HOO_FEATURE_REMORT_V1 As String = "hoo-remort-v1"
 Public Const HOO_FEATURE_TARGETED_SPELL_CAST_V1 As String = "hoo-targeted-spell-cast-v1"
+Public Const HOO_FEATURE_HOUSE_DOOR_ACTIONS_V1 As String = "hoo-house-door-actions-v1"
+
+Public Enum e_HooHouseDoorAction
+    eHooHouseDoorAction_Open = 0
+    eHooHouseDoorAction_Close = 1
+    eHooHouseDoorAction_Lock = 2
+    eHooHouseDoorAction_Unlock = 3
+    eHooHouseDoorAction_UnlockAndOpen = 4
+End Enum
+
+Public Enum e_HooHouseDoorActionResult
+    eHooHouseDoorActionResult_Success = 0
+    eHooHouseDoorActionResult_InvalidAction = 1
+    eHooHouseDoorActionResult_InvalidTarget = 2
+    eHooHouseDoorActionResult_TooFarAway = 3
+    eHooHouseDoorActionResult_NotDoor = 4
+    eHooHouseDoorActionResult_InvalidTransition = 5
+    eHooHouseDoorActionResult_NoAccess = 6
+    eHooHouseDoorActionResult_Cooldown = 7
+    eHooHouseDoorActionResult_Unavailable = 8
+End Enum
 
 Public Enum e_HooTargetedSpellCastResult
     eHooTargetedSpellCastResult_Success = 0

--- a/Codigo/PacketId.bas
+++ b/Codigo/PacketId.bas
@@ -228,6 +228,7 @@ Public Enum ServerPacketID
     eRemortState
     eRemortResult
     eHooTargetedSpellCastResult
+    eHooHouseDoorActionResult
     eMaxPacket
     [PacketCount]
 End Enum
@@ -553,6 +554,7 @@ Public Enum ClientPacketID
     eHooClientCapabilities
     eRequestRemort
     eHooTargetedSpellCast
+    eHooHouseDoorAction
     eMaxPacket
     [PacketCount]
 End Enum

--- a/Codigo/Protocol.bas
+++ b/Codigo/Protocol.bas
@@ -935,6 +935,8 @@ Public Function HandleIncomingData(ByVal ConnectionID As Long, ByVal Message As 
             Call HandleRequestRemort(UserIndex)
         Case ClientPacketID.eHooTargetedSpellCast
             Call HandleHooTargetedSpellCast(UserIndex)
+        Case ClientPacketID.eHooHouseDoorAction
+            Call HandleHooHouseDoorAction(UserIndex)
             #If PYMMO = 0 Then
             Case ClientPacketID.eCreateAccount
                 Call HandleCreateAccount(ConnectionID)
@@ -998,6 +1000,11 @@ End Function
 Public Function UserSupportsHooTargetedSpellCast(ByVal UserIndex As Integer) As Boolean
     UserSupportsHooTargetedSpellCast = IsFeatureEnabled(HOO_FEATURE_TARGETED_SPELL_CAST_V1) And _
         UserSupportsHooCapability(UserIndex, HOO_CAP_TARGETED_SPELL_CAST_V1)
+End Function
+
+Public Function UserSupportsHooHouseDoorActions(ByVal UserIndex As Integer) As Boolean
+    UserSupportsHooHouseDoorActions = IsFeatureEnabled(HOO_FEATURE_HOUSE_DOOR_ACTIONS_V1) And _
+        UserSupportsHooCapability(UserIndex, HOO_CAP_HOUSE_DOOR_ACTIONS_V1)
 End Function
 
 Public Function ResolveHooTargetedSpellNpc(ByVal TargetCharacterIndex As Integer) As Integer
@@ -1230,6 +1237,9 @@ Public Function AcceptedHooCapabilityMask(ByVal ProtocolVersion As Byte, ByVal R
     If IsFeatureEnabled(HOO_FEATURE_TARGETED_SPELL_CAST_V1) Then
         SupportedMask = SupportedMask Or HOO_CAP_TARGETED_SPELL_CAST_V1
     End If
+    If IsFeatureEnabled(HOO_FEATURE_HOUSE_DOOR_ACTIONS_V1) Then
+        SupportedMask = SupportedMask Or HOO_CAP_HOUSE_DOOR_ACTIONS_V1
+    End If
     AcceptedHooCapabilityMask = RequestedMask And SupportedMask
 End Function
 
@@ -1258,6 +1268,34 @@ Private Sub HandleHooClientCapabilities(ByVal UserIndex As Integer)
 HandleHooClientCapabilities_Err:
     Call ResetHooClientCapabilities(UserIndex)
     Call TraceError(Err.Number, Err.Description, "Protocol.HandleHooClientCapabilities", Erl)
+End Sub
+
+Private Sub HandleHooHouseDoorAction(ByVal UserIndex As Integer)
+    On Error GoTo HandleHooHouseDoorAction_Err
+    Dim RequestId As Long
+    Dim ActionValue As Byte
+    Dim x As Byte
+    Dim y As Byte
+    RequestId = reader.ReadInt32
+    ActionValue = reader.ReadInt8
+    x = reader.ReadInt8
+    y = reader.ReadInt8
+    If Not UserSupportsHooHouseDoorActions(UserIndex) Then
+        Call LogSecurity("Rejected HOO house door action without negotiated capability; user=" & CStr(UserIndex))
+        Exit Sub
+    End If
+    Dim Result As e_HooHouseDoorActionResult
+    Result = ExecuteHooHouseDoorAction(UserIndex, CInt(ActionValue), x, y)
+    Call WriteHooHouseDoorActionResult(UserIndex, RequestId, CInt(ActionValue), Result, x, y)
+    If IsFeatureEnabled("debug_connections") Then
+        Call LogInfoServidor("HouseDoorAction user=" & CStr(UserIndex) & _
+            " request=" & CStr(RequestId) & " action=" & CStr(ActionValue) & _
+            " map=" & CStr(UserList(UserIndex).pos.Map) & _
+            " tile=" & CStr(x) & "," & CStr(y) & " result=" & CStr(Result))
+    End If
+    Exit Sub
+HandleHooHouseDoorAction_Err:
+    Call TraceError(Err.Number, Err.Description, "Protocol.HandleHooHouseDoorAction", Erl)
 End Sub
 
 Private Sub HandleHooTargetedSpellCast(ByVal UserIndex As Integer)

--- a/Codigo/Protocol_Writes.bas
+++ b/Codigo/Protocol_Writes.bas
@@ -147,6 +147,22 @@ WriteHooTargetedSpellCastResult_Err:
     Call TraceError(Err.Number, Err.Description, "Argentum20Server.Protocol_Writes.WriteHooTargetedSpellCastResult", Erl)
 End Sub
 
+Public Sub WriteHooHouseDoorActionResult(ByVal UserIndex As Integer, ByVal RequestId As Long, ByVal ActionValue As Integer, ByVal Result As e_HooHouseDoorActionResult, ByVal x As Byte, ByVal y As Byte)
+    On Error GoTo WriteHooHouseDoorActionResult_Err
+    If Not UserSupportsHooHouseDoorActions(UserIndex) Then Exit Sub
+    Call Writer.WriteInt16(ServerPacketID.eHooHouseDoorActionResult)
+    Call Writer.WriteInt32(RequestId)
+    Call Writer.WriteInt8(CByte(ActionValue))
+    Call Writer.WriteInt8(CByte(Result))
+    Call Writer.WriteInt8(x)
+    Call Writer.WriteInt8(y)
+    Call modSendData.SendData(ToIndex, UserIndex)
+    Exit Sub
+WriteHooHouseDoorActionResult_Err:
+    Call Writer.Clear
+    Call TraceError(Err.Number, Err.Description, "Argentum20Server.Protocol_Writes.WriteHooHouseDoorActionResult", Erl)
+End Sub
+
 Public Sub WriteHora(ByVal UserIndex As Integer)
     On Error GoTo WriteHora_Err
     Call modSendData.SendData(ToIndex, UserIndex, PrepareMessageHora())

--- a/Codigo/UnitTesting.bas
+++ b/Codigo/UnitTesting.bas
@@ -395,6 +395,8 @@ Private Function test_suite_remort_capability_state() As Boolean
     Call RunTest("remort packet is appended", CInt(ServerPacketID.eRemortState) = CInt(ServerPacketID.eShowPickUpObj) + 1)
     Call RunTest("remort operation packet IDs are appended", CInt(ServerPacketID.eRemortResult) = CInt(ServerPacketID.eRemortState) + 1 And CInt(ClientPacketID.eRequestRemort) = CInt(ClientPacketID.eHooClientCapabilities) + 1)
     Call RunTest("targeted spell packet IDs are appended", CInt(ServerPacketID.eHooTargetedSpellCastResult) = CInt(ServerPacketID.eRemortResult) + 1 And CInt(ClientPacketID.eHooTargetedSpellCast) = CInt(ClientPacketID.eRequestRemort) + 1)
+    Call RunTest("house door packet IDs and legacy key IDs", test_house_door_packet_ids_and_capability())
+    Call RunTest("house door actions validate before mutation", test_house_door_actions())
     Call RunTest("targeted spell capability and feature gate", test_targeted_spell_capability())
     Call RunTest("targeted spell retry interval is wrap safe", test_targeted_spell_retry_interval())
     Call RunTest("targeted spell NPC resolution rejects stale mappings", test_targeted_spell_target_resolution())
@@ -404,6 +406,133 @@ Private Function test_suite_remort_capability_state() As Boolean
     Call RunTest("remort equipment and count eligibility", test_remort_equipment_and_count_eligibility())
     Call RunTest("remort live reset and preservation", test_remort_live_reset_and_preservation())
     test_suite_remort_capability_state = True
+End Function
+
+Private Function test_house_door_packet_ids_and_capability() As Boolean
+    On Error GoTo TestError
+    Dim OriginalFeatureEnabled As Boolean
+    OriginalFeatureEnabled = IsFeatureEnabled(HOO_FEATURE_HOUSE_DOOR_ACTIONS_V1)
+    Call SetFeatureToggle(HOO_FEATURE_HOUSE_DOOR_ACTIONS_V1, True)
+    If AcceptedHooCapabilityMask(HOO_CAP_PROTOCOL_VERSION, HOO_CAP_HOUSE_DOOR_ACTIONS_V1) <> HOO_CAP_HOUSE_DOOR_ACTIONS_V1 Then GoTo TestDone
+    Call SetFeatureToggle(HOO_FEATURE_HOUSE_DOOR_ACTIONS_V1, False)
+    If AcceptedHooCapabilityMask(HOO_CAP_PROTOCOL_VERSION, HOO_CAP_HOUSE_DOOR_ACTIONS_V1) <> 0 Then GoTo TestDone
+    If HOO_CAP_HOUSE_DOOR_ACTIONS_V1 <> &H8& Then GoTo TestDone
+    If CInt(ClientPacketID.eUseKey) <> 209 Or CInt(ServerPacketID.eUpdateUserKey) <> 159 Then GoTo TestDone
+    If CInt(ClientPacketID.eHooHouseDoorAction) <> CInt(ClientPacketID.eHooTargetedSpellCast) + 1 Then GoTo TestDone
+    If CInt(ServerPacketID.eHooHouseDoorActionResult) <> CInt(ServerPacketID.eHooTargetedSpellCastResult) + 1 Then GoTo TestDone
+    test_house_door_packet_ids_and_capability = True
+TestDone:
+    Call SetFeatureToggle(HOO_FEATURE_HOUSE_DOOR_ACTIONS_V1, OriginalFeatureEnabled)
+    Exit Function
+TestError:
+    test_house_door_packet_ids_and_capability = False
+    Resume TestDone
+End Function
+
+Private Function test_house_door_actions() As Boolean
+    On Error GoTo TestError
+    Dim OriginalObj(1 To 4) As t_ObjData
+    Dim i As Integer
+    For i = 1 To 4
+        OriginalObj(i) = ObjData(i)
+    Next i
+    Dim OriginalTileObj As t_Obj
+    Dim OriginalPairObj As t_Obj
+    OriginalTileObj = MapData(1, 50, 50).ObjInfo
+    OriginalPairObj = MapData(1, 47, 51).ObjInfo
+    Dim OriginalBlocked As Byte
+    Dim OriginalBlockedSouth As Byte
+    OriginalBlocked = MapData(1, 50, 50).Blocked
+    OriginalBlockedSouth = MapData(1, 50, 51).Blocked
+    Dim OriginalMap As Integer
+    Dim OriginalX As Byte
+    Dim OriginalY As Byte
+    Dim OriginalTimer As Long
+    OriginalMap = UserList(1).pos.Map
+    OriginalX = UserList(1).pos.x
+    OriginalY = UserList(1).pos.y
+    OriginalTimer = UserList(1).Counters.TimerUsar
+    Dim OriginalKeys(1 To MAXKEYS) As Integer
+    For i = 1 To MAXKEYS
+        OriginalKeys(i) = UserList(1).Keys(i)
+        UserList(1).Keys(i) = 0
+    Next i
+
+    For i = 1 To 3
+        ObjData(i).OBJType = e_OBJType.otDoors
+        ObjData(i).clave = 410
+        ObjData(i).IndexAbierta = 1
+        ObjData(i).IndexCerrada = 2
+        ObjData(i).IndexCerradaLlave = 3
+        ObjData(i).Subtipo = 4
+        ObjData(i).GrhIndex = 1
+    Next i
+    ObjData(1).Cerrada = 0: ObjData(1).Llave = 0
+    ObjData(2).Cerrada = 1: ObjData(2).Llave = 0
+    ObjData(3).Cerrada = 1: ObjData(3).Llave = 1
+    ObjData(4).OBJType = e_OBJType.otKeys: ObjData(4).clave = 410
+    UserList(1).pos.Map = 1: UserList(1).pos.x = 50: UserList(1).pos.y = 50
+    MapData(1, 50, 50).ObjInfo.ObjIndex = 2
+    MapData(1, 50, 50).ObjInfo.amount = 1
+
+    If ExecuteHooHouseDoorAction(1, eHooHouseDoorAction_Open, 50, 50) <> eHooHouseDoorActionResult_Success Then GoTo TestDone
+    If MapData(1, 50, 50).ObjInfo.ObjIndex <> 1 Then GoTo TestDone
+    If ExecuteHooHouseDoorAction(1, eHooHouseDoorAction_Close, 50, 50) <> eHooHouseDoorActionResult_Success Then GoTo TestDone
+    If MapData(1, 50, 50).ObjInfo.ObjIndex <> 2 Then GoTo TestDone
+    If ExecuteHooHouseDoorAction(1, 250, 50, 50) <> eHooHouseDoorActionResult_InvalidAction Then GoTo TestDone
+    If MapData(1, 50, 50).ObjInfo.ObjIndex <> 2 Then GoTo TestDone
+    UserList(1).pos.x = 1: UserList(1).pos.y = 1
+    If ExecuteHooHouseDoorAction(1, eHooHouseDoorAction_Open, 50, 50) <> eHooHouseDoorActionResult_TooFarAway Then GoTo TestDone
+    UserList(1).pos.x = 50: UserList(1).pos.y = 50
+    MapData(1, 50, 50).ObjInfo.ObjIndex = 4
+    If ExecuteHooHouseDoorAction(1, eHooHouseDoorAction_Open, 50, 50) <> eHooHouseDoorActionResult_NotDoor Then GoTo TestDone
+    MapData(1, 50, 50).ObjInfo.ObjIndex = 2
+    If ExecuteHooHouseDoorAction(1, eHooHouseDoorAction_Lock, 50, 50) <> eHooHouseDoorActionResult_NoAccess Then GoTo TestDone
+    UserList(1).Keys(1) = 4
+    UserList(1).Counters.TimerUsar = 0
+    If ExecuteHooHouseDoorAction(1, eHooHouseDoorAction_Lock, 50, 50) <> eHooHouseDoorActionResult_Success Then GoTo TestDone
+    If MapData(1, 50, 50).ObjInfo.ObjIndex <> 3 Then GoTo TestDone
+    UserList(1).Counters.TimerUsar = GetTickCountRaw()
+    If ExecuteHooHouseDoorAction(1, eHooHouseDoorAction_Unlock, 50, 50) <> eHooHouseDoorActionResult_Cooldown Then GoTo TestDone
+    If MapData(1, 50, 50).ObjInfo.ObjIndex <> 3 Then GoTo TestDone
+    UserList(1).Counters.TimerUsar = 0
+    If ExecuteHooHouseDoorAction(1, eHooHouseDoorAction_Unlock, 50, 50) <> eHooHouseDoorActionResult_Success Then GoTo TestDone
+    If MapData(1, 50, 50).ObjInfo.ObjIndex <> 2 Then GoTo TestDone
+    MapData(1, 50, 50).ObjInfo.ObjIndex = 3
+    UserList(1).Counters.TimerUsar = 0
+    If ExecuteHooHouseDoorAction(1, eHooHouseDoorAction_UnlockAndOpen, 50, 50) <> eHooHouseDoorActionResult_Success Then GoTo TestDone
+    If MapData(1, 50, 50).ObjInfo.ObjIndex <> 1 Then GoTo TestDone
+    MapData(1, 50, 50).ObjInfo.ObjIndex = 2
+    ObjData(1).Subtipo = 1
+    MapData(1, 47, 51).ObjInfo.ObjIndex = 2
+    MapData(1, 47, 51).ObjInfo.amount = 1
+    If ExecuteHooHouseDoorAction(1, eHooHouseDoorAction_Open, 50, 50) <> eHooHouseDoorActionResult_Success Then GoTo TestDone
+    If MapData(1, 50, 50).ObjInfo.ObjIndex <> 1 Or MapData(1, 47, 51).ObjInfo.ObjIndex <> 1 Then GoTo TestDone
+    MapData(1, 50, 50).ObjInfo.ObjIndex = 2
+    MapData(1, 47, 51).ObjInfo.ObjIndex = 0
+    If ExecuteHooHouseDoorAction(1, eHooHouseDoorAction_Open, 50, 50) <> eHooHouseDoorActionResult_Unavailable Then GoTo TestDone
+    If MapData(1, 50, 50).ObjInfo.ObjIndex <> 2 Then GoTo TestDone
+    test_house_door_actions = True
+TestDone:
+    For i = 1 To 4
+        ObjData(i) = OriginalObj(i)
+        UserList(1).Keys(i) = OriginalKeys(i)
+    Next i
+    For i = 5 To MAXKEYS
+        UserList(1).Keys(i) = OriginalKeys(i)
+    Next i
+    MapData(1, 50, 50).ObjInfo = OriginalTileObj
+    MapData(1, 47, 51).ObjInfo = OriginalPairObj
+    MapData(1, 50, 50).Blocked = OriginalBlocked
+    MapData(1, 50, 51).Blocked = OriginalBlockedSouth
+    UserList(1).pos.Map = OriginalMap
+    UserList(1).pos.x = OriginalX
+    UserList(1).pos.y = OriginalY
+    UserList(1).Counters.TimerUsar = OriginalTimer
+    Exit Function
+TestError:
+    test_house_door_actions = False
+    Resume TestDone
 End Function
 
 Private Function test_targeted_spell_range_boundaries() As Boolean

--- a/Codigo/WorldActions.bas
+++ b/Codigo/WorldActions.bas
@@ -601,6 +601,168 @@ Handler:
     Call TraceError(Err.Number, Err.Description, "WorldActions.HandleDoorAction", Erl)
 End Sub
 
+Private Function IsValidHooDoorObject(ByVal ObjIndex As Integer) As Boolean
+    If ObjIndex < LBound(ObjData) Or ObjIndex > UBound(ObjData) Then Exit Function
+    IsValidHooDoorObject = (ObjData(ObjIndex).OBJType = e_OBJType.otDoors)
+End Function
+
+Private Function ResolveHooDoorDestination(ByVal CurrentObjIndex As Integer, ByVal ActionValue As Integer, ByRef DestinationObjIndex As Integer, ByRef DestinationBlocked As Boolean) As Boolean
+    If Not IsValidHooDoorObject(CurrentObjIndex) Then Exit Function
+    Dim CurrentDoor As t_ObjData
+    CurrentDoor = ObjData(CurrentObjIndex)
+    Select Case ActionValue
+        Case eHooHouseDoorAction_Open
+            If CurrentDoor.Cerrada <> 1 Or CurrentDoor.Llave <> 0 Then Exit Function
+            DestinationObjIndex = CurrentDoor.IndexAbierta
+            DestinationBlocked = False
+        Case eHooHouseDoorAction_Close
+            If CurrentDoor.Cerrada <> 0 Then Exit Function
+            DestinationObjIndex = CurrentDoor.IndexCerrada
+            DestinationBlocked = True
+        Case eHooHouseDoorAction_Lock
+            If CurrentDoor.Cerrada <> 1 Or CurrentDoor.Llave <> 0 Then Exit Function
+            DestinationObjIndex = CurrentDoor.IndexCerradaLlave
+            DestinationBlocked = True
+        Case eHooHouseDoorAction_Unlock
+            If CurrentDoor.Cerrada <> 1 Or CurrentDoor.Llave = 0 Then Exit Function
+            DestinationObjIndex = CurrentDoor.IndexCerrada
+            DestinationBlocked = True
+        Case eHooHouseDoorAction_UnlockAndOpen
+            If CurrentDoor.Cerrada <> 1 Or CurrentDoor.Llave = 0 Then Exit Function
+            DestinationObjIndex = CurrentDoor.IndexAbierta
+            DestinationBlocked = False
+        Case Else
+            Exit Function
+    End Select
+    If Not IsValidHooDoorObject(DestinationObjIndex) Then Exit Function
+    If ObjData(DestinationObjIndex).clave <> CurrentDoor.clave Then Exit Function
+    Select Case ActionValue
+        Case eHooHouseDoorAction_Open, eHooHouseDoorAction_UnlockAndOpen
+            If ObjData(DestinationObjIndex).Cerrada <> 0 Then Exit Function
+        Case eHooHouseDoorAction_Close, eHooHouseDoorAction_Unlock
+            If ObjData(DestinationObjIndex).Cerrada <> 1 Or ObjData(DestinationObjIndex).Llave <> 0 Then Exit Function
+        Case eHooHouseDoorAction_Lock
+            If ObjData(DestinationObjIndex).Cerrada <> 1 Or ObjData(DestinationObjIndex).Llave = 0 Then Exit Function
+    End Select
+    ResolveHooDoorDestination = True
+End Function
+
+Private Function UserHasMatchingHooDoorKey(ByVal UserIndex As Integer, ByVal DoorObjIndex As Integer) As Boolean
+    If ObjData(DoorObjIndex).clave = 0 Then Exit Function
+    Dim Slot As Integer
+    Dim KeyObjIndex As Integer
+    For Slot = 1 To MAXKEYS
+        KeyObjIndex = UserList(UserIndex).Keys(Slot)
+        If KeyObjIndex >= LBound(ObjData) And KeyObjIndex <= UBound(ObjData) Then
+            If ObjData(KeyObjIndex).OBJType = e_OBJType.otKeys And ObjData(KeyObjIndex).clave <> 0 Then
+                If ObjData(KeyObjIndex).clave = ObjData(DoorObjIndex).clave Then
+                    UserHasMatchingHooDoorKey = True
+                    Exit Function
+                End If
+            End If
+        End If
+    Next Slot
+End Function
+
+Private Sub SetHooDoorTileState(ByVal Map As Integer, ByVal x As Byte, ByVal y As Byte, ByVal DestinationObjIndex As Integer, ByVal DestinationBlocked As Boolean)
+    MapData(Map, x, y).ObjInfo.ObjIndex = DestinationObjIndex
+    Call BloquearPuerta(Map, x, y, DestinationBlocked)
+End Sub
+
+Private Sub BroadcastHooDoorTile(ByVal Map As Integer, ByVal x As Byte, ByVal y As Byte)
+    Call modSendData.SendToAreaByPos(Map, x, y, PrepareMessageObjectCreate(MapData(Map, x, y).ObjInfo.ObjIndex, MapData(Map, x, y).ObjInfo.amount, x, y, MapData(Map, x, y).ObjInfo.ElementalTags))
+End Sub
+
+Private Function HooDoorSound(ByVal ObjIndex As Integer) As Integer
+    Select Case ObjData(ObjIndex).GrhIndex
+        Case 11445, 11444, 59878, 59877
+            HooDoorSound = SND_PUERTA_DUCTO
+        Case Else
+            HooDoorSound = SND_PUERTA
+    End Select
+End Function
+
+Public Function ExecuteHooHouseDoorAction(ByVal UserIndex As Integer, ByVal ActionValue As Integer, ByVal x As Byte, ByVal y As Byte) As e_HooHouseDoorActionResult
+    On Error GoTo ExecuteHooHouseDoorAction_Err
+    ExecuteHooHouseDoorAction = eHooHouseDoorActionResult_InvalidAction
+    If ActionValue < eHooHouseDoorAction_Open Or ActionValue > eHooHouseDoorAction_UnlockAndOpen Then Exit Function
+    ExecuteHooHouseDoorAction = eHooHouseDoorActionResult_InvalidTarget
+    Dim Map As Integer
+    Map = UserList(UserIndex).pos.Map
+    If Not InMapBounds(Map, x, y) Then Exit Function
+    If Distance(UserList(UserIndex).pos.x, UserList(UserIndex).pos.y, x, y) > 2 Then
+        ExecuteHooHouseDoorAction = eHooHouseDoorActionResult_TooFarAway
+        Exit Function
+    End If
+    Dim CurrentObjIndex As Integer
+    CurrentObjIndex = MapData(Map, x, y).ObjInfo.ObjIndex
+    If CurrentObjIndex <= 0 Then Exit Function
+    If Not IsValidHooDoorObject(CurrentObjIndex) Then
+        ExecuteHooHouseDoorAction = eHooHouseDoorActionResult_NotDoor
+        Exit Function
+    End If
+    Dim DestinationObjIndex As Integer
+    Dim DestinationBlocked As Boolean
+    If Not ResolveHooDoorDestination(CurrentObjIndex, ActionValue, DestinationObjIndex, DestinationBlocked) Then
+        ExecuteHooHouseDoorAction = eHooHouseDoorActionResult_InvalidTransition
+        Exit Function
+    End If
+    Dim PairX As Integer
+    Dim PairY As Integer
+    Dim PairCurrentObjIndex As Integer
+    Dim PairDestinationObjIndex As Integer
+    Dim PairDestinationBlocked As Boolean
+    Dim HasLinkedDoor As Boolean
+    HasLinkedDoor = (ObjData(DestinationObjIndex).Subtipo = 1)
+    If HasLinkedDoor Then
+        If ActionValue <> eHooHouseDoorAction_Open And ActionValue <> eHooHouseDoorAction_Close Then
+            ExecuteHooHouseDoorAction = eHooHouseDoorActionResult_Unavailable
+            Exit Function
+        End If
+        PairX = CInt(x) - 3
+        PairY = CInt(y) + 1
+        If Not InMapBounds(Map, PairX, PairY) Then
+            ExecuteHooHouseDoorAction = eHooHouseDoorActionResult_Unavailable
+            Exit Function
+        End If
+        PairCurrentObjIndex = MapData(Map, PairX, PairY).ObjInfo.ObjIndex
+        If Not ResolveHooDoorDestination(PairCurrentObjIndex, ActionValue, PairDestinationObjIndex, PairDestinationBlocked) Then
+            ExecuteHooHouseDoorAction = eHooHouseDoorActionResult_Unavailable
+            Exit Function
+        End If
+    End If
+    If ActionValue >= eHooHouseDoorAction_Lock Then
+        If Not UserHasMatchingHooDoorKey(UserIndex, CurrentObjIndex) Then
+            ExecuteHooHouseDoorAction = eHooHouseDoorActionResult_NoAccess
+            Exit Function
+        End If
+        If Not IntervaloPermiteUsar(UserIndex, False) Then
+            ExecuteHooHouseDoorAction = eHooHouseDoorActionResult_Cooldown
+            Exit Function
+        End If
+        If Not IntervaloPermiteUsar(UserIndex) Then
+            ExecuteHooHouseDoorAction = eHooHouseDoorActionResult_Cooldown
+            Exit Function
+        End If
+    End If
+    Dim DoorSound As Integer
+    DoorSound = HooDoorSound(CurrentObjIndex)
+    Call SetHooDoorTileState(Map, x, y, DestinationObjIndex, DestinationBlocked)
+    If HasLinkedDoor Then
+        Call SetHooDoorTileState(Map, CByte(PairX), CByte(PairY), PairDestinationObjIndex, PairDestinationBlocked)
+    End If
+    Call BroadcastHooDoorTile(Map, x, y)
+    If HasLinkedDoor Then
+        Call BroadcastHooDoorTile(Map, CByte(PairX), CByte(PairY))
+    End If
+    Call SendData(SendTarget.ToPCArea, UserIndex, PrepareMessagePlayWave(DoorSound, x, y))
+    ExecuteHooHouseDoorAction = eHooHouseDoorActionResult_Success
+    Exit Function
+ExecuteHooHouseDoorAction_Err:
+    ExecuteHooHouseDoorAction = eHooHouseDoorActionResult_Unavailable
+    Call TraceError(Err.Number, Err.Description, "WorldActions.ExecuteHooHouseDoorAction", Erl)
+End Function
+
 Sub HandleNpcDoorAction(ByVal Map As Integer, ByVal x As Byte, ByVal y As Byte, ByVal NpcIndex As Integer)
     On Error GoTo Handler
     Dim puerta As t_ObjData 'ver ReyarB

--- a/Example.feature_toggle.ini
+++ b/Example.feature_toggle.ini
@@ -1,5 +1,5 @@
 [INIT]
-TOGGLECOUNT=28
+TOGGLECOUNT=29
 [TOGGLE1]
 name=bandit_unequip_bonus
 value=1
@@ -83,4 +83,7 @@ name=npc-cross-map-pursuit
 value=0
 [TOGGLE28]
 name=hoo-targeted-spell-cast-v1
+value=0
+[TOGGLE29]
+name=hoo-house-door-actions-v1
 value=0


### PR DESCRIPTION
## Summary
- adds capability-gated HOO house door action request/result packets
- validates door state, distance, key ownership, cooldowns, and destinations server-side
- applies authoritative open, close, lock, unlock, and unlock-and-open transitions
- preserves existing collision, object broadcast, and sound behavior
- leaves legacy HandleLeftClick, LookatTile, HandleDoorAction, ModLlaves.UsarLlave, and eUseKey behavior unchanged

## Protocol
- HOO capability bit: `0x8`
- feature toggle: `hoo-house-door-actions-v1`
- request packet: `eHooHouseDoorAction = 312`
- result packet: `eHooHouseDoorActionResult = 205`

## Validation
- VB6 unit suite: 325/325 passed
- production PYMMO=1 build passed
- git diff --check passed

ProtocolGenerator definitions are already synchronized on master.